### PR TITLE
Replace cmp() in lex and yacc for Python 3

### DIFF
--- a/tools/wraptypes/lex.py
+++ b/tools/wraptypes/lex.py
@@ -646,7 +646,7 @@ def lex(module=None,object=None,debug=0,optimize=0,lextab="lextab",reflags=0,now
 
     # Sort the functions by line number
     for f in funcsym.values():
-        f.sort(lambda x,y: cmp(x[1].func_code.co_firstlineno,y[1].func_code.co_firstlineno))
+        f.sort(key=lambda func: func[1].__code__.co_firstlineno)
 
     # Sort the strings by regular expression length
     for s in strsym.values():

--- a/tools/wraptypes/yacc.py
+++ b/tools/wraptypes/yacc.py
@@ -2117,7 +2117,7 @@ def yacc(method=default_lr, debug=yaccdebug, module=None, tabmodule=tab_module, 
             raise YaccError("no rules of the form p_rulename are defined.")
 
         # Sort the symbols by line number
-        symbols.sort(lambda x,y: cmp(x.func_code.co_firstlineno,y.func_code.co_firstlineno))
+        symbols.sort(key=lambda func: func.__code__.co_firstlineno)
 
         # Add all of the symbols to the grammar
         for f in symbols:


### PR DESCRIPTION
Fixes  #33  __cmp()___ was removed in Python so modify these __sort()__ calls to work in both Python 2 and Python 3.

```python
#!/usr/bin/env python2

def e():
    pass

def d():
    pass

def c():
    pass

def b():
    pass

def a():
    pass

funcs = [c, e, b, a, d]
symbols = funcs[:]
symbols.sort(lambda x,y: cmp(x.func_code.co_firstlineno,y.func_code.co_firstlineno))
print(", ".join(func.__name__ for func in symbols))
funcs.sort(key=lambda func: func.__code__.co_firstlineno)
print(", ".join(func.__name__ for func in funcs))

print ("=" * 20)

funcs = [(func.__name__, func) for func in (c, e, b, a, d)]
f = funcs[:]
f.sort(lambda x,y: cmp(x[1].func_code.co_firstlineno,y[1].func_code.co_firstlineno))
print(", ".join(func[0] for func in f))
funcs.sort(key=lambda func: func[1].__code__.co_firstlineno)
print(", ".join(func[0] for func in funcs))
```