### PR TITLE
Add missing XListDeviceProperties and XGetDeviceProperty calls

### DIFF
--- a/pyglet/libs/x11/xinput.py
+++ b/pyglet/libs/x11/xinput.py
@@ -70,6 +70,10 @@ sz_xGetExtensionVersionReq = 8 	# /usr/include/X11/extensions/XI.h:56
 sz_xGetExtensionVersionReply = 32 	# /usr/include/X11/extensions/XI.h:57
 sz_xListInputDevicesReq = 4 	# /usr/include/X11/extensions/XI.h:58
 sz_xListInputDevicesReply = 32 	# /usr/include/X11/extensions/XI.h:59
+sz_xListDevicePropertiesReq = 8     # /usr/include/X11/extensions/XI.h
+sz_xListDevicePropertiesReply = 32  # /usr/include/X11/extensions/XI.h
+sz_xGetDevicePropertyReq = 24     # /usr/include/X11/extensions/XI.h
+sz_xGetDevicePropertyReply = 32  # /usr/include/X11/extensions/XI.h
 sz_xOpenDeviceReq = 8 	# /usr/include/X11/extensions/XI.h:60
 sz_xOpenDeviceReply = 32 	# /usr/include/X11/extensions/XI.h:61
 sz_xCloseDeviceReq = 8 	# /usr/include/X11/extensions/XI.h:62
@@ -1509,6 +1513,16 @@ XListInputDevices = _lib.XListInputDevices
 XListInputDevices.restype = POINTER(XDeviceInfo)
 XListInputDevices.argtypes = [POINTER(Display), POINTER(c_int)]
 
+# /usr/include/X11/extensions/XInput.h
+XListDeviceProperties = _lib.XListDeviceProperties
+XListDeviceProperties.restype = POINTER(Atom)
+XListDeviceProperties.argtypes = [POINTER(Display), POINTER(XDevice), POINTER(c_int)]
+
+# /usr/include/X11/extensions/XInput.h
+XGetDeviceProperty = _lib.XGetDeviceProperty
+XGetDeviceProperty.restype = c_int
+XGetDeviceProperty.argtypes = [POINTER(Display), POINTER(XDevice), Atom, c_long, c_long, c_bool, Atom, POINTER(Atom), POINTER(c_int), POINTER(c_ulong), POINTER(c_ulong), POINTER(c_char_p)]
+
 # /usr/include/X11/extensions/XInput.h:5943
 XFreeDeviceList = _lib.XFreeDeviceList
 XFreeDeviceList.restype = None
@@ -1672,8 +1686,9 @@ __all__ = ['sz_xGetExtensionVersionReq', 'sz_xGetExtensionVersionReply',
 'XGetDeviceKeyMapping', 'XChangeDeviceKeyMapping',
 'XGetDeviceModifierMapping', 'XSetDeviceModifierMapping',
 'XSetDeviceButtonMapping', 'XGetDeviceButtonMapping', 'XQueryDeviceState',
-'XFreeDeviceState', 'XGetExtensionVersion', 'XListInputDevices',
-'XFreeDeviceList', 'XOpenDevice', 'XCloseDevice', 'XSetDeviceMode',
+'XFreeDeviceState', 'XGetExtensionVersion', 'XListInputDevices', 
+'XListDeviceProperties', 'XGetDeviceProperty', 'XFreeDeviceList', 
+'XOpenDevice', 'XCloseDevice', 'XSetDeviceMode',
 'XSetDeviceValuators', 'XGetDeviceControl', 'XChangeDeviceControl',
 'XSelectExtensionEvent', 'XGetSelectedExtensionEvents',
 'XChangeDeviceDontPropagateList', 'XGetDeviceDontPropagateList',


### PR DESCRIPTION
Usage sample:
```
import ctypes
from ctypes import *
import pyglet.canvas
from pyglet.libs.x11 import xinput as xi
from pyglet.libs.x11 import xlib

def _ptr_add_offset(ptr, offset):
   address = ctypes.addressof(ptr.contents) + offset
   return ctypes.pointer(type(ptr.contents).from_address(address))


display = pyglet.canvas.get_display()
count = ctypes.c_int(0)
device_list = xi.XListInputDevices(display._display, count)
for i in range(count.value):
    device_info = device_list[i]
    ptr = device_info.inputclassinfo
    print("\nID: {}".format(device_info.id))
    print("Name: {}".format(device_info.name))
    xdev = xi.XOpenDevice(display._display, device_info.id)
    if xdev:
        props = xi.XListDeviceProperties(display._display, xdev, ctypes.c_int(4))
        
        for n in range(4):
            name = xlib.XGetAtomName(display._display, props.contents)
            if name:
                s_name = str(name, 'utf-8') 
            if s_name == "Device Node":
                print("Device Node Found!")
                print("Property: " + s_name)
                 
                act_type = ctypes.c_ulong(0)
                act_format = ctypes.c_int(0)
                nitems = ctypes.c_ulong(0)
                bytes_after = ctypes.c_ulong(0)
                prop = ctypes.c_char_p()

                xi.XGetDeviceProperty(display._display, xdev, props.contents, 0, 1000, False, xlib.AnyPropertyType, act_type, act_format, nitems, bytes_after, prop)
            
                print("Value:" + str(prop.value, 'utf-8'))
                
            props = _ptr_add_offset(props, sizeof(props.contents))           

        xi.XCloseDevice(display._display, xdev)
```