### PR TITLE
Fixed some import mistakes in mac cocoa code

### DIFF
--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -68,6 +68,7 @@ NSEvent = cocoapy.ObjCClass('NSEvent')
 NSImage = cocoapy.ObjCClass('NSImage')
 
 quartz = cocoapy.quartz
+cf = cocoapy.cf
 
 class CocoaMouseCursor(MouseCursor):
     drawable = False
@@ -361,11 +362,11 @@ class CocoaWindow(BaseWindow):
         cgimage = c_void_p(quartz.CGImageCreate(
             image.width, image.height, 8, 32, bytesPerRow,
             colorSpace,
-            kCGImageAlphaFirst,
+            cocoapy.kCGImageAlphaFirst,
             provider,
             None,
             True,
-            kCGRenderingIntentDefault))
+            cocoapy.kCGRenderingIntentDefault))
 
         if not cgimage:
             return


### PR DESCRIPTION
Found by testing:

https://github.com/XenonLab-Studio/TerraCraft

**Errors:**

```
Traceback (most recent call last):
  File "main.py", line 62, in <module>
    main()
  File "main.py", line 50, in main
    window.set_icon(pyglet.resource.image('icon.png'))
  File "/usr/local/lib/python3.7/site-packages/pyglet/window/cocoa/__init__.py", line 355, in set_icon
    cfdata = c_void_p(cf.CFDataCreate(None, data, len(data)))
NameError: name 'cf' is not defined
```

```
Traceback (most recent call last):
  File "main.py", line 62, in <module>
    main()
  File "main.py", line 50, in main
    window.set_icon(pyglet.resource.image('icon.png'))
  File "/usr/local/lib/python3.7/site-packages/pyglet/window/cocoa/__init__.py", line 365, in set_icon
    kCGImageAlphaFirst,
NameError: name 'kCGImageAlphaFirst' is not defined
```

**Introduced in:**

https://github.com/pyglet/pyglet/pull/13
bb2d402a1ee364e3d45574e9bf1cec82f16ebfd0