### PR TITLE
Add get_pixel_ratio to BaseWindow

### DIFF
--- a/examples/multiple_windows.py
+++ b/examples/multiple_windows.py
@@ -86,6 +86,6 @@ w2.switch_to()
 setup()
 
 # On some platforms the actual framebuffer size is bigger than the window.
-pixel_ratio = w1.get_framebuffer_size()[0] / w1.width
+pixel_ratio = w1.get_pixel_ratio()
 
 pyglet.app.run()

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1075,6 +1075,23 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         """
         raise NotImplementedError('abstract')
 
+    def get_pixel_ratio(self):
+        """Return the framebuffer/window size ratio.
+
+        Some platforms and/or window system do supports subpixel scaling
+        making the framebuffer size larger than the window size.
+        Retina screens on OS X and Gnome on Linux are some examples.
+
+        On a Retina systems the returned ratio would usually be 2.0 as a
+        window of size 500 x 500 would have a frambuffer of 1000 x 1000.
+        A pixel ratio between 1.0 and 2.0 should also be expected and
+        possibly also above 2.0 in the future.
+
+        :rtype: float
+        :return: The framebuffer/window size ratio
+        """
+        return self.get_framebuffer_size()[0] / self.width
+
     def get_size(self):
         """Return the current size of the window.
 


### PR DESCRIPTION
Making this a method matching `get_size` and `get_framebuffer_size`.

I think in 2.0 it could be an idea making these into `@property` methods.
