### PR TITLE
Modernize tweaks: MSAA + Double Buffering

### DIFF
--- a/doc/programming_guide/context.txt
+++ b/doc/programming_guide/context.txt
@@ -172,19 +172,18 @@ configured with the following attributes:
         you are compositing in multiple passes) you should specify
         ``alpha_size=8`` to ensure that this channel is created.
     ``sample_buffers`` and ``samples``
-        Configures the buffer for multisampling, in which more than one color
+        Configures the buffer for multisampling (MSAA), in which more than one color
         sample is used to determine the color of each pixel, leading to a
         higher quality, antialiased image.
 
-        Enable multisampling by setting ``sample_buffers=1``, then give the
+        Enable multisampling (MSAA) by setting ``sample_buffers=1``, then give the
         number of samples per pixel to use in ``samples``.  For example,
         ``samples=2`` is the fastest, lowest-quality multisample
-        configuration.  A higher-quality buffer (with a compromise in
-        performance) is possible with ``samples=4``.
+        configuration. ``samples=4`` is still widely supported
+        and fairly performant even on Intel HD and AMD Vega.
+        Most modern GPUs support 2×, 4×, 8×, and 16× MSAA samples
+        with fairly high performance.
 
-        Not all video hardware supports multisampling; you may need to make
-        this a user-selectable option, or be prepared to automatically
-        downgrade the configuration if the requested one is not available.
     ``stereo``
         Creates separate left and right buffers, for use with stereo hardware.
         Only specialised video hardware such as stereoscopic glasses will

--- a/doc/programming_guide/windowing.txt
+++ b/doc/programming_guide/windowing.txt
@@ -331,8 +331,9 @@ Double-buffering
 
 If the window is double-buffered (i.e., the configuration specified
 ``double_buffer=True``, the default), OpenGL commands are applied to a hidden
-back buffer.  This back buffer can be copied to the window using the `flip`
-method.  If you are using the standard `pyglet.app.run` or
+back buffer. This back buffer can be brought to the front using the `flip`
+method. The previous front buffer then becomes the hidden back buffer
+we render to in the next frame. If you are using the standard `pyglet.app.run` or
 :py:class:`pyglet.app.EventLoop` event loop, this is taken care of automatically after
 each :py:meth:`~pyglet.window.Window.on_draw` event.
 


### PR DESCRIPTION
I think these sections needed some modernizing:
* MSAA: These features are required and common today even on Intel HD and AMD Vega (even HW 5+ years back)
* Double buffering is done thought buffer swapping in the vast majority of the cases.
