### PR TITLE
Updated display docs and improved XlibDisplay interface

### DIFF
--- a/doc/programming_guide/context.txt
+++ b/doc/programming_guide/context.txt
@@ -39,7 +39,7 @@ of its properties::
     c_int(1)
     >>> config.stereo
     c_int(0)
-    >>> config.sample_buffers     
+    >>> config.sample_buffers
     c_int(0)
 
 Note that the values of the config's attributes are all ctypes instances.
@@ -58,37 +58,39 @@ are interested in.  See :ref:`guide_simple-context-configuration` for details.
 Displays
 ^^^^^^^^
 
-The system may actually support several different sets of configs, depending
-on which display device is being used.  For example, a computer with two video
-cards may not support the same configs on each card.  Another example
-is using X11 remotely: the display device will support different
-configurations than the local driver.  Even a single video card on the local
-computer may support different configs for two monitors plugged in.
+The system may actually support several different sets of configs, depending on
+which display device is being used.  For example, a computer with two video
+cards may not support the same configs on each card.  Another example is using
+X11 remotely: the display device will support different configurations than the
+local driver.  Even a single video card on the local computer may support
+different configs for two monitors plugged in.
 
 In pyglet, a :class:`~pyglet.canvas.Display` is a collection of "screens"
 attached to a single display device.  On Linux, the display device corresponds
-to the X11 display
-being used.  On Windows and Mac OS X, there is only one display (as these
-operating systems present multiple video cards as a single virtual device).
+to the X11 display being used.  On Windows and Mac OS X, there is only one
+display (as these operating systems present multiple video cards as a single
+virtual device).
 
-There is a singleton class :class:`~pyglet.window.Platform` which provides 
-access to the display(s);
-this represents the computer on which your application is running.  It is
-usually sufficient to use the default display::
+The :mod:`pyglet.canvas` module provides access to the display(s). Use the
+:func:`~pyglet.canvas.get_display` function to get the default display::
 
-    >>> platform = pyglet.window.get_platform()
-    >>> display = platform.get_default_display()
+    >>> display = pyglet.canvas.get_display()
 
-On X11, you can specify the display string to use, for example to use a
-remotely connected display.  The display string is in the same format as used
-by the ``DISPLAY`` environment variable::
+.. note::
 
-    >>> display = platform.get_display('remote:1.0')
+    On X11, you can use the :class:`~pyglet.canvas.Display` class directly to
+    specify the display string to use, for example to use a remotely connected
+    display.  The name string is in the same format as used by the ``DISPLAY``
+    environment variable::
 
-You use the same string to specify a separate X11 screen [#display]_::
+        >>> display = pyglet.canvas.Display(name=':1')
 
-    >>> display = platform.get_display(':0.1')
+    If you have multiple physical screens and you're using Xinerama, see
+    :ref:`guide_screens` to select the desired screen as you would for Windows
+    and Mac OS X. Otherwise, you can specify the screen number via the
+    ``x_screen`` argument::
 
+        >>> display = pyglet.canvas.Display(name=':1', x_screen=1)
 
 .. _guide_screens:
 
@@ -128,10 +130,6 @@ the default screen is usually the one that contains the taskbar (on Windows) or
 menu bar (on OS X).
 You can access this screen directly using 
 :meth:`~pyglet.canvas.Display.get_default_screen`.
-
-.. [#display] Assuming Xinerama is not being used to combine the screens.  If
-              Xinerama is enabled, use screen 0 in the display string, and
-              select a screen in the same manner as for Windows and Mac OS X.
 
 
 .. _guide_glconfig:

--- a/pyglet/canvas/__init__.py
+++ b/pyglet/canvas/__init__.py
@@ -36,21 +36,21 @@
 """Display and screen management.
 
 Rendering is performed on a :class:`Canvas`, which conceptually could be an
-off-screen buffer, the content area of a :class:`pyglet.window.Window`, or an 
-entire screen. Currently, canvases can only be created with windows (though 
+off-screen buffer, the content area of a :class:`pyglet.window.Window`, or an
+entire screen. Currently, canvases can only be created with windows (though
 windows can be set fullscreen).
 
-Windows and canvases must belong to a :class`~pyglet.canvas.Display`  On Windows and Mac OS 
-X there is only one display, which can be obtained with :func:`get_display`.  
-Linux supports multiple displays, corresponding to discrete X11 display 
-connections and screens.  :func:`get_display` on  Linux returns the default 
-display and screen 0 (``localhost:0.0``); if a particular screen or display is 
-required then :class`~pyglet.canvas.Display`can be instantiated directly.
+Windows and canvases must belong to a :class:`Display`. On Windows and Mac OS X
+there is only one display, which can be obtained with :func:`get_display`.
+Linux supports multiple displays, corresponding to discrete X11 display
+connections and screens.  :func:`get_display` on Linux returns the default
+display and screen 0 (``localhost:0.0``); if a particular screen or display is
+required then :class:`Display` can be instantiated directly.
 
 Within a display one or more screens are attached.  A :class:`Screen` often
 corresponds to a physical attached monitor, however a monitor or projector set
 up to clone another screen will not be listed.  Use :meth:`Display.get_screens`
-to get a list of the attached screens; these can then be queried for their 
+to get a list of the attached screens; these can then be queried for their
 sizes and virtual positions on the desktop.
 
 The size of a screen is determined by its current mode, which can be changed
@@ -68,10 +68,9 @@ _is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
 
 
 _displays = WeakSet()
-"""Set of all open displays.  Instances of :class:`pyglet.canvas.Display` 
-are automatically added to this set upon construction.  The set uses weak 
-references, so displays are removed from the set when they are no longer 
-referenced.
+"""Set of all open displays.  Instances of :class:`Display` are automatically
+added to this set upon construction.  The set uses weak references, so displays
+are removed from the set when they are no longer referenced.
 
 :type: :class:`WeakSet`
 """
@@ -80,13 +79,13 @@ referenced.
 def get_display():
     """Get the default display device.
 
-    If there is already a :class`~pyglet.canvas.Display`connection, that display will be 
-    returned. Otherwise, a default :class`~pyglet.canvas.Display`is created and returned.  
+    If there is already a :class:`Display` connection, that display will be
+    returned. Otherwise, a default :class:`Display` is created and returned.
     If multiple display connections are active, an arbitrary one is returned.
 
     .. versionadded:: 1.2
 
-    :rtype: :class`~pyglet.canvas.Display`
+    :rtype: :class:`Display`
     """
     # If there are existing displays, return one of them arbitrarily.
     for display in _displays:

--- a/pyglet/canvas/base.py
+++ b/pyglet/canvas/base.py
@@ -89,7 +89,7 @@ class Display(object):
     def get_screens(self):
         """Get the available screens.
 
-        A typical multi-monitor workstation comprises one :class`~pyglet.canvas.Display`
+        A typical multi-monitor workstation comprises one :class:`Display`
         with multiple :class:`Screen` s.  This method returns a list of 
         screens which can be enumerated to select one for full-screen display.
 

--- a/pyglet/canvas/xlib.py
+++ b/pyglet/canvas/xlib.py
@@ -115,6 +115,9 @@ class XlibDisplay(XlibSelectDevice, Display):
         if x_screen is None:
             x_screen = 0
 
+        if isinstance(name, str):
+            name = c_char_p(name.encode('ascii'))
+
         self._display = xlib.XOpenDisplay(name)
         if not self._display:
             raise NoSuchDisplayException('Cannot connect to "%s"' % name)


### PR DESCRIPTION
I'm new to pyglet and while reading the [context page](https://pyglet.readthedocs.io/en/pyglet-1.3-maintenance/programming_guide/context.html) I came across what seems to be some outdated information. I did my best to update the docs to reflect the current state of the library and clean up some minor issues.

Since the docs claim you can pass a string to `XlibDisplay`, I went ahead and added that functionality as mentioned in #11.