### PR TITLE
cmp was removed in Python 3

### DIFF
--- a/tools/wraptypes/preprocessor.py
+++ b/tools/wraptypes/preprocessor.py
@@ -146,7 +146,7 @@ punctuators = {
 
 def punctuator_regex(punctuators):
     punctuator_regexes = [v[0] for v in punctuators.values()]
-    punctuator_regexes.sort(lambda a, b: -cmp(len(a), len(b)))
+    punctuator_regexes.sort(key=len, reverse=True)
     return '(%s)' % '|'.join(punctuator_regexes)
 
 def t_clinecomment(t):


### PR DESCRIPTION
A partial solution to #33 

```python
#!/usr/bin/env python2

for ab in (["a", "b"],
           ["a", "bb"],
           ["aa", "b"],
           ["aa", "bbb"],
           ["aaa", "bb"],
           ["", "b"]):
    old = ab[:]
    old.sort(lambda a, b: -cmp(len(a), len(b)))
    new = ab[:]
    new.sort(key=len, reverse=True)
    print(ab, old, new)
    assert old == new
```