### PR TITLE
Checking for NULL pointer as a workaround for #95

### DIFF
--- a/pyglet/input/darwin_hid.py
+++ b/pyglet/input/darwin_hid.py
@@ -345,12 +345,12 @@ class HIDDevice(object):
             kCFRunLoopDefaultMode)
 
     def _get_elements(self):
-        try:
-            cfarray = c_void_p(iokit.IOHIDDeviceCopyMatchingElements(self.deviceRef, None, 0))
-            elements = cfarray_to_list(cfarray)
-            cf.CFRelease(cfarray)
-        except:
+        cfarray = c_void_p(iokit.IOHIDDeviceCopyMatchingElements(self.deviceRef, None, 0))
+        if not cfarray:
+            # requires "Security & Privacy / Input Monitoring", see #95
             return []
+        elements = cfarray_to_list(cfarray)
+        cf.CFRelease(cfarray)
         return elements
 
     # Page and usage IDs are from the HID usage tables located at


### PR DESCRIPTION
This is an alternative workaround with macOS Catalina (and beyond), which requires an explicit "Security & Privacy" /  "Input Monitoring" setting for "pyglet.input".

Tested on a freshly installed macOS 10.15.2, both with (built-in) python 2 & 3.