### PR TITLE
Issues with uniform block inspection

### DIFF
--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -332,7 +332,11 @@ class ShaderProgram:
             if location == -1:
                 # May be in a UniformBlock. Currently we only
                 # support Named Uniform Blocks. Try to parse it:
-                block_name, uniform_name = uniform_name.split(".")
+                try:
+                    block_name, uniform_name = uniform_name.split(".")
+                except ValueError:
+                    block_name = uniform_name
+                    
                 if block_name not in block_uniforms:
                     block_uniforms[block_name] = {}
 


### PR DESCRIPTION
While most people may not use the gl_ModelViewProjectionMatrix, it does cause the uniform block inspection to crash when trying to split it. 