### PR TITLE
Torxed multi inheritance

### DIFF
--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -190,6 +190,7 @@ class Sprite(event.EventDispatcher):
     _scale_y = 1.0
     _visible = True
     _vertex_list = None
+    _texture = None
 
     def __init__(self,
                  img, x=0, y=0,
@@ -310,9 +311,11 @@ class Sprite(event.EventDispatcher):
             self._batch.migrate(self._vertex_list, GL_QUADS, self._group, batch)
             self._batch = batch
         else:
-            self._vertex_list.delete()
+            if self._vertex_list:
+                self._vertex_list.delete()
             self._batch = batch
-            self._create_vertex_list()
+            if self._texture:
+                self._create_vertex_list()
 
     @property
     def group(self):

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -191,6 +191,7 @@ class Sprite(event.EventDispatcher):
     _visible = True
     _vertex_list = None
     _texture = None
+    _group = None
 
     def __init__(self,
                  img, x=0, y=0,
@@ -307,7 +308,7 @@ class Sprite(event.EventDispatcher):
         if self._batch == batch:
             return
 
-        if batch is not None and self._batch is not None:
+        if batch is not None and self._batch is not None and self._vertex_list and self._group:
             self._batch.migrate(self._vertex_list, GL_QUADS, self._group, batch)
             self._batch = batch
         else:

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -196,7 +196,6 @@ class Sprite(event.EventDispatcher):
     _texture = None
     _x = 0
     _y = 0
-    _subpixel = False
 
     def __init__(self,
                  img, x=0, y=0,
@@ -446,8 +445,7 @@ class Sprite(event.EventDispatcher):
                         int(vertices[2]), int(vertices[3]),
                         int(vertices[4]), int(vertices[5]),
                         int(vertices[6]), int(vertices[7]))
-        if self._vertex_list:
-            self._vertex_list.vertices[:] = vertices
+        self._vertex_list.vertices[:] = vertices
 
     def _update_color(self):
         r, g, b = self._rgb

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -190,8 +190,12 @@ class Sprite(event.EventDispatcher):
     _scale_y = 1.0
     _visible = True
     _vertex_list = None
-    _texture = None
+    _subpixel = False
+    _usage = 'dynamic'
     _group = None
+    _texture = None
+    _x = 0
+    _y = 0
 
     def __init__(self,
                  img, x=0, y=0,
@@ -308,15 +312,14 @@ class Sprite(event.EventDispatcher):
         if self._batch == batch:
             return
 
-        if batch is not None and self._batch is not None and self._vertex_list and self._group:
+        if batch is not None and self._batch is not None:
             self._batch.migrate(self._vertex_list, GL_QUADS, self._group, batch)
             self._batch = batch
         else:
             if self._vertex_list:
                 self._vertex_list.delete()
             self._batch = batch
-            if self._texture:
-                self._create_vertex_list()
+            self._create_vertex_list()
 
     @property
     def group(self):


### PR DESCRIPTION
Fixing issue #79 where `Sprite()` might not yet be instantiated in a parent class in a inheritance chain scenario or a multi inheritances scenario.

The problem appears to be the assumption that when setting batch, the java-alike `setter` is called and it assumes that `.batch` is already set in a previous iteration. This isn't true if `Sprite()` isn't instantiated in the right order.

Moving away from this assumption, and not calling `.migrate()` if the `_vertex_list` is empty, seams to solve the corner case.

**Note**: Tested on two smaller projects, no extensive tests have been made!