### PR TITLE
if setting vsync fails, make it non-fatal

### DIFF
--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -256,7 +256,10 @@ class XlibWindow(BaseWindow):
             self.canvas = XlibCanvas(self.display, self._view)
 
             self.context.attach(self.canvas)
-            self.context.set_vsync(self._vsync) # XXX ?
+            try:
+                self.context.set_vsync(self._vsync) # XXX ?
+            except Exception as e:
+                print('Failed to set vsync:  request:', e)
 
             # Setting null background pixmap disables drawing the background,
             # preventing flicker while resizing (in theory).


### PR DESCRIPTION
This allow applications to work even when glinfo reports swapinterval but the function is missing from the library