### PR TITLE
Create readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: doc/requirements.txt


### PR DESCRIPTION
This will stabelize builds in general instead of always falling back to rtd's default config that is constantly changing.

Most of my projects not having this config file broke yesterday. 