### PR TITLE
Catch StopIteration at the end of an iterator

### DIFF
--- a/pyglet/text/runlist.py
+++ b/pyglet/text/runlist.py
@@ -418,7 +418,11 @@ class ZipRunIterator(AbstractRunIterator):
                 start = min_end
                 for i, iterator in enumerate(iterators):
                     if ends[i] == min_end:
-                        starts[i], ends[i], values[i] = next(iterator)
+                        try:
+                            starts[i], ends[i], values[i] = next(iterator)
+                        except StopIteration:
+                            return
+
         except StopIteration:
             return
 


### PR DESCRIPTION
This change avoids a RuntimeError that arises when initializing a text object. I think this error arises because of a change in the way Python 3.7 handles a StopIteration. I've tested this in Psychopy v3.1.5 running Python 3.7.3.