### PR TITLE
Force Window Size

### DIFF
--- a/doc/programming_guide/examplegame.rst
+++ b/doc/programming_guide/examplegame.rst
@@ -46,7 +46,7 @@ To set up a window, simply `import pyglet`, create a new instance of
 :class:`pyglet.window.Window`, and call `pyglet.app.run()`::
 
     import pyglet
-    game_window = pyglet.window.Window()
+    game_window = pyglet.window.Window(800, 600)
 
     if __name__ == '__main__':
         pyglet.app.run()


### PR DESCRIPTION
This change forces the window size to be `(800, 600)` which is what this tutorial expects. Without this code, it's possible for a different window size to be used.  In my case, Pyglet was creating a window of (640, 480).