### PR TITLE
Issue #66. Change findlib so it properly puts together a library name.

### DIFF
--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -212,7 +212,7 @@ class MachOLibraryLoader(LibraryLoader):
         libname = os.path.basename(path)
         search_path = []
 
-        if '.' not in libname:
+        if '.dylib' not in libname:
             libname = 'lib' + libname + '.dylib'
 
         # py2app support


### PR DESCRIPTION
Really hoping this doesn't mess anything else up. It does allow the pyglet-ffmpeg2 package to load libraries on the mac.