### PR TITLE
Resolve 50+ Python undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ addons:
 before_install: pip install --upgrade pip flake8 pytest
 install: python setup.py install
 before_script: flake8 . --count --exclude=./.*,*/future/* --select=E9,F63,F7,F82 --show-source --statistics || true
-script: pytest
+script: pytest --ignore=tests/base --ignore=tests/interactive
 # after_success: coveralls

--- a/pyglet/gl/__init__.py
+++ b/pyglet/gl/__init__.py
@@ -40,7 +40,7 @@ functions.  Functions have identical signatures to their C counterparts.  For
 example::
 
     from pyglet.gl import *
-    
+
     # [...omitted: set up a GL context and framebuffer]
     glBegin(GL_QUADS)
     glVertex3f(0, 0, 0)
@@ -48,7 +48,7 @@ example::
     glVertex3f(0.1, 0.2, 0.3)
     glEnd()
 
-OpenGL is documented in full at the `OpenGL Reference Pages`_.  
+OpenGL is documented in full at the `OpenGL Reference Pages`_.
 
 The `OpenGL Programming Guide`_ is a popular reference manual organised by
 topic.  The free online version documents only OpenGL 1.1.  `Later editions`_
@@ -195,7 +195,7 @@ if _pyglet.options['debug_texture']:
         else:
             for i in range(n):
                 _debug_texture_dealloc(textures[i].value)
-        
+
         return _glDeleteTextures(n, textures)
 
 def _create_shadow_window():
@@ -204,7 +204,7 @@ def _create_shadow_window():
     import pyglet
     if not pyglet.options['shadow_window'] or _is_pyglet_doc_run:
         return
-    
+
     from pyglet.window import Window
     _shadow_window = Window(width=1, height=1, visible=False)
     _shadow_window.switch_to()
@@ -222,7 +222,7 @@ elif compat_platform.startswith('linux'):
     from .xlib import XlibConfig as Config
 elif compat_platform == 'darwin':
     from .cocoa import CocoaConfig as Config
-del base
+del base  # noqa: F821
 
 # XXX remove
 _shadow_window = None
@@ -230,8 +230,8 @@ _shadow_window = None
 # Import pyglet.window now if it isn't currently being imported (this creates
 # the shadow window).
 if (not _is_pyglet_doc_run and
-    'pyglet.window' not in _sys.modules and 
+    'pyglet.window' not in _sys.modules and
     _pyglet.options['shadow_window']):
-    # trickery is for circular import 
+    # trickery is for circular import
     _pyglet.gl = _sys.modules[__name__]
     import pyglet.window

--- a/pyglet/image/codecs/__init__.py
+++ b/pyglet/image/codecs/__init__.py
@@ -39,7 +39,7 @@ Modules must subclass ImageDecoder and ImageEncoder for each method of
 decoding/encoding they support.
 
 Modules must also implement the two functions::
-    
+
     def get_decoders():
         # Return a list of ImageDecoder instances or []
         return []
@@ -47,7 +47,7 @@ Modules must also implement the two functions::
     def get_encoders():
         # Return a list of ImageEncoder instances or []
         return []
-    
+
 """
 from builtins import object
 
@@ -178,7 +178,7 @@ def add_encoders(module):
             if extension not in _encoder_extensions:
                 _encoder_extensions[extension] = []
             _encoder_extensions[extension].append(encoder)
- 
+
 
 def add_default_image_codecs():
     # Add the codecs we know about.  These should be listed in order of
@@ -195,7 +195,7 @@ def add_default_image_codecs():
     # Mac OS X default: Quartz
     if compat_platform == 'darwin':
         try:
-            import pyglet.image.codecs.quartz
+            from pyglet.image.codecs import quartz
             add_encoders(quartz)
             add_decoders(quartz)
         except ImportError:
@@ -204,7 +204,7 @@ def add_default_image_codecs():
     # Windows XP default: GDI+
     if compat_platform in ('win32', 'cygwin'):
         try:
-            import pyglet.image.codecs.gdiplus
+            from pyglet.image.codecs import gdiplus
             add_encoders(gdiplus)
             add_decoders(gdiplus)
         except ImportError:
@@ -213,7 +213,7 @@ def add_default_image_codecs():
     # Linux default: GdkPixbuf 2.0
     if compat_platform.startswith('linux'):
         try:
-            import pyglet.image.codecs.gdkpixbuf2
+            from pyglet.image.codecs import gdkpixbuf2
             add_encoders(gdkpixbuf2)
             add_decoders(gdkpixbuf2)
         except ImportError:
@@ -221,7 +221,7 @@ def add_default_image_codecs():
 
     # Fallback: PIL
     try:
-        import pyglet.image.codecs.pil
+        from pyglet.image.codecs import pil
         add_encoders(pil)
         add_decoders(pil)
     except ImportError:
@@ -229,7 +229,7 @@ def add_default_image_codecs():
 
     # Fallback: PNG loader (slow)
     try:
-        import pyglet.image.codecs.png
+        from pyglet.image.codecs import png
         add_encoders(png)
         add_decoders(png)
     except ImportError:
@@ -237,7 +237,7 @@ def add_default_image_codecs():
 
     # Fallback: BMP loader (slow)
     try:
-        import pyglet.image.codecs.bmp
+        from pyglet.image.codecs import bmp
         add_encoders(bmp)
         add_decoders(bmp)
     except ImportError:

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -36,7 +36,7 @@
 """Windowing and user-interface events.
 
 This module allows applications to create and display windows with an
-OpenGL context.  Windows can be created with a variety of border styles 
+OpenGL context.  Windows can be created with a variety of border styles
 or set fullscreen.
 
 You can register event handlers for keyboard, mouse and window events.
@@ -137,6 +137,7 @@ import math
 import pyglet
 from pyglet import gl
 from pyglet.event import EventDispatcher
+from pyglet.window import key
 import pyglet.window.key
 import pyglet.window.event
 
@@ -181,8 +182,8 @@ class MouseCursor(object):
         """Abstract render method.
 
         The cursor should be drawn with the "hot" spot at the given
-        coordinates.  The projection is set to the pyglet default (i.e., 
-        orthographic in window-space), however no other aspects of the 
+        coordinates.  The projection is set to the pyglet default (i.e.,
+        orthographic in window-space), however no other aspects of the
         state can be assumed.
 
         :Parameters:
@@ -301,8 +302,8 @@ class Projection3D(Projection):
 
 
 def _PlatformEventHandler(data):
-    """Decorator for platform event handlers.  
-    
+    """Decorator for platform event handlers.
+
     Apply giving the platform-specific data needed by the window to associate
     the method with an event.  See platform-specific subclasses of this
     decorator for examples.
@@ -402,19 +403,19 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
     #: A mouse cursor indicating the element can be resized from the
     #: upper-right corner.
     CURSOR_SIZE_UP_RIGHT = 'size_up_right'
-    #: A mouse cursor indicating the element can be resized from the right 
+    #: A mouse cursor indicating the element can be resized from the right
     #: border.
     CURSOR_SIZE_RIGHT = 'size_right'
     #: A mouse cursor indicating the element can be resized from the lower-right
     #: corner.
     CURSOR_SIZE_DOWN_RIGHT = 'size_down_right'
-    #: A mouse cursor indicating the element can be resized from the bottom 
+    #: A mouse cursor indicating the element can be resized from the bottom
     #: border.
     CURSOR_SIZE_DOWN = 'size_down'
     #: A mouse cursor indicating the element can be resized from the lower-left
     #: corner.
     CURSOR_SIZE_DOWN_LEFT = 'size_down_left'
-    #: A mouse cursor indicating the element can be resized from the left 
+    #: A mouse cursor indicating the element can be resized from the left
     #: border.
     CURSOR_SIZE_LEFT = 'size_left'
     #: A mouse cursor indicating the element can be resized from the upper-left
@@ -513,7 +514,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         where they are not specified.
 
         The `display`, `screen`, `config` and `context` parameters form
-        a hierarchy of control: there is no need to specify more than 
+        a hierarchy of control: there is no need to specify more than
         one of these.  For example, if you specify `screen` the `display`
         will be inferred, and a default `config` and `context` will be
         created.
@@ -667,7 +668,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
             `changes` : list of str
                 List of attribute names that were changed since the last
                 `_create` or `_recreate`.  For example, ``['fullscreen']``
-                is given if the window is to be toggled to or from fullscreen. 
+                is given if the window is to be toggled to or from fullscreen.
         """
         raise NotImplementedError('abstract')
 
@@ -841,8 +842,8 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         """Draw the custom mouse cursor.
 
         If the current mouse cursor has ``drawable`` set, this method
-        is called before the buffers are flipped to render it.  
-        
+        is called before the buffers are flipped to render it.
+
         This method always leaves the ``GL_MODELVIEW`` matrix as current,
         regardless of what it was set to previously.  No other GL state
         is affected.
@@ -1060,7 +1061,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
 
     def set_size(self, width, height):
         """Resize the window.
-        
+
         The behaviour is undefined if the window is not resizable, or if
         it is currently fullscreen.
 
@@ -1085,7 +1086,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         On a Retina systems the returned ratio would usually be 2.0 as a
         window of size 500 x 500 would have a frambuffer of 1000 x 1000.
         Fractional values between 1.0 and 2.0, as well as values above
-        2.0 may also be encountered. 
+        2.0 may also be encountered.
 
         :rtype: float
         :return: The framebuffer/window size ratio
@@ -1302,7 +1303,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
     def set_icon(self, *images):
         """Set the window icon.
 
-        If multiple images are provided, one with an appropriate size 
+        If multiple images are provided, one with an appropriate size
         will be selected (if the correct size is not provided, the image
         will be scaled).
 
@@ -1312,7 +1313,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         :Parameters:
             `images` : sequence of `pyglet.image.AbstractImage`
                 List of images to use for the window icon.
-        
+
         """
         pass
 
@@ -1360,7 +1361,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
                     The key symbol pressed.
                 `modifiers` : int
                     Bitwise combination of the key modifiers active.
-            
+
             :event:
             """
 
@@ -1519,7 +1520,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
                 `modifiers` : int
                     Bitwise combination of any keyboard modifiers currently
                     active.
-                
+
             :event:
             """
 
@@ -1691,7 +1692,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
 
         def on_context_lost(self):
             """The window's GL context was lost.
-            
+
             When the context is lost no more GL methods can be called until it
             is recreated.  This is a rare event, triggered perhaps by the user
             switching to an incompatible video mode.  When it occurs, an
@@ -1778,12 +1779,12 @@ class FPSDisplay(object):
 
     The style and position of the display can be modified via the :py:func:`~pyglet.text.Label`
     attribute.  Different text can be substituted by overriding the
-    `set_fps` method.  The display can be set to update more or less often 
+    `set_fps` method.  The display can be set to update more or less often
     by setting the `update_period` attribute.
 
     :Ivariables:
         `label` : Label
-            The text label displaying the framerate. 
+            The text label displaying the framerate.
 
     """
 

--- a/tests/extlibs/mock.py
+++ b/tests/extlibs/mock.py
@@ -2331,11 +2331,11 @@ def mock_open(mock=None, read_data=''):
     global file_spec
     if file_spec is None:
         # set on first use
-        if inPy3k:
+        try:
+            file_spec = file
+        except NameError:
             import _io
             file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
-        else:
-            file_spec = file
 
     if mock is None:
         mock = MagicMock(name='open', spec=open)

--- a/tests/integration/window/test_event_sequence.py
+++ b/tests/integration/window/test_event_sequence.py
@@ -16,7 +16,7 @@ class EventSequenceFixture(object):
         self.received_events = queue.Queue()
 
     def create_window(self, **kwargs):
-        w = event_loop.create_window(**kwargs)
+        w = self.event_loop.create_window(**kwargs)
         w.push_handlers(self)
         return w
 

--- a/tools/license.py
+++ b/tools/license.py
@@ -8,6 +8,8 @@ Usage:
     license.py --help  for more information
 """
 
+from __future__ import print_function
+
 import os
 import sys
 import datetime

--- a/tools/wraptypes/lex.py
+++ b/tools/wraptypes/lex.py
@@ -175,6 +175,7 @@ class Lexer:
     # ------------------------------------------------------------
     def readtab(self,tabfile,fdict):
         exec("import %s as lextab" % tabfile)
+        global lextab  # declare the name of the imported module
         self.lextokens      = lextab._lextokens
         self.lexreflags     = lextab._lexreflags
         self.lexliterals    = lextab._lexliterals

--- a/tools/wraptypes/preprocessor.py
+++ b/tools/wraptypes/preprocessor.py
@@ -216,7 +216,7 @@ def t_identifier(t):
 def t_pp_number(t):
     t.type = 'PP_NUMBER'
     return t
-    
+
 @TOKEN(STRING_LITERAL)
 def t_string_literal(t):
     t.type = 'STRING_LITERAL'
@@ -295,7 +295,7 @@ class BinaryExpressionNode(ExpressionNode):
         self.right = right
 
     def evaluate(self, context):
-        return self.op(self.left.evaluate(context), 
+        return self.op(self.left.evaluate(context),
                        self.right.evaluate(context))
 
     def __str__(self):
@@ -349,7 +349,7 @@ class PreprocessorLexer(lex.Lexer):
 
     def input(self, data, filename=None):
         if filename:
-            self.filename = filename 
+            self.filename = filename
         self.lasttoken = None
         self.input_stack = []
 
@@ -445,7 +445,7 @@ class PreprocessorGrammar(Grammar):
 
     def p_group_opt(self, p):
         '''group_opt : group
-                     | 
+                     |
         '''
 
     def p_group(self, p):
@@ -470,7 +470,7 @@ class PreprocessorGrammar(Grammar):
     def p_if_line(self, p):
         '''if_line : IF replaced_constant_expression NEWLINE
                    | IFDEF IDENTIFIER NEWLINE
-                   | IFNDEF IDENTIFIER NEWLINE 
+                   | IFNDEF IDENTIFIER NEWLINE
         '''
         if p.parser.enable_declaratives():
             type = p.slice[1].type
@@ -487,7 +487,7 @@ class PreprocessorGrammar(Grammar):
                 p.parser.write((create_token('PP_IFNDEF', p[2], p),))
         else:
             result = False
-        
+
         p.parser.condition_if(result)
 
     def p_elif_groups_opt(self, p):
@@ -541,7 +541,7 @@ class PreprocessorGrammar(Grammar):
         '''
 
     def p_include_line(self, p):
-        '''include_line : INCLUDE pp_tokens 
+        '''include_line : INCLUDE pp_tokens
                         | INCLUDE_NEXT pp_tokens
                         | IMPORT pp_tokens
         '''
@@ -571,7 +571,7 @@ class PreprocessorGrammar(Grammar):
             print('Invalid #include', file=sys.stderr)
 
     def p_define_object(self, p):
-        '''define_object : DEFINE IDENTIFIER replacement_list NEWLINE 
+        '''define_object : DEFINE IDENTIFIER replacement_list NEWLINE
         '''
         if p.parser.enable_declaratives():
             p.parser.namespace.define_object(p[2], p[3])
@@ -579,7 +579,7 @@ class PreprocessorGrammar(Grammar):
             # Try to parse replacement list as an expression
             tokens = p.parser.namespace.apply_macros(p[3])
             lexer = TokenListLexer(tokens)
-            expr_parser = StrictConstantExpressionParser(lexer, 
+            expr_parser = StrictConstantExpressionParser(lexer,
                                                          p.parser.namespace)
             value = expr_parser.parse(debug=False)
             if value is not None:
@@ -620,7 +620,7 @@ class PreprocessorGrammar(Grammar):
         '''error_line : ERROR pp_tokens_opt NEWLINE
         '''
         if p.parser.enable_declaratives():
-            p.parser.error(' '.join([t.value for t in p[2]]), 
+            p.parser.error(' '.join([t.value for t in p[2]]),
                            p.slice[1].filename, p.slice[1].lineno)
 
     def p_text_line(self, p):
@@ -632,7 +632,7 @@ class PreprocessorGrammar(Grammar):
             p.parser.write(tokens)
 
     def p_replacement_list(self, p):
-        '''replacement_list : 
+        '''replacement_list :
                             | preprocessing_token_no_lparen
                             | preprocessing_token_no_lparen pp_tokens
         '''
@@ -645,7 +645,7 @@ class PreprocessorGrammar(Grammar):
 
     def p_identifier_list_opt(self, p):
         '''identifier_list_opt : identifier_list
-                               | 
+                               |
         '''
         if len(p) == 2:
             p[0] = p[1]
@@ -667,7 +667,7 @@ class PreprocessorGrammar(Grammar):
             tokens = p[1]
             tokens = p.parser.namespace.apply_macros(tokens)
             lexer = TokenListLexer(tokens)
-            parser = ConstantExpressionParser(lexer, p.parser.namespace) 
+            parser = ConstantExpressionParser(lexer, p.parser.namespace)
             p[0] = parser.parse(debug=True)
         else:
             p[0] = ConstantExpressionNode(0)
@@ -678,7 +678,7 @@ class PreprocessorGrammar(Grammar):
             tokens = p[1]
             tokens = p.parser.namespace.apply_macros(tokens)
             lexer = TokenListLexer(tokens)
-            parser = ConstantExpressionParser(lexer, p.parser.namespace) 
+            parser = ConstantExpressionParser(lexer, p.parser.namespace)
             p[0] = parser.parse(debug=True)
         else:
             p[0] = ConstantExpressionNode(0)
@@ -686,7 +686,7 @@ class PreprocessorGrammar(Grammar):
 
     def p_pp_tokens_opt(self, p):
         '''pp_tokens_opt : pp_tokens
-                         |  
+                         |
         '''
         if len(p) == 2:
             p[0] = p[1]
@@ -721,53 +721,53 @@ class PreprocessorGrammar(Grammar):
         p[0] = symbol_to_token(p.slice[1])
 
     def p_punctuator(self, p):
-        '''punctuator : ELLIPSIS 
-                      | RIGHT_ASSIGN 
-                      | LEFT_ASSIGN 
+        '''punctuator : ELLIPSIS
+                      | RIGHT_ASSIGN
+                      | LEFT_ASSIGN
                       | ADD_ASSIGN
-                      | SUB_ASSIGN 
-                      | MUL_ASSIGN 
-                      | DIV_ASSIGN 
-                      | MOD_ASSIGN 
-                      | AND_ASSIGN 
-                      | XOR_ASSIGN 
-                      | OR_ASSIGN 
-                      | RIGHT_OP 
-                      | LEFT_OP 
-                      | INC_OP 
-                      | DEC_OP 
-                      | PTR_OP 
-                      | AND_OP 
-                      | OR_OP 
-                      | LE_OP 
+                      | SUB_ASSIGN
+                      | MUL_ASSIGN
+                      | DIV_ASSIGN
+                      | MOD_ASSIGN
+                      | AND_ASSIGN
+                      | XOR_ASSIGN
+                      | OR_ASSIGN
+                      | RIGHT_OP
+                      | LEFT_OP
+                      | INC_OP
+                      | DEC_OP
+                      | PTR_OP
+                      | AND_OP
+                      | OR_OP
+                      | LE_OP
                       | GE_OP
-                      | EQ_OP 
-                      | NE_OP 
-                      | HASH_HASH 
-                      | ';' 
-                      | '{' 
-                      | '}' 
-                      | ',' 
-                      | ':' 
-                      | '=' 
-                      | '(' 
-                      | ')' 
-                      | '[' 
-                      | ']' 
+                      | EQ_OP
+                      | NE_OP
+                      | HASH_HASH
+                      | ';'
+                      | '{'
+                      | '}'
+                      | ','
+                      | ':'
+                      | '='
+                      | '('
+                      | ')'
+                      | '['
+                      | ']'
                       | PERIOD
-                      | '&' 
-                      | '!' 
-                      | '~' 
+                      | '&'
+                      | '!'
+                      | '~'
                       | '-'
-                      | '+' 
-                      | '*' 
-                      | '/' 
-                      | '%' 
-                      | '<' 
-                      | '>' 
-                      | '^' 
-                      | '|' 
-                      | '?' 
+                      | '+'
+                      | '*'
+                      | '/'
+                      | '%'
+                      | '<'
+                      | '>'
+                      | '^'
+                      | '|'
+                      | '?'
                       | '#'
         '''
         p[0] = symbol_to_token(p.slice[1])
@@ -780,7 +780,7 @@ class PreprocessorGrammar(Grammar):
             # TODO
             print('%s:%d Syntax error at %r' % \
                 (t.lexer.filename, t.lexer.lineno, t.value), file=sys.stderr)
-            #t.lexer.cparser.handle_error('Syntax error at %r' % t.value, 
+            #t.lexer.cparser.handle_error('Syntax error at %r' % t.value,
             #     t.lexer.filename, t.lexer.lineno)
         # Don't alter lexer: default behaviour is to pass error production
         # up until it hits the catch-all at declaration, at which point
@@ -804,7 +804,7 @@ class ConstantExpressionGrammar(Grammar):
         '''
         try:
             value = ord(eval(p[1].lstrip('L')))
-        except StandardError:
+        except Exception:
             value = 0
         p[0] = ConstantExpressionNode(value)
 
@@ -848,7 +848,7 @@ class ConstantExpressionGrammar(Grammar):
         '''postfix_expression : primary_expression
         '''
         p[0] = p[1]
-        
+
     def p_unary_expression(self, p):
         '''unary_expression : postfix_expression
                             | unary_operator cast_expression
@@ -919,7 +919,7 @@ class ConstantExpressionGrammar(Grammar):
                 '>>': operator.rshift}[p[2]], p[2], p[1], p[3])
 
     def p_relational_expression(self, p):
-        '''relational_expression : shift_expression 
+        '''relational_expression : shift_expression
                                  | relational_expression '<' shift_expression
                                  | relational_expression '>' shift_expression
                                  | relational_expression LE_OP shift_expression
@@ -958,7 +958,7 @@ class ConstantExpressionGrammar(Grammar):
     def p_exclusive_or_expression(self, p):
         '''exclusive_or_expression : and_expression
                                    | exclusive_or_expression '^' and_expression
-        ''' 
+        '''
         if len(p) == 2:
             p[0] = p[1]
         else:
@@ -1087,7 +1087,7 @@ class PreprocessorParser(yacc.Parser):
 
     def add_gcc_search_path(self):
         from subprocess import Popen, PIPE
-        path = Popen('gcc -print-file-name=include', 
+        path = Popen('gcc -print-file-name=include',
                      shell=True, stdout=PIPE).communicate()[0].strip()
         if path:
             self.include_path.append(path)
@@ -1111,7 +1111,7 @@ class PreprocessorParser(yacc.Parser):
                     print(('Adding:', output[0].strip()))
                     del output[0]
 
-    def parse(self, filename=None, data=None, namespace=None, debug=False): 
+    def parse(self, filename=None, data=None, namespace=None, debug=False):
         self.output = []
         if not namespace:
             namespace = self.namespace
@@ -1189,7 +1189,7 @@ class PreprocessorParser(yacc.Parser):
                 self.push_file(path)
         else:
             print('"%s" not found' % header, file=sys.stderr) # TODO
- 
+
     def get_header_path(self, header):
         p = os.path.join(os.path.dirname(self.lexer.filename), header)
         if os.path.exists(p):
@@ -1221,14 +1221,14 @@ class PreprocessorParser(yacc.Parser):
                 localpath += parent + '.framework'
                 paths.append(os.path.join(localpath, 'Frameworks'))
             for path in paths:
-                p = os.path.join(path, '%s.framework' % framework, 
+                p = os.path.join(path, '%s.framework' % framework,
                                  'Headers', header)
                 if os.path.exists(p):
                     return p
 
     def error(self, message, filename, line):
         print('%s:%d #error %s' % (filename, line, message), file=sys.stderr)
-    
+
     def condition_if(self, result):
         self.condition_stack.append(
             ExecutionState(self.condition_stack[-1].enabled, result))
@@ -1268,7 +1268,7 @@ class PreprocessorParser(yacc.Parser):
                 while tb is not None:
                     if hasattr(tb, 'lexer'):
                         del tb.lexer
-                    self.output.append(tb) 
+                    self.output.append(tb)
                     tb = l.token()
 
                 tc = create_token('>', '>')
@@ -1283,7 +1283,7 @@ class PreprocessorParser(yacc.Parser):
             self.output.append(t)
 
     def get_memento(self):
-        return (set(self.namespace.objects.keys()), 
+        return (set(self.namespace.objects.keys()),
                 set(self.namespace.functions.keys()))
 
 class ConstantExpressionParser(yacc.Parser):
@@ -1308,7 +1308,7 @@ class StrictConstantExpressionParser(ConstantExpressionParser):
     _const_grammar = StrictConstantExpressionGrammar
 
 class PreprocessorNamespace(EvaluationContext):
-    def __init__(self, gcc_macros=True, 
+    def __init__(self, gcc_macros=True,
                        stdc_macros=True,
                        workaround_macros=True):
         self.objects = {}
@@ -1316,7 +1316,7 @@ class PreprocessorNamespace(EvaluationContext):
 
         if stdc_macros:
             self.add_stdc_macros()
-        
+
         if gcc_macros:
             self.add_gcc_macros()
 
@@ -1334,15 +1334,15 @@ class PreprocessorNamespace(EvaluationContext):
         import time
         date = time.strftime('%b %d %Y') # XXX %d should have leading space
         t = time.strftime('%H:%M:S')
-        self.define_object('__DATE__', 
+        self.define_object('__DATE__',
                            (create_token('STRING_LITERAL', date),))
-        self.define_object('__TIME__', 
+        self.define_object('__TIME__',
                            (create_token('STRING_LITERAL', t),))
-        self.define_object('__STDC__', 
+        self.define_object('__STDC__',
                            (create_token('PP_NUMBER', '1'),))
-        self.define_object('__STDC_HOSTED__', 
+        self.define_object('__STDC_HOSTED__',
                            (create_token('PP_NUMBER', '1'),))
-        self.define_object('__STDC_VERSION', 
+        self.define_object('__STDC_VERSION',
                            (create_token('PP_NUMBER', '199901L'),))
 
     def add_gcc_macros(self):
@@ -1377,7 +1377,7 @@ class PreprocessorNamespace(EvaluationContext):
         tok1.value = '1'
         tok1.lineno = -1
         tok1.lexpos = -1
-        
+
         for macro in machine_macros + platform_macros + gcc_macros:
             self.define_object(macro, (tok1,))
 
@@ -1423,7 +1423,7 @@ class PreprocessorNamespace(EvaluationContext):
             elif t.type == 'IDENTIFIER' and t.value == '__VA_ARGS__' and \
                 '...' in params:
                 replacements[i] = len(params) - 1
-                
+
         self.functions[name] = replacements, numargs
 
     def apply_macros(self, tokens, replacing=None):

--- a/tools/wraptypes/yacc.py
+++ b/tools/wraptypes/yacc.py
@@ -477,7 +477,7 @@ def validate_dict(d):
                 doc = v.__doc__.split(" ")
                 if doc[1] == ':':
                     sys.stderr.write("%s:%d: Warning. Possible grammar rule '%s' defined without p_ prefix.\n" % (v.func_code.co_filename, v.func_code.co_firstlineno,n))
-            except StandardError:
+            except Exception:
                 pass
 
 # -----------------------------------------------------------------------------
@@ -791,7 +791,7 @@ def add_function(f):
                 error += e
 
 
-            except StandardError:
+            except Exception:
                 sys.stderr.write("%s:%d: Syntax error in rule '%s'\n" % (file,dline,ps))
                 error -= 1
     else:
@@ -1766,7 +1766,7 @@ def lr_parse_table(method):
                                 action[st,a] = j
                                 actionp[st,a] = p
 
-            except StandardError as e:
+            except Exception as e:
                 raise YaccError("Hosed in lr_parse_table", e)
 
         # Print the actions associated with each terminal
@@ -1938,6 +1938,7 @@ def lr_read_tables(module=tab_module,optimize=0):
     global _lr_action, _lr_goto, _lr_productions, _lr_method
     try:
         exec("import %s as parsetab" % module)
+        global parsetab  # declare the name of the imported module
 
         if (optimize) or (Signature.digest() == parsetab._lr_signature):
             _lr_action = parsetab._lr_action
@@ -2055,7 +2056,7 @@ def yacc(method=default_lr, debug=yaccdebug, module=None, tabmodule=tab_module, 
                         raise TypeError
                     v1 = [x.split(".") for x in v]
                     Requires[r] = v1
-                except StandardError:
+                except Exception:
                     print("Invalid specification for rule '%s' in require. Expected a list of strings" % r)
 
 


### PR DESCRIPTION
[__StandardError__ was removed in Python 3](https://portingguide.readthedocs.io/en/latest/exceptions.html#the-removed-standarderror) in favor of __Exception__ which works as expected in both Python 2 and Python 3.  

__flake8__ results:
* before: https://travis-ci.org/pyglet/pyglet/builds/566994718#L1768 62 undefined names
* after: https://travis-ci.org/pyglet/pyglet/builds/567020258#L1776 8 undefined names

[__wraptypes__](https://pyglet.readthedocs.io/en/pyglet-1.3-maintenance/internal/wraptypes.html) needs work.
There is still three instances of __cmp()__ that was removed in Python 3  https://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-function