### PR TITLE
Renamed .hgignore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-syntax: glob
+__pycache__
 .hgrc
 *~
 *.pyc
@@ -21,7 +21,6 @@ tests/interactive/screenshots/committed/*.png
 .coverage
 coverage_report/
 *.bak
-*.un~
 *.cache
 tools/*tab.py
 exprtab.py


### PR DESCRIPTION
Prevents committing temporary files, like test logs, pycache, etc.