### PR TITLE
ENH: Support Python 3.8 on Windows

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,7 +4,7 @@ Minor bugfix release.
 
 Bugfixes
 --------
-= #xxx Python 3.8 support on Windows.
+= #101 Python 3.8 support on Windows.
 
 Pyglet 1.3.2
 ============

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,11 @@
+Pyglet 1.3.3
+============
+Minor bugfix release.
+
+Bugfixes
+--------
+= #xxx Python 3.8 support on Windows.
+
 Pyglet 1.3.2
 ============
 Bugfix release.

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,7 +4,7 @@ Minor bugfix release.
 
 Bugfixes
 --------
-= #101 Python 3.8 support on Windows.
+- #101 Python 3.8 support on Windows.
 
 Pyglet 1.3.2
 ============

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -143,6 +143,7 @@ from __future__ import division
 from builtins import range
 from builtins import object
 
+import sys
 import time
 import ctypes
 from operator import attrgetter
@@ -163,7 +164,10 @@ if compat_platform in ('win32', 'cygwin'):
         def sleep(self, microseconds):
             time.sleep(microseconds * 1e-6)
 
-    _default_time_function = time.clock
+    if sys.version_info >= (3, 8):
+        _default_time_function = time.perf_counter
+    else:
+        _default_time_function = time.clock
 
 else:
     _c = pyglet.lib.load_library('c')


### PR DESCRIPTION
`time.clock()` was removed in Python 3.8, however it was still used on the Windows platform. This commit changes the default time function to `time.perf_counter()` on Windows for Python 3.8+.

(We _could_ make that change for Python 3.3+, however I'd rather leave things unchanged for those previous versions!)