### PR TITLE
darwin: Make context creation more flexible

### DIFF
--- a/pyglet/gl/cocoa.py
+++ b/pyglet/gl/cocoa.py
@@ -198,9 +198,9 @@ class CocoaConfig(Config):
             # check if we're wanting core or legacy
             # Mavericks (Darwin 13) and up are capable of the Core 4.1 profile,
             # while Lion and up are only capable of Core 3.2
-            if version[0] == 4 and version[1] >= 1 and _os_x_version >= os_x_release['mavericks']:
+            if version[0] >= 4 and _os_x_version >= os_x_release['mavericks']:
                 attrs.append(int(cocoapy.NSOpenGLProfileVersion4_1Core))
-            elif version[0] == 3 and version[1] >= 2:
+            elif version[0] >= 3:
                 attrs.append(int(cocoapy.NSOpenGLProfileVersion3_2Core))
             else:
                 attrs.append(int(cocoapy.NSOpenGLProfileVersionLegacy))


### PR DESCRIPTION
On OS X the opengl major/minor version is really only a lose suggestion because you'll always get the highest core context available no matter what gl version you request. This is in line with how most (if not all) window libraries are handling it.

https://github.com/glfw/glfw/blob/fa602692455d87e11c9ff5a5fb0681ca6403772a/src/nsgl_context.m#L234-L246