### PR TITLE
Reduce verbosity of FFMPEG logging

### DIFF
--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -1024,6 +1024,7 @@ if pyglet.options['debug_media']:
     _debug = True
 else:
     _debug = False
+    avutil.av_log_set_level(8)
 
 
 #########################################

--- a/pyglet/media/codecs/ffmpeg_lib/libavutil.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavutil.py
@@ -200,7 +200,8 @@ avutil.av_dict_set.restype = c_int
 avutil.av_dict_set.argtypes = [POINTER(POINTER(AVDictionary)),
                                c_char_p, c_char_p, c_int]
 avutil.av_dict_free.argtypes = [POINTER(POINTER(AVDictionary))]
-
+avutil.av_log_set_level.restype = c_int
+avutil.av_log_set_level.argtypes = [c_uint]
 
 __all__ = [
 'avutil',


### PR DESCRIPTION
By default FFMPEG uses AV_LOG_INFO for verbose logging. Typically not needed unless you are debugging, so we set it to a quieter log level if you have debug_media disabled.