### PR TITLE
 Changed to explicit imports for cocoapy

### DIFF
--- a/pyglet/app/cocoa.py
+++ b/pyglet/app/cocoa.py
@@ -36,15 +36,15 @@ __docformat__ = 'restructuredtext'
 __version__ = '$Id: $'
 
 from pyglet.app.base import PlatformEventLoop
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin import cocoapy
 
-NSApplication = ObjCClass('NSApplication')
-NSMenu = ObjCClass('NSMenu')
-NSMenuItem = ObjCClass('NSMenuItem')
-NSAutoreleasePool = ObjCClass('NSAutoreleasePool')
-NSDate = ObjCClass('NSDate')
-NSEvent = ObjCClass('NSEvent')
-NSUserDefaults = ObjCClass('NSUserDefaults')
+NSApplication = cocoapy.ObjCClass('NSApplication')
+NSMenu = cocoapy.ObjCClass('NSMenu')
+NSMenuItem = cocoapy.ObjCClass('NSMenuItem')
+NSAutoreleasePool = cocoapy.ObjCClass('NSAutoreleasePool')
+NSDate = cocoapy.ObjCClass('NSDate')
+NSEvent = cocoapy.ObjCClass('NSEvent')
+NSUserDefaults = cocoapy.ObjCClass('NSUserDefaults')
 
 
 class AutoReleasePool(object):
@@ -59,9 +59,9 @@ class AutoReleasePool(object):
 
 def add_menu_item(menu, title, action, key):
     with AutoReleasePool():
-        title = CFSTR(title)
-        action = get_selector(action)
-        key = CFSTR(key)
+        title = cocoapy.CFSTR(title)
+        action = cocoapy.get_selector(action)
+        key = cocoapy.CFSTR(key)
         menuItem = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
             title, action, key)
         menu.addItem_(menuItem)
@@ -106,12 +106,12 @@ class CocoaEventLoop(PlatformEventLoop):
                 return
             if not self.NSApp.mainMenu():
                 create_menu()
-            self.NSApp.setActivationPolicy_(NSApplicationActivationPolicyRegular)
+            self.NSApp.setActivationPolicy_(cocoapy.NSApplicationActivationPolicyRegular)
             # Prevent Lion / Mountain Lion from automatically saving application state.
             # If we don't do this, new windows will not display on 10.8 after finishLaunching
             # has been called.  
             defaults = NSUserDefaults.standardUserDefaults()
-            ignoreState = CFSTR("ApplePersistenceIgnoreState")
+            ignoreState = cocoapy.CFSTR("ApplePersistenceIgnoreState")
             if not defaults.objectForKey_(ignoreState):
                 defaults.setBool_forKey_(True, ignoreState)
             self._finished_launching = False
@@ -142,12 +142,12 @@ class CocoaEventLoop(PlatformEventLoop):
             # We only process one event per call of step().
             self._is_running.set()
             event = self.NSApp.nextEventMatchingMask_untilDate_inMode_dequeue_(
-                NSAnyEventMask, timeout_date, NSDefaultRunLoopMode, True)
+                cocoapy.NSAnyEventMask, timeout_date, cocoapy.NSDefaultRunLoopMode, True)
 
             # Dispatch the event (if any).
             if event is not None:
                 event_type = event.type()
-                if event_type != NSApplicationDefined:
+                if event_type != cocoapy.NSApplicationDefined:
                     # Send out event as normal.  Responders will still receive
                     # keyUp:, keyDown:, and flagsChanged: events.
                     self.NSApp.sendEvent_(event)
@@ -160,12 +160,12 @@ class CocoaEventLoop(PlatformEventLoop):
                     # replacements ensure that we see all the raw key presses & releases.
                     # We also filter out key-down repeats since pyglet only sends one
                     # on_key_press event per key press.
-                    if event_type == NSKeyDown and not event.isARepeat():
-                        self.NSApp.sendAction_to_from_(get_selector("pygletKeyDown:"), None, event)
-                    elif event_type == NSKeyUp:
-                        self.NSApp.sendAction_to_from_(get_selector("pygletKeyUp:"), None, event)
-                    elif event_type == NSFlagsChanged:
-                        self.NSApp.sendAction_to_from_(get_selector("pygletFlagsChanged:"), None, event)
+                    if event_type == cocoapy.NSKeyDown and not event.isARepeat():
+                        self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyDown:"), None, event)
+                    elif event_type == cocoapy.NSKeyUp:
+                        self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyUp:"), None, event)
+                    elif event_type == cocoapy.NSFlagsChanged:
+                        self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletFlagsChanged:"), None, event)
 
                 self.NSApp.updateWindows()
                 did_time_out = False
@@ -182,15 +182,15 @@ class CocoaEventLoop(PlatformEventLoop):
     def notify(self):
         with AutoReleasePool():
             notifyEvent = NSEvent.otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
-                NSApplicationDefined, # type
-                NSPoint(0.0, 0.0),    # location
-                0,                    # modifierFlags
-                0,                    # timestamp
-                0,                    # windowNumber
-                None,                 # graphicsContext
-                0,                    # subtype
-                0,                    # data1
-                0,                    # data2
+                cocoapy.NSApplicationDefined, # type
+                cocoapy.NSPoint(0.0, 0.0),    # location
+                0,                            # modifierFlags
+                0,                            # timestamp
+                0,                            # windowNumber
+                None,                         # graphicsContext
+                0,                            # subtype
+                0,                            # data1
+                0,                            # data2
                 )
 
             self.NSApp.postEvent_atStart_(notifyEvent, False)

--- a/pyglet/app/cocoa.py
+++ b/pyglet/app/cocoa.py
@@ -109,7 +109,7 @@ class CocoaEventLoop(PlatformEventLoop):
             self.NSApp.setActivationPolicy_(cocoapy.NSApplicationActivationPolicyRegular)
             # Prevent Lion / Mountain Lion from automatically saving application state.
             # If we don't do this, new windows will not display on 10.8 after finishLaunching
-            # has been called.  
+            # has been called.
             defaults = NSUserDefaults.standardUserDefaults()
             ignoreState = cocoapy.CFSTR("ApplePersistenceIgnoreState")
             if not defaults.objectForKey_(ignoreState):

--- a/pyglet/canvas/cocoa.py
+++ b/pyglet/canvas/cocoa.py
@@ -42,13 +42,12 @@ __docformat__ = 'restructuredtext'
 __version__ = '$Id: $'
 
 from ctypes import *
-from ctypes import util
 
 from pyglet import app
 from .base import Display, Screen, ScreenMode, Canvas
 
-from pyglet.libs.darwin.cocoapy import *
-
+from pyglet.libs.darwin.cocoapy import CGDirectDisplayID, quartz, cf
+from pyglet.libs.darwin.cocoapy import cfstring_to_string, cfarray_to_list
 
 class CocoaDisplay(Display):
 

--- a/pyglet/canvas/cocoa.py
+++ b/pyglet/canvas/cocoa.py
@@ -52,7 +52,7 @@ from pyglet.libs.darwin.cocoapy import cfstring_to_string, cfarray_to_list
 class CocoaDisplay(Display):
 
     def get_screens(self):
-        maxDisplays = 256 
+        maxDisplays = 256
         activeDisplays = (CGDirectDisplayID * maxDisplays)()
         count = c_uint32()
         quartz.CGGetActiveDisplayList(maxDisplays, activeDisplays, byref(count))
@@ -78,7 +78,7 @@ class CocoaScreen(Screen):
     # However the NSScreens.screens() message currently sends out a warning:
     # "*** -[NSLock unlock]: lock (<NSLock: 0x...> '(null)') unlocked when not locked"
     # on Snow Leopard and apparently causes python to crash on Lion.
-    # 
+    #
     # def get_nsscreen(self):
     #     """Returns the NSScreen instance that matches our CGDirectDisplayID."""
     #     NSScreen = ObjCClass('NSScreen')
@@ -111,7 +111,7 @@ class CocoaScreen(Screen):
         quartz.CGDisplayModeRelease(cgmode)
         return mode
 
-    def set_mode(self, mode): 
+    def set_mode(self, mode):
         assert mode.screen is self
         quartz.CGDisplayCapture(self._cg_display_id)
         quartz.CGDisplaySetDisplayMode(self._cg_display_id, mode.cgmode, None)
@@ -143,7 +143,7 @@ class CocoaScreenMode(ScreenMode):
     def __del__(self):
         quartz.CGDisplayModeRelease(self.cgmode)
         self.cgmode = None
-        
+
     def getBitsPerPixel(self, cgmode):
         # from /System/Library/Frameworks/IOKit.framework/Headers/graphics/IOGraphicsTypes.h
         IO8BitIndexedPixels = "PPPPPPPP"
@@ -159,7 +159,7 @@ class CocoaScreenMode(ScreenMode):
         if pixelEncoding == IO32BitDirectPixels: return 32
         return 0
 
-                   
+
 class CocoaCanvas(Canvas):
 
     def __init__(self, display, screen, nsview):

--- a/pyglet/font/quartz.py
+++ b/pyglet/font/quartz.py
@@ -79,7 +79,7 @@ class QuartzGlyphRenderer(base.GlyphRenderer):
         line = c_void_p(ct.CTLineCreateWithAttributedString(string))
         cf.CFRelease(string)
         cf.CFRelease(attributes)
-        
+
         # Get a bounding rectangle for glyphs in string.
         count = len(text)
         chars = (cocoapy.UniChar * count)(*list(map(ord,str(text))))
@@ -106,12 +106,12 @@ class QuartzGlyphRenderer(base.GlyphRenderer):
         bytesPerRow = 4*width
         colorSpace = c_void_p(quartz.CGColorSpaceCreateDeviceRGB())
         bitmap = c_void_p(quartz.CGBitmapContextCreate(
-                None, 
-                width, 
-                height, 
-                bitsPerComponent, 
-                bytesPerRow, 
-                colorSpace, 
+                None,
+                width,
+                height,
+                bitsPerComponent,
+                bytesPerRow,
+                colorSpace,
                 cocoapy.kCGImageAlphaPremultipliedLast))
 
         # Draw text to bitmap context.
@@ -142,7 +142,7 @@ class QuartzGlyphRenderer(base.GlyphRenderer):
         glyph.set_bearings(baseline, lsb, advance)
         t = list(glyph.tex_coords)
         glyph.tex_coords = t[9:12] + t[6:9] + t[3:6] + t[:3]
-        
+
         return glyph
 
 
@@ -164,7 +164,7 @@ class QuartzFont(base.Font):
         fonts = self._loaded_CGFont_table[family]
         if not fonts:
             return None
-        # Return font with desired traits if it is available. 
+        # Return font with desired traits if it is available.
         if traits in fonts:
             return fonts[traits]
         # Otherwise try to find a font with some of the traits.
@@ -211,7 +211,7 @@ class QuartzFont(base.Font):
         # I don't know what is the right thing to do here.
         if dpi is None: dpi = 96
         size = size * dpi / 72.0
-        
+
         # Construct traits value.
         traits = 0
         if bold: traits |= cocoapy.kCTFontBoldTrait
@@ -253,8 +253,8 @@ class QuartzFont(base.Font):
 
     @classmethod
     def add_font_data(cls, data):
-        # Create a cgFont with the data.  There doesn't seem to be a way to 
-        # register a font loaded from memory such that the operating system will 
+        # Create a cgFont with the data.  There doesn't seem to be a way to
+        # register a font loaded from memory such that the operating system will
         # find it later.  So instead we just store the cgFont in a table where
         # it can be found by our __init__ method.
         # Note that the iOS CTFontManager *is* able to register graphics fonts,
@@ -290,5 +290,3 @@ class QuartzFont(base.Font):
         if fullName not in cls._loaded_CGFont_table:
             cls._loaded_CGFont_table[fullName] = {}
         cls._loaded_CGFont_table[fullName][traits] = cgFont
-
-        

--- a/pyglet/gl/cocoa.py
+++ b/pyglet/gl/cocoa.py
@@ -33,6 +33,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 import platform
+from ctypes import c_uint32, c_int, byref
 
 from pyglet.gl.base import Config, CanvasConfig, Context
 
@@ -42,11 +43,11 @@ from pyglet.gl import agl
 
 from pyglet.canvas.cocoa import CocoaCanvas
 
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin import cocoapy
 
 
-NSOpenGLPixelFormat = ObjCClass('NSOpenGLPixelFormat')
-NSOpenGLContext = ObjCClass('NSOpenGLContext')
+NSOpenGLPixelFormat = cocoapy.ObjCClass('NSOpenGLPixelFormat')
+NSOpenGLContext = cocoapy.ObjCClass('NSOpenGLContext')
 
 # Version info, needed as OpenGL different Lion and onward
 """Version is based on Darwin kernel, not OS-X version.
@@ -98,44 +99,44 @@ _os_x_version = os_x_version()
 
 # Valid names for GL attributes and their corresponding NSOpenGL constant.
 _gl_attributes = {
-    'double_buffer': NSOpenGLPFADoubleBuffer,
-    'stereo': NSOpenGLPFAStereo,
-    'buffer_size': NSOpenGLPFAColorSize,
-    'sample_buffers': NSOpenGLPFASampleBuffers,
-    'samples': NSOpenGLPFASamples,
-    'aux_buffers': NSOpenGLPFAAuxBuffers,
-    'alpha_size': NSOpenGLPFAAlphaSize,
-    'depth_size': NSOpenGLPFADepthSize,
-    'stencil_size': NSOpenGLPFAStencilSize,
+    'double_buffer': cocoapy.NSOpenGLPFADoubleBuffer,
+    'stereo': cocoapy.NSOpenGLPFAStereo,
+    'buffer_size': cocoapy.NSOpenGLPFAColorSize,
+    'sample_buffers': cocoapy.NSOpenGLPFASampleBuffers,
+    'samples': cocoapy.NSOpenGLPFASamples,
+    'aux_buffers': cocoapy.NSOpenGLPFAAuxBuffers,
+    'alpha_size': cocoapy.NSOpenGLPFAAlphaSize,
+    'depth_size': cocoapy.NSOpenGLPFADepthSize,
+    'stencil_size': cocoapy.NSOpenGLPFAStencilSize,
 
     # Not exposed by pyglet API (set internally)
-    'all_renderers': NSOpenGLPFAAllRenderers,
-    'fullscreen': NSOpenGLPFAFullScreen,
-    'minimum_policy': NSOpenGLPFAMinimumPolicy,
-    'maximum_policy': NSOpenGLPFAMaximumPolicy,
-    'screen_mask' : NSOpenGLPFAScreenMask,
+    'all_renderers': cocoapy.NSOpenGLPFAAllRenderers,
+    'fullscreen': cocoapy.NSOpenGLPFAFullScreen,
+    'minimum_policy': cocoapy.NSOpenGLPFAMinimumPolicy,
+    'maximum_policy': cocoapy.NSOpenGLPFAMaximumPolicy,
+    'screen_mask' : cocoapy.NSOpenGLPFAScreenMask,
 
     # Not supported in current pyglet API
-    'color_float': NSOpenGLPFAColorFloat,
-    'offscreen': NSOpenGLPFAOffScreen,
-    'sample_alpha': NSOpenGLPFASampleAlpha,
-    'multisample': NSOpenGLPFAMultisample,
-    'supersample': NSOpenGLPFASupersample,
+    'color_float': cocoapy.NSOpenGLPFAColorFloat,
+    'offscreen': cocoapy.NSOpenGLPFAOffScreen,
+    'sample_alpha': cocoapy.NSOpenGLPFASampleAlpha,
+    'multisample': cocoapy.NSOpenGLPFAMultisample,
+    'supersample': cocoapy.NSOpenGLPFASupersample,
 }
 
 # NSOpenGL constants which do not require a value.
 _boolean_gl_attributes = frozenset([
-    NSOpenGLPFAAllRenderers,
-    NSOpenGLPFADoubleBuffer,
-    NSOpenGLPFAStereo,
-    NSOpenGLPFAMinimumPolicy,
-    NSOpenGLPFAMaximumPolicy,
-    NSOpenGLPFAOffScreen,
-    NSOpenGLPFAFullScreen,
-    NSOpenGLPFAColorFloat,
-    NSOpenGLPFAMultisample,
-    NSOpenGLPFASupersample,
-    NSOpenGLPFASampleAlpha,
+    cocoapy.NSOpenGLPFAAllRenderers,
+    cocoapy.NSOpenGLPFADoubleBuffer,
+    cocoapy.NSOpenGLPFAStereo,
+    cocoapy.NSOpenGLPFAMinimumPolicy,
+    cocoapy.NSOpenGLPFAMaximumPolicy,
+    cocoapy.NSOpenGLPFAOffScreen,
+    cocoapy.NSOpenGLPFAFullScreen,
+    cocoapy.NSOpenGLPFAColorFloat,
+    cocoapy.NSOpenGLPFAMultisample,
+    cocoapy.NSOpenGLPFASupersample,
+    cocoapy.NSOpenGLPFASampleAlpha,
 ])
 
 # Attributes for which no NSOpenGLPixelFormatAttribute name exists.
@@ -166,10 +167,10 @@ class CocoaConfig(Config):
                 attrs.append(int(value))
 
         # Support for RAGE-II, which is not compliant.
-        attrs.append(NSOpenGLPFAAllRenderers)
+        attrs.append(cocoapy.NSOpenGLPFAAllRenderers)
 
         # Force selection policy.
-        attrs.append(NSOpenGLPFAMaximumPolicy)
+        attrs.append(cocoapy.NSOpenGLPFAMaximumPolicy)
 
         # NSOpenGLPFAFullScreen is always supplied so we can switch to and
         # from fullscreen without losing the context.  Also must supply the
@@ -181,8 +182,8 @@ class CocoaConfig(Config):
         # Otherwise, make sure we refer to the correct Profile for OpenGL (Core or
         # Legacy) on Lion and afterwards
         if _os_x_version < os_x_release['snow_leopard']:
-            attrs.append(NSOpenGLPFAFullScreen)
-            attrs.append(NSOpenGLPFAScreenMask)
+            attrs.append(cocoapy.NSOpenGLPFAFullScreen)
+            attrs.append(cocoapy.NSOpenGLPFAScreenMask)
             attrs.append(quartz.CGDisplayIDToOpenGLDisplayMask(quartz.CGMainDisplayID()))
         elif _os_x_version >= os_x_release['lion']:
             # check for opengl profile
@@ -192,17 +193,17 @@ class CocoaConfig(Config):
                 getattr(self, 'minor_version', None)
                 )
             # tell os-x we want to request a profile
-            attrs.append(NSOpenGLPFAOpenGLProfile)
+            attrs.append(cocoapy.NSOpenGLPFAOpenGLProfile)
 
             # check if we're wanting core or legacy
             # Mavericks (Darwin 13) and up are capable of the Core 4.1 profile,
             # while Lion and up are only capable of Core 3.2
             if version[0] == 4 and version[1] >= 1 and _os_x_version >= os_x_release['mavericks']:
-                attrs.append(int(NSOpenGLProfileVersion4_1Core))
+                attrs.append(int(cocoapy.NSOpenGLProfileVersion4_1Core))
             elif version[0] == 3 and version[1] >= 2:
-                attrs.append(int(NSOpenGLProfileVersion3_2Core))
+                attrs.append(int(cocoapy.NSOpenGLProfileVersion3_2Core))
             else:
-                attrs.append(int(NSOpenGLProfileVersionLegacy))
+                attrs.append(int(cocoapy.NSOpenGLProfileVersionLegacy))
         # Terminate the list.
         attrs.append(0)
 
@@ -240,14 +241,14 @@ class CocoaCanvasConfig(CanvasConfig):
             vals = c_int()
             profile = self._pixel_format.getValues_forAttribute_forVirtualScreen_(
                 byref(vals),
-                NSOpenGLPFAOpenGLProfile,
+                cocoapy.NSOpenGLPFAOpenGLProfile,
                 0
                 )
 
-            if vals.value == NSOpenGLProfileVersion4_1Core:
+            if vals.value == cocoapy.NSOpenGLProfileVersion4_1Core:
                 setattr(self, "major_version", 4)
                 setattr(self, "minor_version", 1)
-            elif vals.value == NSOpenGLProfileVersion3_2Core:
+            elif vals.value == cocoapy.NSOpenGLProfileVersion3_2Core:
                 setattr(self, "major_version", 3)
                 setattr(self, "minor_version", 2)
             else:
@@ -315,11 +316,11 @@ class CocoaContext(Context):
 
     def set_vsync(self, vsync=True):
         vals = c_int(vsync)
-        self._nscontext.setValues_forParameter_(byref(vals), NSOpenGLCPSwapInterval)
+        self._nscontext.setValues_forParameter_(byref(vals), cocoapy.NSOpenGLCPSwapInterval)
 
     def get_vsync(self):
         vals = c_int()
-        self._nscontext.getValues_forParameter_(byref(vals), NSOpenGLCPSwapInterval)
+        self._nscontext.getValues_forParameter_(byref(vals), cocoapy.NSOpenGLCPSwapInterval)
         return vals.value
 
     def flip(self):

--- a/pyglet/image/codecs/quartz.py
+++ b/pyglet/image/codecs/quartz.py
@@ -35,6 +35,7 @@
 
 '''
 '''
+from ctypes import c_void_p, c_ubyte
 from builtins import range
 
 __docformat__ = 'restructuredtext'
@@ -43,7 +44,11 @@ __version__ = '$Id$'
 from pyglet.image import ImageData, Animation, AnimationFrame
 from pyglet.image.codecs import *
 
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin.cocoapy import cf, quartz, NSMakeRect
+from pyglet.libs.darwin.cocoapy import cfnumber_to_number
+from pyglet.libs.darwin.cocoapy import kCGImageAlphaPremultipliedLast
+from pyglet.libs.darwin.cocoapy import kCGImagePropertyGIFDictionary
+from pyglet.libs.darwin.cocoapy import kCGImagePropertyGIFDelayTime
 
 
 class QuartzImageDecoder(ImageDecoder):

--- a/pyglet/image/codecs/quartz.py
+++ b/pyglet/image/codecs/quartz.py
@@ -54,12 +54,12 @@ from pyglet.libs.darwin.cocoapy import kCGImagePropertyGIFDelayTime
 class QuartzImageDecoder(ImageDecoder):
     def get_file_extensions(self):
         # Quartz can actually decode many more formats, but these are the most common.
-        return [ '.bmp', '.cur', '.gif', '.ico', '.jp2', '.jpg', '.jpeg', 
+        return [ '.bmp', '.cur', '.gif', '.ico', '.jp2', '.jpg', '.jpeg',
                  '.pcx', '.png', '.tga', '.tif', '.tiff', '.xbm', '.xpm' ]
 
     def get_animation_file_extensions(self):
         return ['.gif']
-     
+
     def _get_pyglet_ImageData_from_source_at_index(self, sourceRef, index):
         imageRef = c_void_p(quartz.CGImageSourceCreateImageAtIndex(sourceRef, index, None))
 
@@ -79,20 +79,20 @@ class QuartzImageDecoder(ImageDecoder):
         # Create a bitmap context for the RGBA formatted data.
         # Note that premultiplied alpha is required:
         # http://developer.apple.com/library/mac/#qa/qa1037/_index.html
-        bitmap = c_void_p(quartz.CGBitmapContextCreate(buffer, 
-                                                       width, height, 
-                                                       bitsPerComponent, 
-                                                       bytesPerRow, 
-                                                       rgbColorSpace, 
+        bitmap = c_void_p(quartz.CGBitmapContextCreate(buffer,
+                                                       width, height,
+                                                       bitsPerComponent,
+                                                       bytesPerRow,
+                                                       rgbColorSpace,
                                                        kCGImageAlphaPremultipliedLast))
-                          
+
         # Write the image data into the bitmap.
         quartz.CGContextDrawImage(bitmap, NSMakeRect(0,0,width,height), imageRef)
-        
+
         quartz.CGImageRelease(imageRef)
         quartz.CGContextRelease(bitmap)
         quartz.CGColorSpaceRelease(rgbColorSpace)
-        
+
         pitch = bytesPerRow
         return ImageData(width, height, format, buffer, -pitch)
 
@@ -117,7 +117,7 @@ class QuartzImageDecoder(ImageDecoder):
 
         # Get number of frames in the animation.
         count = quartz.CGImageSourceGetCount(sourceRef)
-        
+
         frames = []
 
         for index in range(count):
@@ -128,7 +128,7 @@ class QuartzImageDecoder(ImageDecoder):
                 gif_props = c_void_p(cf.CFDictionaryGetValue(props, kCGImagePropertyGIFDictionary))
                 if cf.CFDictionaryContainsKey(gif_props, kCGImagePropertyGIFDelayTime):
                     duration = cfnumber_to_number(c_void_p(cf.CFDictionaryGetValue(gif_props, kCGImagePropertyGIFDelayTime)))
-            
+
             cf.CFRelease(props)
             image = self._get_pyglet_ImageData_from_source_at_index(sourceRef, index)
             frames.append( AnimationFrame(image, duration) )
@@ -137,7 +137,7 @@ class QuartzImageDecoder(ImageDecoder):
         cf.CFRelease(sourceRef)
 
         return Animation(frames)
-        
+
 
 def get_decoders():
     return [ QuartzImageDecoder() ]

--- a/pyglet/input/darwin_hid.py
+++ b/pyglet/input/darwin_hid.py
@@ -35,13 +35,19 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from builtins import object
+
+from ctypes import cdll, util, CFUNCTYPE, byref, c_void_p
+from ctypes import c_int, c_ubyte, c_bool, c_uint32, c_uint32, c_uint64
+
 # Uses the HID API introduced in Mac OS X version 10.5
 # http://developer.apple.com/library/mac/#technotes/tn2007/tn2187.html
 
 import sys
 __LP64__ = (sys.maxsize > 2**32)
 
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin.cocoapy import CFSTR, CFIndex, CFTypeID, \
+    kCFRunLoopDefaultMode, CFAllocatorRef, known_cftypes, cf, \
+    cfset_to_set, cftype_to_value, cfarray_to_list
 
 # Load iokit framework
 iokit = cdll.LoadLibrary(util.find_library('IOKit'))

--- a/pyglet/input/darwin_hid.py
+++ b/pyglet/input/darwin_hid.py
@@ -88,8 +88,8 @@ IOReturn = c_int  # IOReturn.h
 IOOptionBits = c_uint32   # IOTypes.h
 
 # IOHIDKeys.h
-IOHIDElementType = c_int 
-IOHIDElementCollectionType = c_int 
+IOHIDElementType = c_int
+IOHIDElementCollectionType = c_int
 if __LP64__:
     IOHIDElementCookie = c_uint32
 else:
@@ -231,16 +231,16 @@ iokit.IOHIDValueGetTypeID.restype = CFTypeID
 iokit.IOHIDValueGetTypeID.argtypes = []
 
 # Callback function types
-HIDManagerCallback = CFUNCTYPE(None, c_void_p, c_int, c_void_p, c_void_p)    
-HIDDeviceCallback = CFUNCTYPE(None, c_void_p, c_int, c_void_p)    
-HIDDeviceValueCallback = CFUNCTYPE(None, c_void_p, c_int, c_void_p, c_void_p)    
+HIDManagerCallback = CFUNCTYPE(None, c_void_p, c_int, c_void_p, c_void_p)
+HIDDeviceCallback = CFUNCTYPE(None, c_void_p, c_int, c_void_p)
+HIDDeviceValueCallback = CFUNCTYPE(None, c_void_p, c_int, c_void_p, c_void_p)
 
 ######################################################################
 # HID Class Wrappers
 
 # Lookup tables cache python objects for the devices and elements so that
 # we can avoid creating multiple wrapper objects for the same device.
-_device_lookup = {}  # IOHIDDeviceRef to python HIDDevice object  
+_device_lookup = {}  # IOHIDDeviceRef to python HIDDevice object
 _element_lookup = {} # IOHIDElementRef to python HIDDeviceElement object
 
 class HIDValue(object):
@@ -290,7 +290,7 @@ class HIDDevice(object):
         self.primaryUsage = self.get_property("PrimaryUsage")
         self.primaryUsagePage = self.get_property("PrimaryUsagePage")
         # Populate self.elements with our device elements.
-        self.get_elements()        
+        self.get_elements()
         # Set up callback functions.
         self.value_observers = set()
         self.removal_observers = set()
@@ -298,7 +298,7 @@ class HIDDevice(object):
         self.register_input_value_callback()
 
     def dump_info(self):
-        for x in ('manufacturer', 'product', 'transport', 'vendorID', 'vendorIDSource', 'productID', 
+        for x in ('manufacturer', 'product', 'transport', 'vendorID', 'vendorIDSource', 'productID',
                   'versionNumber', 'serialNumber', 'locationID', 'primaryUsage', 'primaryUsagePage'):
             value = getattr(self, x)
             print(x + ":", value)
@@ -306,7 +306,7 @@ class HIDDevice(object):
     def unique_identifier(self):
         # Since we can't rely on the serial number, create our own identifier.
         # Can use this to find devices when they are plugged back in.
-        return (self.manufacturer, self.product, self.vendorID, self.productID, 
+        return (self.manufacturer, self.product, self.vendorID, self.productID,
                 self.versionNumber, self.primaryUsage, self.primaryUsagePage)
 
     def get_property(self, name):
@@ -314,25 +314,25 @@ class HIDDevice(object):
         cfvalue = c_void_p(iokit.IOHIDDeviceGetProperty(self.deviceRef, cfname))
         cf.CFRelease(cfname)
         return cftype_to_value(cfvalue)
-        
+
     def open(self, exclusive_mode=False):
         if exclusive_mode: options = kIOHIDOptionsTypeSeizeDevice
         else: options = kIOHIDOptionsTypeNone
         return bool(iokit.IOHIDDeviceOpen(self.deviceRef, options))
-    
+
     def close(self):
         return bool(iokit.IOHIDDeviceClose(self.deviceRef, kIOHIDOptionsTypeNone))
 
     def schedule_with_run_loop(self):
         iokit.IOHIDDeviceScheduleWithRunLoop(
-            self.deviceRef, 
-            c_void_p(cf.CFRunLoopGetCurrent()), 
+            self.deviceRef,
+            c_void_p(cf.CFRunLoopGetCurrent()),
             kCFRunLoopDefaultMode)
 
     def unschedule_from_run_loop(self):
         iokit.IOHIDDeviceUnscheduleFromRunLoop(
-            self.deviceRef, 
-            c_void_p(cf.CFRunLoopGetCurrent()), 
+            self.deviceRef,
+            c_void_p(cf.CFRunLoopGetCurrent()),
             kCFRunLoopDefaultMode)
 
     def get_elements(self):
@@ -385,7 +385,7 @@ class HIDDevice(object):
     def register_input_value_callback(self):
         self.value_callback = HIDDeviceValueCallback(self.py_value_callback)
         iokit.IOHIDDeviceRegisterInputValueCallback(
-            self.deviceRef, 
+            self.deviceRef,
             self.value_callback,
             None)
 
@@ -437,8 +437,8 @@ class HIDDeviceElement(object):
         self.name = cftype_to_value(iokit.IOHIDElementGetName(elementRef))
         self.reportID = iokit.IOHIDElementGetReportID(elementRef)
         self.reportSize = iokit.IOHIDElementGetReportSize(elementRef)
-        self.reportCount = iokit.IOHIDElementGetReportCount(elementRef)        
-        self.unit = iokit.IOHIDElementGetUnit(elementRef)        
+        self.reportCount = iokit.IOHIDElementGetReportCount(elementRef)
+        self.unit = iokit.IOHIDElementGetUnit(elementRef)
         self.unitExponent = iokit.IOHIDElementGetUnitExponent(elementRef)
         self.logicalMin = iokit.IOHIDElementGetLogicalMin(elementRef)
         self.logicalMax = iokit.IOHIDElementGetLogicalMax(elementRef)
@@ -456,9 +456,9 @@ class HIDManager(object):
         self.matching_observers = set()
         self.register_matching_callback()
         self.get_devices()
-        
+
     def get_devices(self):
-        # Tell manager that we are willing to match *any* device.    
+        # Tell manager that we are willing to match *any* device.
         # (Alternatively, we could restrict by device usage, or usage page.)
         iokit.IOHIDManagerSetDeviceMatching(self.managerRef, None)
         # Copy the device set and convert it to python.
@@ -471,17 +471,17 @@ class HIDManager(object):
 
     def close(self):
         iokit.IOHIDManagerClose(self.managerRef, kIOHIDOptionsTypeNone)
-        
+
     def schedule_with_run_loop(self):
         iokit.IOHIDManagerScheduleWithRunLoop(
-            self.managerRef, 
-            c_void_p(cf.CFRunLoopGetCurrent()), 
+            self.managerRef,
+            c_void_p(cf.CFRunLoopGetCurrent()),
             kCFRunLoopDefaultMode)
-        
+
     def unschedule_from_run_loop(self):
         iokit.IOHIDManagerUnscheduleFromRunLoop(
-            self.managerRef, 
-            c_void_p(cf.CFRunLoopGetCurrent()), 
+            self.managerRef,
+            c_void_p(cf.CFRunLoopGetCurrent()),
             kCFRunLoopDefaultMode)
 
     def py_matching_callback(self, context, result, sender, device):
@@ -555,7 +555,7 @@ class PygletDevice(Device):
         self._create_controls()
         self._is_open = False
         self._is_exclusive = False
-    
+
     def open(self, window=None, exclusive=False):
         super(PygletDevice, self).open(window, exclusive)
         self.device.open(exclusive)
@@ -587,10 +587,10 @@ class PygletDevice(Device):
             self.device.add_removal_observer(self)
             # Don't need to recreate controls since this is same device.
             # They are indexed by cookie, which is constant.
-            if self._is_open: 
+            if self._is_open:
                 self.device.open(self._is_exclusive)
                 self.device.schedule_with_run_loop()
-        
+
     def device_value_changed(self, hid_device, hid_value):
         # Called by device when input value changes.
         control = self._controls[hid_value.element.cookie]
@@ -611,7 +611,7 @@ class PygletDevice(Device):
                 control = Button(name, raw_name)
             else:
                 continue
-            
+
             control._cookie = element.cookie
 
             self._controls[control._cookie] = control
@@ -640,4 +640,3 @@ def get_apple_remote(display=None):
     for device in _manager.devices:
         if device.product == 'Apple IR':
             return AppleRemote(PygletDevice(display, device, _manager))
-

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -52,7 +52,7 @@ from pyglet.event import EventDispatcher
 
 from pyglet.canvas.cocoa import CocoaCanvas
 
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin import cocoapy
 
 from .systemcursor import SystemCursor
 from .pyglet_delegate import PygletDelegate
@@ -60,13 +60,14 @@ from .pyglet_textview import PygletTextView
 from .pyglet_window import PygletWindow, PygletToolWindow
 from .pyglet_view import PygletView
 
-NSApplication = ObjCClass('NSApplication')
-NSCursor = ObjCClass('NSCursor')
-NSAutoreleasePool = ObjCClass('NSAutoreleasePool')
-NSColor = ObjCClass('NSColor')
-NSEvent = ObjCClass('NSEvent')
-NSImage = ObjCClass('NSImage')
+NSApplication = cocoapy.ObjCClass('NSApplication')
+NSCursor = cocoapy.ObjCClass('NSCursor')
+NSAutoreleasePool = cocoapy.ObjCClass('NSAutoreleasePool')
+NSColor = cocoapy.ObjCClass('NSColor')
+NSEvent = cocoapy.ObjCClass('NSEvent')
+NSImage = cocoapy.ObjCClass('NSImage')
 
+quartz = cocoapy.quartz
 
 class CocoaMouseCursor(MouseCursor):
     drawable = False
@@ -102,15 +103,15 @@ class CocoaWindow(BaseWindow):
 
     # NSWindow style masks.
     _style_masks = {
-        BaseWindow.WINDOW_STYLE_DEFAULT:    NSTitledWindowMask |
-                                            NSClosableWindowMask |
-                                            NSMiniaturizableWindowMask,
-        BaseWindow.WINDOW_STYLE_DIALOG:     NSTitledWindowMask |
-                                            NSClosableWindowMask,
-        BaseWindow.WINDOW_STYLE_TOOL:       NSTitledWindowMask |
-                                            NSClosableWindowMask | 
-                                            NSUtilityWindowMask,
-        BaseWindow.WINDOW_STYLE_BORDERLESS: NSBorderlessWindowMask,
+        BaseWindow.WINDOW_STYLE_DEFAULT:    cocoapy.NSTitledWindowMask |
+                                            cocoapy.NSClosableWindowMask |
+                                            cocoapy.NSMiniaturizableWindowMask,
+        BaseWindow.WINDOW_STYLE_DIALOG:     cocoapy.NSTitledWindowMask |
+                                            cocoapy.NSClosableWindowMask,
+        BaseWindow.WINDOW_STYLE_TOOL:       cocoapy.NSTitledWindowMask |
+                                            cocoapy.NSClosableWindowMask |
+                                            cocoapy.NSUtilityWindowMask,
+        BaseWindow.WINDOW_STYLE_BORDERLESS: cocoapy.NSBorderlessWindowMask,
     }
 
     def _recreate(self, changes):
@@ -142,16 +143,16 @@ class CocoaWindow(BaseWindow):
             self._delegate = None
 
         # Determine window parameters.
-        content_rect = NSMakeRect(0, 0, self._width, self._height)
+        content_rect = cocoapy.NSMakeRect(0, 0, self._width, self._height)
         WindowClass = PygletWindow
         if self._fullscreen:
-            style_mask = NSBorderlessWindowMask
+            style_mask = cocoapy.NSBorderlessWindowMask
         else:
             if self._style not in self._style_masks:
                 self._style = self.WINDOW_STYLE_DEFAULT
             style_mask = self._style_masks[self._style]
             if self._resizable:
-                style_mask |= NSResizableWindowMask
+                style_mask |= cocoapy.NSResizableWindowMask
             if self._style == BaseWindow.WINDOW_STYLE_TOOL:
                 WindowClass = PygletToolWindow
 
@@ -170,10 +171,10 @@ class CocoaWindow(BaseWindow):
         #     self.screen.get_nsscreen())  # screen      
 
         self._nswindow = WindowClass.alloc().initWithContentRect_styleMask_backing_defer_(
-            content_rect,            # contentRect
-            style_mask,              # styleMask
-            NSBackingStoreBuffered,  # backing
-            False)                   # defer
+            content_rect,                    # contentRect
+            style_mask,                      # styleMask
+            cocoapy.NSBackingStoreBuffered,  # backing
+            False)                           # defer
 
         if self._fullscreen:
             # BUG: I suspect that this doesn't do the right thing when using
@@ -234,7 +235,7 @@ class CocoaWindow(BaseWindow):
             self._center_window()
         # Otherwise, cascade from last window in list.
         else:
-            point = visible_windows[-1]._nswindow.cascadeTopLeftFromPoint_(NSZeroPoint)
+            point = visible_windows[-1]._nswindow.cascadeTopLeftFromPoint_(cocoapy.NSZeroPoint)
             self._nswindow.cascadeTopLeftFromPoint_(point)
 
     def _center_window(self):
@@ -242,7 +243,7 @@ class CocoaWindow(BaseWindow):
         # and also always moves the window to the main display.
         x = self.screen.x + int((self.screen.width - self._width) // 2)
         y = self.screen.y + int((self.screen.height - self._height) // 2)
-        self._nswindow.setFrameOrigin_(NSPoint(x, y))
+        self._nswindow.setFrameOrigin_(cocoapy.NSPoint(x, y))
 
     def close(self):
         # If we've already gone through this once, don't do it again.
@@ -306,19 +307,19 @@ class CocoaWindow(BaseWindow):
         NSApp = NSApplication.sharedApplication()
         while event and self._nswindow and self._context:
             event = NSApp.nextEventMatchingMask_untilDate_inMode_dequeue_(
-                NSAnyEventMask, None, NSEventTrackingRunLoopMode, True)
+                cocoapy.NSAnyEventMask, None, cocoapy.NSEventTrackingRunLoopMode, True)
 
             if event:
                 event_type = event.type()
                 # Pass on all events.
                 NSApp.sendEvent_(event)
                 # And resend key events to special handlers.
-                if event_type == NSKeyDown and not event.isARepeat():
-                    NSApp.sendAction_to_from_(get_selector('pygletKeyDown:'), None, event)
-                elif event_type == NSKeyUp:
-                    NSApp.sendAction_to_from_(get_selector('pygletKeyUp:'), None, event)
-                elif event_type == NSFlagsChanged:
-                    NSApp.sendAction_to_from_(get_selector('pygletFlagsChanged:'), None, event)
+                if event_type == cocoapy.NSKeyDown and not event.isARepeat():
+                    NSApp.sendAction_to_from_(cocoapy.get_selector('pygletKeyDown:'), None, event)
+                elif event_type == cocoapy.NSKeyUp:
+                    NSApp.sendAction_to_from_(cocoapy.get_selector('pygletKeyUp:'), None, event)
+                elif event_type == cocoapy.NSFlagsChanged:
+                    NSApp.sendAction_to_from_(cocoapy.get_selector('pygletFlagsChanged:'), None, event)
                 NSApp.updateWindows()
 
         pool.drain()
@@ -333,7 +334,7 @@ class CocoaWindow(BaseWindow):
     def set_caption(self, caption):
         self._caption = caption
         if self._nswindow is not None:
-            self._nswindow.setTitle_(get_NSString(caption))
+            self._nswindow.setTitle_(cocoapy.get_NSString(caption))
 
     def set_icon(self, *images):
         # Only use the biggest image from the list.
@@ -374,7 +375,7 @@ class CocoaWindow(BaseWindow):
         quartz.CGColorSpaceRelease(colorSpace)
 
         # Turn the CGImage into an NSImage.
-        size = NSMakeSize(image.width, image.height)
+        size = cocoapy.NSMakeSize(image.width, image.height)
         nsimage = NSImage.alloc().initWithCGImage_size_(cgimage, size)
         if not nsimage:
             return
@@ -398,7 +399,7 @@ class CocoaWindow(BaseWindow):
         screen_frame = self._nswindow.screen().frame()
         screen_width = int(screen_frame.size.width)
         screen_height = int(screen_frame.size.height)
-        origin = NSPoint(x, screen_height - y - rect.size.height)
+        origin = cocoapy.NSPoint(x, screen_height - y - rect.size.height)
         self._nswindow.setFrameOrigin_(origin)
 
     def get_size(self):
@@ -432,13 +433,13 @@ class CocoaWindow(BaseWindow):
         self._nswindow.setFrame_display_animate_(new_frame, True, is_visible)
 
     def set_minimum_size(self, width, height):
-        self._minimum_size = NSSize(width, height)
+        self._minimum_size = cocoapy.NSSize(width, height)
 
         if self._nswindow is not None:
             self._nswindow.setContentMinSize_(self._minimum_size)
 
     def set_maximum_size(self, width, height):
-        self._maximum_size = NSSize(width, height)
+        self._maximum_size = cocoapy.NSSize(width, height)
 
         if self._nswindow is not None:
             self._nswindow.setContentMaxSize_(self._maximum_size)
@@ -485,7 +486,7 @@ class CocoaWindow(BaseWindow):
         point = NSEvent.mouseLocation()
         window_frame = self._nswindow.frame()
         rect = self._nswindow.contentRectForFrameRect_(window_frame)
-        return foundation.NSMouseInRect(point, rect, False)
+        return cocoapy.foundation.NSMouseInRect(point, rect, False)
 
     def set_mouse_platform_visible(self, platform_visible=None):
         # When the platform_visible argument is supplied with a boolean, then this
@@ -571,14 +572,14 @@ class CocoaWindow(BaseWindow):
             # which display the window is in and then convert x, y into local
             # display coords where (0,0) is now top-left of display and y down.
             screenInfo = self._nswindow.screen().deviceDescription()
-            displayID = screenInfo.objectForKey_(get_NSString('NSScreenNumber'))
+            displayID = screenInfo.objectForKey_(cocoapy.get_NSString('NSScreenNumber'))
             displayID = displayID.intValue()
             displayBounds = quartz.CGDisplayBounds(displayID)
             frame = self._nswindow.frame()
             windowOrigin = frame.origin
             x += windowOrigin.x
             y = displayBounds.size.height - windowOrigin.y - y
-            quartz.CGDisplayMoveCursorToPoint(displayID, NSPoint(x, y))
+            quartz.CGDisplayMoveCursorToPoint(displayID, cocoapy.NSPoint(x, y))
 
     def set_exclusive_mouse(self, exclusive=True):
         self._is_mouse_exclusive = exclusive
@@ -610,13 +611,12 @@ class CocoaWindow(BaseWindow):
         if exclusive:
             # "Be nice! Don't disable force-quit!" 
             #          -- Patrick Swayze, Road House (1989)
-            options = NSApplicationPresentationHideDock | \
-                      NSApplicationPresentationHideMenuBar | \
-                      NSApplicationPresentationDisableProcessSwitching | \
-                      NSApplicationPresentationDisableHideApplication
+            options = cocoapy.NSApplicationPresentationHideDock | \
+                      cocoapy.NSApplicationPresentationHideMenuBar | \
+                      cocoapy.NSApplicationPresentationDisableProcessSwitching | \
+                      cocoapy.NSApplicationPresentationDisableHideApplication
         else:
-            options = NSApplicationPresentationDefault
+            options = cocoapy.NSApplicationPresentationDefault
 
         NSApp = NSApplication.sharedApplication()
         NSApp.setPresentationOptions_(options)
-

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -72,7 +72,7 @@ quartz = cocoapy.quartz
 class CocoaMouseCursor(MouseCursor):
     drawable = False
     def __init__(self, cursorName):
-        # cursorName is a string identifying one of the named default NSCursors 
+        # cursorName is a string identifying one of the named default NSCursors
         # e.g. 'pointingHandCursor', and can be sent as message to NSCursor class.
         self.cursorName = cursorName
     def set(self):
@@ -87,7 +87,7 @@ class CocoaWindow(BaseWindow):
 
     # Delegate object.
     _delegate = None
-    
+
     # Window properties
     _minimum_size = None
     _maximum_size = None
@@ -117,7 +117,7 @@ class CocoaWindow(BaseWindow):
     def _recreate(self, changes):
         if 'context' in changes:
             self.context.set_current()
-        
+
         if 'fullscreen' in changes:
             if not self._fullscreen:  # leaving fullscreen
                 self.screen.release_display()
@@ -168,7 +168,7 @@ class CocoaWindow(BaseWindow):
         #     style_mask,             # styleMask
         #     NSBackingStoreBuffered, # backing
         #     False,                  # defer
-        #     self.screen.get_nsscreen())  # screen      
+        #     self.screen.get_nsscreen())  # screen
 
         self._nswindow = WindowClass.alloc().initWithContentRect_styleMask_backing_defer_(
             content_rect,                    # contentRect
@@ -263,7 +263,7 @@ class CocoaWindow(BaseWindow):
             self._nswindow.setDelegate_(None)
             self._delegate.release()
             self._delegate = None
-            
+
         # Remove window from display and remove its view.
         if self._nswindow:
             self._nswindow.orderOut_(None)
@@ -280,7 +280,7 @@ class CocoaWindow(BaseWindow):
             self.canvas.nsview = None
             self.canvas = None
 
-        # Do this last, so that we don't see white flash 
+        # Do this last, so that we don't see white flash
         # when exiting application from fullscreen mode.
         super(CocoaWindow, self).close()
 
@@ -354,7 +354,7 @@ class CocoaWindow(BaseWindow):
         # a CFDataRef object first and use it to create the data provider.
         cfdata = c_void_p(cf.CFDataCreate(None, data, len(data)))
         provider = c_void_p(quartz.CGDataProviderCreateWithCFData(cfdata))
-        
+
         colorSpace = c_void_p(quartz.CGColorSpaceCreateDeviceRGB())
 
         # Then create a CGImage from the provider.
@@ -366,7 +366,7 @@ class CocoaWindow(BaseWindow):
             None,
             True,
             kCGRenderingIntentDefault))
-        
+
         if not cgimage:
             return
 
@@ -454,7 +454,7 @@ class CocoaWindow(BaseWindow):
         self._visible = visible
         if self._nswindow is not None:
             if visible:
-                # Not really sure why on_resize needs to be here, 
+                # Not really sure why on_resize needs to be here,
                 # but it's what pyglet wants.
                 self.dispatch_event('on_resize', self._width, self._height)
                 self.dispatch_event('on_show')
@@ -555,7 +555,7 @@ class CocoaWindow(BaseWindow):
             self.CURSOR_TEXT:            'IBeamCursor',
             self.CURSOR_WAIT:            'arrowCursor',  # No wristwatch cursor in Cocoa
             self.CURSOR_WAIT_ARROW:      'arrowCursor',  # No wristwatch cursor in Cocoa
-            }  
+            }
         if name not in cursors:
             raise RuntimeError('Unknown cursor name "%s"' % name)
         return CocoaMouseCursor(cursors[name])
@@ -566,7 +566,7 @@ class CocoaWindow(BaseWindow):
             # which sets (0,0) at top left corner of main display.  It is possible
             # to warp the mouse position to a point inside of another display.
             quartz.CGWarpMouseCursorPosition(CGPoint(x,y))
-        else: 
+        else:
             # Window-relative coordinates: (x, y) are given in window coords
             # with (0,0) at bottom-left corner of window and y up.  We find
             # which display the window is in and then convert x, y into local
@@ -601,15 +601,15 @@ class CocoaWindow(BaseWindow):
         # http://developer.apple.com/mac/library/technotes/tn2002/tn2062.html
         # http://developer.apple.com/library/mac/#technotes/KioskMode/
 
-        # BUG: System keys like F9 or command-tab are disabled, however 
+        # BUG: System keys like F9 or command-tab are disabled, however
         # pyglet also does not receive key press events for them.
 
-        # This flag is queried by window delegate to determine whether 
+        # This flag is queried by window delegate to determine whether
         # the quit menu item is active.
         self._is_keyboard_exclusive = exclusive
-            
+
         if exclusive:
-            # "Be nice! Don't disable force-quit!" 
+            # "Be nice! Don't disable force-quit!"
             #          -- Patrick Swayze, Road House (1989)
             options = cocoapy.NSApplicationPresentationHideDock | \
                       cocoapy.NSApplicationPresentationHideMenuBar | \

--- a/pyglet/window/cocoa/pyglet_delegate.py
+++ b/pyglet/window/cocoa/pyglet_delegate.py
@@ -47,7 +47,7 @@ NSApplication = ObjCClass('NSApplication')
 
 class PygletDelegate_Implementation(object):
     PygletDelegate = ObjCSubclass('NSObject', 'PygletDelegate')
-    
+
     @PygletDelegate.method(b'@'+PyObjectEncoding)
     def initWithWindow_(self, window):
         self = ObjCInstance(send_super(self, 'init'))
@@ -59,16 +59,16 @@ class PygletDelegate_Implementation(object):
         self._window = window
         window._nswindow.setDelegate_(self)
 
-        # Register delegate for hide and unhide notifications so that we 
+        # Register delegate for hide and unhide notifications so that we
         # can dispatch the corresponding pyglet events.
         notificationCenter = NSNotificationCenter.defaultCenter()
 
         notificationCenter.addObserver_selector_name_object_(
-            self, get_selector('applicationDidHide:'), 
+            self, get_selector('applicationDidHide:'),
             NSApplicationDidHideNotification, None)
 
         notificationCenter.addObserver_selector_name_object_(
-            self, get_selector('applicationDidUnhide:'), 
+            self, get_selector('applicationDidUnhide:'),
             NSApplicationDidUnhideNotification, None)
 
         # Flag set when we pause exclusive mouse mode if window loses key status.
@@ -86,7 +86,7 @@ class PygletDelegate_Implementation(object):
     @PygletDelegate.method('v@')
     def applicationDidHide_(self, notification):
         self._window.dispatch_event("on_hide")
-    
+
     @PygletDelegate.method('v@')
     def applicationDidUnhide_(self, notification):
         if self._window._is_mouse_exclusive and quartz.CGCursorIsVisible():
@@ -118,7 +118,7 @@ class PygletDelegate_Implementation(object):
          # Restore previous mouse visibility settings.
          self._window.set_mouse_platform_visible()
          self._window.dispatch_event("on_activate")
-    
+
     @PygletDelegate.method('v@')
     def windowDidResignKey_(self, notification):
         # Pause exclusive mouse mode if it is active.
@@ -128,11 +128,11 @@ class PygletDelegate_Implementation(object):
             # We need to prevent the window from being unintentionally dragged
             # (by the call to set_mouse_position in set_exclusive_mouse) when
             # the window is reactivated by clicking on its title bar.
-            self._window._nswindow.setMovable_(False)  # Mac OS X 10.6 
+            self._window._nswindow.setMovable_(False)  # Mac OS X 10.6
         # Make sure that cursor is visible.
         self._window.set_mouse_platform_visible(True)
         self._window.dispatch_event("on_deactivate")
-        
+
     @PygletDelegate.method('v@')
     def windowDidMiniaturize_(self, notification):
         self._window.dispatch_event("on_hide")

--- a/pyglet/window/cocoa/pyglet_delegate.py
+++ b/pyglet/window/cocoa/pyglet_delegate.py
@@ -34,7 +34,12 @@
 # ----------------------------------------------------------------------------
 from __future__ import absolute_import
 from builtins import object
-from pyglet.libs.darwin.cocoapy import *
+
+from pyglet.libs.darwin.cocoapy import ObjCClass, ObjCSubclass, ObjCInstance
+from pyglet.libs.darwin.cocoapy import NSApplicationDidHideNotification
+from pyglet.libs.darwin.cocoapy import NSApplicationDidUnhideNotification
+from pyglet.libs.darwin.cocoapy import send_super, get_selector
+from pyglet.libs.darwin.cocoapy import PyObjectEncoding
 from .systemcursor import SystemCursor
 
 NSNotificationCenter = ObjCClass('NSNotificationCenter')

--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -38,7 +38,9 @@ import unicodedata
 
 from pyglet.window import key
 
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin.cocoapy import ObjCClass, ObjCSubclass, ObjCInstance
+from pyglet.libs.darwin.cocoapy import PyObjectEncoding, send_super
+from pyglet.libs.darwin.cocoapy import CFSTR, cfstring_to_string
 
 NSArray = ObjCClass('NSArray')
 NSApplication = ObjCClass('NSApplication')

--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -106,11 +106,11 @@ class PygletTextView_Implementation(object):
 
     @PygletTextView.method('v@')
     def moveWordLeft_(self, sender):
-        self._window.dispatch_event("on_text_motion", key.MOTION_PREVIOUS_WORD)        
+        self._window.dispatch_event("on_text_motion", key.MOTION_PREVIOUS_WORD)
 
     @PygletTextView.method('v@')
     def moveWordRight_(self, sender):
-        self._window.dispatch_event("on_text_motion", key.MOTION_NEXT_WORD)        
+        self._window.dispatch_event("on_text_motion", key.MOTION_NEXT_WORD)
 
     @PygletTextView.method('v@')
     def moveToBeginningOfLine_(self, sender):
@@ -162,11 +162,11 @@ class PygletTextView_Implementation(object):
 
     @PygletTextView.method('v@')
     def moveWordLeftAndModifySelection_(self, sender):
-        self._window.dispatch_event("on_text_motion_select", key.MOTION_PREVIOUS_WORD)        
+        self._window.dispatch_event("on_text_motion_select", key.MOTION_PREVIOUS_WORD)
 
     @PygletTextView.method('v@')
     def moveWordRightAndModifySelection_(self, sender):
-        self._window.dispatch_event("on_text_motion_select", key.MOTION_NEXT_WORD)        
+        self._window.dispatch_event("on_text_motion_select", key.MOTION_NEXT_WORD)
 
     @PygletTextView.method('v@')
     def moveToBeginningOfLineAndModifySelection_(self, sender):      # Mac OS X 10.6

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -97,7 +97,7 @@ class PygletView_Implementation(object):
     @PygletView.method(b'@'+cocoapy.NSRectEncoding+cocoapy.PyObjectEncoding)
     def initWithFrame_cocoaWindow_(self, frame, window):
 
-        # The tracking area is used to get mouseEntered, mouseExited, and cursorUpdate 
+        # The tracking area is used to get mouseEntered, mouseExited, and cursorUpdate
         # events so that we can custom set the mouse cursor within the view.
         self._tracking_area = None
 
@@ -110,7 +110,7 @@ class PygletView_Implementation(object):
         self._window = window
         self.updateTrackingAreas()
 
-        # Create an instance of PygletTextView to handle text events. 
+        # Create an instance of PygletTextView to handle text events.
         # We must do this because NSOpenGLView doesn't conform to the
         # NSTextInputClient protocol by default, and the insertText: method will
         # not do the right thing with respect to translating key sequences like
@@ -152,7 +152,7 @@ class PygletView_Implementation(object):
             None)               # userInfo
 
         self.addTrackingArea_(self._tracking_area)
-    
+
     @PygletView.method('B')
     def canBecomeKeyView(self):
         return True
@@ -235,7 +235,7 @@ class PygletView_Implementation(object):
         # Ignore this event if symbol is not a modifier key.  We must check this
         # because e.g., we receive a flagsChanged message when using CMD-tab to
         # switch applications, with symbol == "a" when command key is released.
-        if symbol is None or symbol not in maskForKey: 
+        if symbol is None or symbol not in maskForKey:
             return
 
         modifiers = getModifiers(nsevent)
@@ -276,20 +276,20 @@ class PygletView_Implementation(object):
         x, y = getMousePosition(self, nsevent)
         dx, dy = getMouseDelta(nsevent)
         self._window.dispatch_event('on_mouse_motion', x, y, dx, dy)
-    
+
     @PygletView.method('v@')
     def scrollWheel_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
         scroll_x, scroll_y = getMouseDelta(nsevent)
         self._window.dispatch_event('on_mouse_scroll', x, y, scroll_x, scroll_y)
-    
+
     @PygletView.method('v@')
     def mouseDown_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
         buttons = mouse.LEFT
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_mouse_press', x, y, buttons, modifiers)
-    
+
     @PygletView.method('v@')
     def mouseDragged_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
@@ -304,14 +304,14 @@ class PygletView_Implementation(object):
         buttons = mouse.LEFT
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_mouse_release', x, y, buttons, modifiers)
-    
+
     @PygletView.method('v@')
     def rightMouseDown_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
         buttons = mouse.RIGHT
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_mouse_press', x, y, buttons, modifiers)
-    
+
     @PygletView.method('v@')
     def rightMouseDragged_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
@@ -319,21 +319,21 @@ class PygletView_Implementation(object):
         buttons = mouse.RIGHT
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_mouse_drag', x, y, dx, dy, buttons, modifiers)
-    
+
     @PygletView.method('v@')
     def rightMouseUp_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
         buttons = mouse.RIGHT
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_mouse_release', x, y, buttons, modifiers)
-    
+
     @PygletView.method('v@')
     def otherMouseDown_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
         buttons = mouse.MIDDLE
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_mouse_press', x, y, buttons, modifiers)
-    
+
     @PygletView.method('v@')
     def otherMouseDragged_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
@@ -341,7 +341,7 @@ class PygletView_Implementation(object):
         buttons = mouse.MIDDLE
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_mouse_drag', x, y, dx, dy, buttons, modifiers)
-    
+
     @PygletView.method('v@')
     def otherMouseUp_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
@@ -370,7 +370,7 @@ class PygletView_Implementation(object):
         # Called when mouse cursor enters view.  Unlike mouseEntered:,
         # this method will be called if the view appears underneath a
         # motionless mouse cursor, as can happen during window creation,
-        # or when switching into fullscreen mode.  
+        # or when switching into fullscreen mode.
         # BUG: If the mouse enters the window via the resize control at the
         # the bottom right corner, the resize control will set the cursor
         # to the default arrow and screw up our cursor tracking.

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -36,9 +36,9 @@ from builtins import object
 from pyglet.window import key, mouse
 from pyglet.libs.darwin.quartzkey import keymap, charmap
 
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin import cocoapy
 
-NSTrackingArea = ObjCClass('NSTrackingArea')
+NSTrackingArea = cocoapy.ObjCClass('NSTrackingArea')
 
 # Event data helper functions.
 
@@ -63,18 +63,18 @@ def getMousePosition(self, nsevent):
 def getModifiers(nsevent):
     modifiers = 0
     modifierFlags = nsevent.modifierFlags()
-    if modifierFlags & NSAlphaShiftKeyMask:
+    if modifierFlags & cocoapy.NSAlphaShiftKeyMask:
         modifiers |= key.MOD_CAPSLOCK
-    if modifierFlags & NSShiftKeyMask:
+    if modifierFlags & cocoapy.NSShiftKeyMask:
         modifiers |= key.MOD_SHIFT
-    if modifierFlags & NSControlKeyMask:
+    if modifierFlags & cocoapy.NSControlKeyMask:
         modifiers |= key.MOD_CTRL
-    if modifierFlags & NSAlternateKeyMask:
+    if modifierFlags & cocoapy.NSAlternateKeyMask:
         modifiers |= key.MOD_ALT
         modifiers |= key.MOD_OPTION
-    if modifierFlags & NSCommandKeyMask:
+    if modifierFlags & cocoapy.NSCommandKeyMask:
         modifiers |= key.MOD_COMMAND
-    if modifierFlags & NSFunctionKeyMask:
+    if modifierFlags & cocoapy.NSFunctionKeyMask:
         modifiers |= key.MOD_FUNCTION
     return modifiers
 
@@ -84,7 +84,7 @@ def getSymbol(nsevent):
     if symbol is not None:
         return symbol
 
-    chars = cfstring_to_string(nsevent.charactersIgnoringModifiers())
+    chars = cocoapy.cfstring_to_string(nsevent.charactersIgnoringModifiers())
     if chars:
         return charmap.get(chars[0].upper(), None)
 
@@ -92,16 +92,16 @@ def getSymbol(nsevent):
 
 
 class PygletView_Implementation(object):
-    PygletView = ObjCSubclass('NSView', 'PygletView')
+    PygletView = cocoapy.ObjCSubclass('NSView', 'PygletView')
 
-    @PygletView.method(b'@'+NSRectEncoding+PyObjectEncoding)
+    @PygletView.method(b'@'+cocoapy.NSRectEncoding+cocoapy.PyObjectEncoding)
     def initWithFrame_cocoaWindow_(self, frame, window):
 
         # The tracking area is used to get mouseEntered, mouseExited, and cursorUpdate 
         # events so that we can custom set the mouse cursor within the view.
         self._tracking_area = None
 
-        self = ObjCInstance(send_super(self, 'initWithFrame:', frame, argtypes=[NSRect]))
+        self = cocoapy.ObjCInstance(cocoapy.send_super(self, 'initWithFrame:', frame, argtypes=[cocoapy.NSRect]))
 
         if not self:
             return None
@@ -117,7 +117,7 @@ class PygletView_Implementation(object):
         # "Option-e", "e" if the protocol isn't implemented.  So the easiest
         # thing to do is to subclass NSTextView which *does* implement the
         # protocol and let it handle text input.
-        PygletTextView = ObjCClass('PygletTextView')
+        PygletTextView = cocoapy.ObjCClass('PygletTextView')
         self._textview = PygletTextView.alloc().initWithCocoaWindow_(window)
         # Add text view to the responder chain.
         self.addSubview_(self._textview)
@@ -126,12 +126,12 @@ class PygletView_Implementation(object):
     @PygletView.method('v')
     def dealloc(self):
         self._window = None
-        # send_message(self.objc_self, 'removeFromSuperviewWithoutNeedingDisplay')
+        # cocoapy.end_message(self.objc_self, 'removeFromSuperviewWithoutNeedingDisplay')
         self._textview.release()
         self._textview = None
         self._tracking_area.release()
         self._tracking_area = None
-        send_super(self, 'dealloc')        
+        cocoapy.send_super(self, 'dealloc')
 
     @PygletView.method('v')
     def updateTrackingAreas(self):
@@ -142,7 +142,7 @@ class PygletView_Implementation(object):
             self._tracking_area.release()
             self._tracking_area = None
 
-        tracking_options = NSTrackingMouseEnteredAndExited | NSTrackingActiveInActiveApp | NSTrackingCursorUpdate
+        tracking_options = cocoapy.NSTrackingMouseEnteredAndExited | cocoapy.NSTrackingActiveInActiveApp | cocoapy.NSTrackingCursorUpdate
         frame = self.frame()
 
         self._tracking_area = NSTrackingArea.alloc().initWithRect_options_owner_userInfo_(
@@ -164,9 +164,9 @@ class PygletView_Implementation(object):
     ## Event responders.
 
     # This method is called whenever the view changes size.
-    @PygletView.method(b'v'+NSSizeEncoding) 
+    @PygletView.method(b'v'+cocoapy.NSSizeEncoding)
     def setFrameSize_(self, size):
-        send_super(self, 'setFrameSize:', size, argtypes=[NSSize])
+        cocoapy.send_super(self, 'setFrameSize:', size, argtypes=[cocoapy.NSSize])
 
         # This method is called when view is first installed as the
         # contentView of window.  Don't do anything on first call.
@@ -227,8 +227,8 @@ class PygletView_Implementation(object):
                       key.ROPTION: NSRightAlternateKeyMask,
                       key.LCOMMAND: NSLeftCommandKeyMask,
                       key.RCOMMAND: NSRightCommandKeyMask,
-                      key.CAPSLOCK: NSAlphaShiftKeyMask,
-                      key.FUNCTION: NSFunctionKeyMask}
+                      key.CAPSLOCK: cocoapy.NSAlphaShiftKeyMask,
+                      key.FUNCTION: cocoapy.NSFunctionKeyMask}
 
         symbol = keymap.get(nsevent.keyCode(), None)
 
@@ -252,15 +252,15 @@ class PygletView_Implementation(object):
         # Let arrow keys and certain function keys pass through the responder
         # chain so that the textview can handle on_text_motion events.
         modifierFlags = nsevent.modifierFlags()
-        if modifierFlags & NSNumericPadKeyMask:
+        if modifierFlags & cocoapy.NSNumericPadKeyMask:
             return False
-        if modifierFlags & NSFunctionKeyMask:
-            ch = cfstring_to_string(nsevent.charactersIgnoringModifiers())
-            if ch in (NSHomeFunctionKey, NSEndFunctionKey, 
-                      NSPageUpFunctionKey, NSPageDownFunctionKey):
+        if modifierFlags & cocoapy.NSFunctionKeyMask:
+            ch = cocoapy.cfstring_to_string(nsevent.charactersIgnoringModifiers())
+            if ch in (cocoapy.NSHomeFunctionKey, cocoapy.NSEndFunctionKey,
+                      cocoapy.NSPageUpFunctionKey, cocoapy.NSPageDownFunctionKey):
                 return False
         # Send the key equivalent to the main menu to perform menu items.
-        NSApp = ObjCClass('NSApplication').sharedApplication()
+        NSApp = cocoapy.ObjCClass('NSApplication').sharedApplication()
         NSApp.mainMenu().performKeyEquivalent_(nsevent)
         # Indicate that we've handled the event so system won't beep.
         return True
@@ -379,4 +379,4 @@ class PygletView_Implementation(object):
             self._window.set_mouse_platform_visible()
 
 
-PygletView = ObjCClass('PygletView')
+PygletView = cocoapy.ObjCClass('PygletView')

--- a/pyglet/window/cocoa/pyglet_window.py
+++ b/pyglet/window/cocoa/pyglet_window.py
@@ -32,8 +32,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
+
+from ctypes import c_void_p, c_bool
 from builtins import object
-from pyglet.libs.darwin.cocoapy import *
+
+from pyglet.libs.darwin.cocoapy import ObjCClass, ObjCSubclass, send_super
+from pyglet.libs.darwin.cocoapy import NSUInteger, NSUIntegerEncoding
+from pyglet.libs.darwin.cocoapy import NSRectEncoding
 
 
 class PygletWindow_Implementation(object):

--- a/pyglet/window/cocoa/pyglet_window.py
+++ b/pyglet/window/cocoa/pyglet_window.py
@@ -67,8 +67,8 @@ class PygletWindow_Implementation(object):
             from pyglet import app
             if app.event_loop is not None:
                 app.event_loop.idle()
-         
-        event = send_super(self, 'nextEventMatchingMask:untilDate:inMode:dequeue:', 
+
+        event = send_super(self, 'nextEventMatchingMask:untilDate:inMode:dequeue:',
                            mask, date, mode, dequeue, argtypes=[NSUInteger, c_void_p, c_void_p, c_bool])
 
         if event.value is None:
@@ -92,8 +92,8 @@ class PygletToolWindow_Implementation(object):
             from pyglet import app
             if app.event_loop is not None:
                 app.event_loop.idle()
-                
-        event = send_super(self, 'nextEventMatchingMask:untilDate:inMode:dequeue:', 
+
+        event = send_super(self, 'nextEventMatchingMask:untilDate:inMode:dequeue:',
                            mask, date, mode, dequeue, argtypes=[NSUInteger, c_void_p, c_void_p, c_bool])
 
         if event.value == None:

--- a/pyglet/window/cocoa/systemcursor.py
+++ b/pyglet/window/cocoa/systemcursor.py
@@ -33,7 +33,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 from builtins import object
-from pyglet.libs.darwin.cocoapy import *
+from pyglet.libs.darwin import cocoapy
 
 # This class is a wrapper around NSCursor which prevents us from
 # sending too many hide or unhide messages in a row.  Apparently
@@ -44,10 +44,10 @@ class SystemCursor(object):
     @classmethod
     def hide(cls):
         if not cls.cursor_is_hidden:
-            send_message('NSCursor', 'hide')
+            cocoapy.send_message('NSCursor', 'hide')
             cls.cursor_is_hidden = True
     @classmethod
     def unhide(cls):
         if cls.cursor_is_hidden:
-            send_message('NSCursor', 'unhide')
+            cocoapy.send_message('NSCursor', 'unhide')
             cls.cursor_is_hidden = False


### PR DESCRIPTION
`import *` can be problematic, especially when we want to update this library.
The new version (PyCocoa) has classes like Screen, which conflict with pyglet
classes. More explicit imports can also highlight what's missing in a newer
version, without having to run the affected code (Import will fail).