### PR TITLE
Xlib, check if drag'n drop is enabled

### DIFF
--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -313,6 +313,9 @@ class XlibWindow(BaseWindow):
                                      xlib.PropModeReplace,
                                      cast(ptr, POINTER(c_ubyte)), 1)
 
+            # Atoms required for Xdnd
+            self._create_xdnd_atoms(self._x_display)
+
             # Support for drag and dropping files needs to be enabled.
             if self._file_drops:
                 # Some variables set because there are 4 different drop events that need shared data.
@@ -320,9 +323,6 @@ class XlibWindow(BaseWindow):
                 self._xdnd_version = None
                 self._xdnd_format = None
                 self._xdnd_position = (0, 0)  # For position callback.
-
-                # Atoms required for Xdnd
-                self._create_xdnd_atoms(self._x_display)
 
                 VERSION = c_ulong(int(XDND_VERSION))
                 ptr = pointer(VERSION)


### PR DESCRIPTION
When running the astraea example in ran into this traceback:
```
Traceback (most recent call last):
  File "astraea.py", line 943, in <module>
    pyglet.app.run()
  File "/lapinot/.venv/lib/python3.8/site-packages/pyglet/app/__init__.py", line 107, in run
    event_loop.run()
  File "/lapinot/.venv/lib/python3.8/site-packages/pyglet/app/base.py", line 168, in run
    platform_event_loop.step(timeout)
  File "/lapinot/.venv/lib/python3.8/site-packages/pyglet/app/xlib.py", line 121, in step
    device.select()
  File "/lapinot/.venv/lib/python3.8/site-packages/pyglet/canvas/xlib.py", line 205, in select
    dispatch(e)
  File "/lapinot/.venv/lib/python3.8/site-packages/pyglet/window/xlib/__init__.py", line 929, in dispatch_platform_event
    event_handler(e)
  File "/lapinot/.venv/lib/python3.8/site-packages/pyglet/window/xlib/__init__.py", line 1208, in _event_clientmessage
    elif ev.xclient.message_type == self._xdnd_atoms['XdndPosition']:
AttributeError: 'XlibWindow' object has no attribute '_xdnd_atoms'

```
Apparently this is because for some reason, my `XlibWindow` has `self._file_drops == False`, which in turns inhibits the initialization of `self._xdnd_atoms` ([here](https://github.com/pyglet/pyglet/blob/e323fc9fba888ce0222e39ea8f062923c7e73577/pyglet/window/xlib/__init__.py#L317)). My fix is to first check `self._file_drops` before looking at any `self._xdnd_*`.

Note that a reason I triggered this code path is because I am running a wayland window manager (sway 1.4) and an xwayland server, which probably doesn't support everything the usual xorg server does.