### PR TITLE
Improve performance by removing unnecessary context switching with single window

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -629,6 +629,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
 
         from pyglet import app
         app.windows.add(self)
+        app.event_loop.update_window_count()
         self._create()
 
         self.switch_to()
@@ -821,6 +822,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         if not self._context:
             return
         app.windows.remove(self)
+        app.event_loop.update_window_count()
         self._context.destroy()
         self._config = None
         self._context = None


### PR DESCRIPTION
Windows has performance overhead when the loop constantly calls `switch_to()`. This change will make it so only multiple windows will need to call `switch_to` to change between contexts, while a single window only needs to call it once.

Was about a 20-30% increase of FPS when doing this for me, but mileage may vary. Either way it's free performance increase.

If anyone has a better way of doing it at some point, we can revisit. 