### PR TITLE
readthedocs theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,7 +189,7 @@ modindex_common_prefix = ['pyglet.']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'pyglet'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -197,7 +197,7 @@ html_theme = 'pyglet'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = ["ext/theme"]
+# html_theme_path = ["ext/theme"]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/doc/external_resources.txt
+++ b/doc/external_resources.txt
@@ -1,0 +1,50 @@
+
+
+Related Documentation
+=====================
+
+* `OpenGL Programming Guide <http://www.glprogramming.com/red/>`_
+* `OpenGL Reference Pages <http://opengl.org/sdk/docs/man/>`_
+* `ctypes Reference <http://docs.python.org/3/library/ctypes.html>`_
+* `Python Documentation <http://docs.python.org/>`_
+
+Third party libraries
+=====================
+
+Listed here are a few third party libraries that you might find useful when
+developing your project.  Please direct any questions to the respective authors.
+If you would like to have your library listed here, let us know!
+
+`glooey -  An object-oriented GUI library for pyglet <http://glooey.readthedocs.io/en/latest/index.html>`_
+    Every game needs a user interface that matches its look and feel. The purpose of glooey
+    is to help you make such an interface.  Towards this end, glooey provides 7 powerful
+    placement widgets, a label widget, an image widget, 3 different button widgets, a text
+    entry widget, a variety of scroll boxes and bars, 4 different dialog box widgets, and a
+    variety of other miscellaneous widgets.  The appearance of any widget can be trivially
+    customized, and glooey comes with built-in fantasy, puzzle, and 8-bit themes to prove it
+    (and to help you hit the ground running if your game fits one of those genres).
+
+`PyShaders - Pythonic OpenGL shader wrapper for python <https://github.com/gabdube/pyshaders>`_
+    Pyshaders aims to completely wraps the opengl2.1 shader api in a python module.
+    Pyshaders provides a pythonic OOP api that hides the lower level (ctypes) calls.
+    Pyshaders provides a high level api and a low level api, and it can be integrated easily
+    with existing code because it does not occlude the underlying opengl values.
+
+`Ratcave - A Simple Python 3D Graphics Engine extension for pyglet, Psychopy, and PyGame <https://github.com/neuroneuro15/ratcave>`_
+    Ratcave provides a simple OOP interface for loading, positioning, and drawing 3D scenes
+    in OpenGL windows.  It's a great fit for simple games and scientific behavioral experiments!
+
+Projects using pyglet
+=====================
+
+pyglet is a fairly lightweight library, which makes it ideal to build upon.  Listed here are
+a few projects that take advantage of pyglet "under the hood".  If you would like to have your
+project listed here, let us know!
+
+`cocos2d - A framework for building 2D games, demos, and other graphical/interactive applications <http://python.cocos2d.org/index.html>`_
+    Cocos2d is an open source software framework. It can be used to build games, apps and
+    other cross platform GUI based interactive programs.
+
+`Arcade - A 2D library for game development focusing on simplicity <http://arcade.academy/>`_
+    Arcade builds on Pyglet with a focus to make creating 2D arcade games simple and easy
+    for hobbyists and new programmers.

--- a/doc/index.txt
+++ b/doc/index.txt
@@ -27,18 +27,12 @@ Please join us on the `mailing list`_!
 
 .. _mailing list: http://groups.google.com/group/pyglet-users
 
-Programming Guide
------------------
-
-The pyglet Programming Guide provides in-depth documentation for writing
-applications using pyglet.  Many topics described here reference the pyglet
-API reference, which is listed below.
-
 If this is your first time reading about pyglet, we suggest you start at
 :doc:`programming_guide/quickstart`.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
+   :caption: Programming Guide
 
    programming_guide/installation
    programming_guide/quickstart
@@ -61,11 +55,9 @@ If this is your first time reading about pyglet, we suggest you start at
    programming_guide/advanced
    programming_guide/examplegame
 
-API Reference
--------------
-
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
+   :caption: API Reference
 
    modules/pyglet
    modules/app
@@ -84,14 +76,9 @@ API Reference
    modules/text/index
    modules/window
 
-Development Guide
------------------
-These documents describe details on how to develop pyglet itself further.  Read
-these to get a more detailed insight into how pyglet is designed, and how to
-help make pyglet even better.  Get in touch if you would like to contribute!
-
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
+   :caption: Development Guide
 
    internal/contributing
    internal/virtualenv
@@ -104,51 +91,8 @@ help make pyglet even better.  Get in touch if you would like to contribute!
    internal/media_manual
    internal/media_logging_manual
 
-Related Documentation
----------------------
+.. toctree::
+   :maxdepth: 3
+   :caption: External Resources
 
-* `OpenGL Programming Guide <http://www.glprogramming.com/red/>`_
-* `OpenGL Reference Pages <http://opengl.org/sdk/docs/man/>`_
-* `ctypes Reference <http://docs.python.org/3/library/ctypes.html>`_
-* `Python Documentation <http://docs.python.org/>`_
-
-Third party libraries
----------------------
-
-Listed here are a few third party libraries that you might find useful when
-developing your project.  Please direct any questions to the respective authors.
-If you would like to have your library listed here, let us know!
-
-`glooey -  An object-oriented GUI library for pyglet <http://glooey.readthedocs.io/en/latest/index.html>`_
-    Every game needs a user interface that matches its look and feel. The purpose of glooey
-    is to help you make such an interface.  Towards this end, glooey provides 7 powerful
-    placement widgets, a label widget, an image widget, 3 different button widgets, a text
-    entry widget, a variety of scroll boxes and bars, 4 different dialog box widgets, and a
-    variety of other miscellaneous widgets.  The appearance of any widget can be trivially
-    customized, and glooey comes with built-in fantasy, puzzle, and 8-bit themes to prove it
-    (and to help you hit the ground running if your game fits one of those genres).
-
-`PyShaders - Pythonic OpenGL shader wrapper for python <https://github.com/gabdube/pyshaders>`_
-    Pyshaders aims to completely wraps the opengl2.1 shader api in a python module.
-    Pyshaders provides a pythonic OOP api that hides the lower level (ctypes) calls.
-    Pyshaders provides a high level api and a low level api, and it can be integrated easily
-    with existing code because it does not occlude the underlying opengl values.
-
-`Ratcave - A Simple Python 3D Graphics Engine extension for pyglet, Psychopy, and PyGame <https://github.com/neuroneuro15/ratcave>`_
-    Ratcave provides a simple OOP interface for loading, positioning, and drawing 3D scenes
-    in OpenGL windows.  It's a great fit for simple games and scientific behavioral experiments!
-
-Projects using pyglet
----------------------
-
-pyglet is a fairly lightweight library, which makes it ideal to build upon.  Listed here are
-a few projects that take advantage of pyglet "under the hood".  If you would like to have your
-project listed here, let us know!
-
-`cocos2d - A framework for building 2D games, demos, and other graphical/interactive applications <http://python.cocos2d.org/index.html>`_
-    Cocos2d is an open source software framework. It can be used to build games, apps and
-    other cross platform GUI based interactive programs.
-
-`Arcade - A 2D library for game development focusing on simplicity <http://arcade.academy/>`_
-    Arcade builds on Pyglet with a focus to make creating 2D arcade games simple and easy
-    for hobbyists and new programmers.
+   external_resources

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx<3
+sphinx-rtd-theme<5
+pytest<6


### PR DESCRIPTION
Not sure if this is the right thing to do, but it's at least not a too radical change in the doc files and can be reverted later without too much trouble.

Because the custom pyglet theme is currently broken, here's some minimal changes to get it working with `sphinx-rtd-theme`. This way we at least have working search.

Changes:
* Created `requirements.txt` for in `doc/` directory.
* The left  menu is now generated from the `toxtree` directives (by adding `:caption:`)
* Added "External Resources" toctree to including the bottom part the index to the left menu

I'm not entirely sure if these to paragraphs should be re-added somewhere else?
* Removed first paragraph from "Programming Guide" as the `toctree` now creates the title
* Removed first paragraph from "API Guide" as the `toctree` now creates the title

There are also some other minor configuration options that can be explored:
https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html

That section also mentions how the left menu is generated:
> Currently the left menu will build based upon any toctree directives defined in your source files. It outputs 4 levels of depth by default, to allow for quick navigation through topics. If no TOC trees are defined, Sphinx’s default behavior is to use the page headings instead.
