### PR TITLE
fixes issue #105 by removing try: except completely

### DIFF
--- a/pyglet/event.py
+++ b/pyglet/event.py
@@ -417,23 +417,19 @@ class EventDispatcher:
             except TypeError as exception:
                 self._raise_dispatch_exception(event_type, args, handler, exception)
 
-        # Check instance for an event handler
+        not_called = () # arbitrary unique, falsy value
         try:
-            if getattr(self, event_type)(*args):
-                return EVENT_HANDLED
-        except AttributeError as e:
-            event_op = getattr(self, event_type, None)
-            if callable(event_op):
-                raise e
+            # Check instance for an event handler
+            retval = getattr(self, event_type, lambda *args: not_called)(*args)
         except TypeError as exception:
             self._raise_dispatch_exception(event_type, args, getattr(self, event_type), exception)
+
+        if retval:
+            return EVENT_HANDLED
+        elif retval is not_called:
+            return False
         else:
-            invoked = True
-
-        if invoked:
             return EVENT_UNHANDLED
-
-        return False
 
     def _raise_dispatch_exception(self, event_type, args, handler, exception):
         # A common problem in applications is having the wrong number of


### PR DESCRIPTION
This solution fixes incorrect `AttributeError` catches by removing the corresponding `try: except` block completely. 

I assume the reason this block was added in the first place was to distinguish between a method not existing and a method returning a falsy value without invoking `hasattr`, for performance reasons.

My solution verifies if the method was invoked by first creating a unique object (`tuple`) that is then returned as a default argument from `getattr`. To check if a method was invoked, that object is then compared to the return value by using the `is` comparator.

