### PR TITLE
ENH: Add support for conda-installed FFmpeg on macOS

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,10 @@
 pyglet 1.4.7
 Bugfix release
 
+Improvements
+------------
+- Add support for `conda`-installed FFmpeg on macOS (#xx)
+
 Bugfixes
 --------
 - Allow creation of non-power-of-two compressed Textures. (#78)

--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -222,6 +222,11 @@ class MachOLibraryLoader(LibraryLoader):
                 sys.frozen is True and pyglet.compat_platform == 'darwin'):
             search_path.append(os.path.join(sys._MEIPASS, libname))
 
+        # conda support
+        if os.environ.get('CONDA_PREFIX', False):
+            search_path.append(os.path.join(os.environ['CONDA_PREFIX'], 'lib',
+                                            libname))
+
         if '/' in path:
             search_path.extend([os.path.join(p, libname) for p in self.dyld_library_path])
             search_path.append(path)

--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -224,8 +224,7 @@ class MachOLibraryLoader(LibraryLoader):
 
         # conda support
         if os.environ.get('CONDA_PREFIX', False):
-            search_path.append(os.path.join(os.environ['CONDA_PREFIX'], 'lib',
-                                            libname))
+            search_path.append(os.path.join(os.environ['CONDA_PREFIX'], 'lib', libname))
 
         if '/' in path:
             search_path.extend([os.path.join(p, libname) for p in self.dyld_library_path])


### PR DESCRIPTION
On macOS, pyglet wasn't able to detect the FFmpeg libraries installed into a `conda` environment, as `conda` doesn't add them to `LD_LIBRARY_PATH`. Instead, one has to consider the `CONDA_PREFIX` environment variable, which points to the currectly active `conda` environment.