### PR TITLE
Fix for issue #105, re-raise error in event loop 

### DIFF
--- a/pyglet/event.py
+++ b/pyglet/event.py
@@ -421,8 +421,10 @@ class EventDispatcher:
         try:
             if getattr(self, event_type)(*args):
                 return EVENT_HANDLED
-        except AttributeError:
-            pass
+        except AttributeError as e:
+            event_op = getattr(self, event_type, None)
+            if callable(event_op):
+                raise e
         except TypeError as exception:
             self._raise_dispatch_exception(event_type, args, getattr(self, event_type), exception)
         else:


### PR DESCRIPTION
If there's an AttributeError in a function like `on_draw` Pyglet will ignore it, which makes debugging really hard. This should check the error returned and see if it needs to be re-raised.