### PR TITLE
Updated data item parameters to current names.

### DIFF
--- a/examples/text_input.py
+++ b/examples/text_input.py
@@ -17,8 +17,8 @@ class Rectangle(object):
     def __init__(self, x1, y1, x2, y2, batch):
         self.vertex_list = batch.add_indexed(4, pyglet.gl.GL_TRIANGLES, None,
                                              [0, 1, 2, 0, 2, 3],
-                                             ('vertices2i', [x1, y1, x2, y1, x2, y2, x1, y2]),
-                                             ('colors4Bn', [200, 200, 220, 255] * 4))
+                                             ('v2i', [x1, y1, x2, y1, x2, y2, x1, y2]),
+                                             ('c4B', [200, 200, 220, 255] * 4))
 
 
 class TextWidget(object):


### PR DESCRIPTION
I was trying out this example and had to change the data item parameters from vertices2i and colors4Bn to v2i and c4B for the example to run. I'm assuming vertices2i and colors4Bn are old data item parameter names.