### PR TITLE
Adds support for ImageMouseCursor to use hardware acceleration

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -172,6 +172,7 @@ class MouseCursor:
     #: Indicates if the cursor is drawn using OpenGL.  This is True
     #: for all mouse cursors except system cursors.
     drawable = True
+    acceleration = False
 
     def draw(self, x, y):
         """Abstract render method.
@@ -194,6 +195,7 @@ class MouseCursor:
 class DefaultMouseCursor(MouseCursor):
     """The default mouse cursor #sed by the operating system."""
     drawable = False
+    acceleration = True
 
 
 class ImageMouseCursor(MouseCursor):
@@ -204,7 +206,7 @@ class ImageMouseCursor(MouseCursor):
     """
     drawable = True
 
-    def __init__(self, image, hot_x=0, hot_y=0):
+    def __init__(self, image, hot_x=0, hot_y=0, acceleration=True):
         """Create a mouse cursor from an image.
 
         :Parameters:
@@ -217,10 +219,19 @@ class ImageMouseCursor(MouseCursor):
             `hot_y` : int
                 Y coordinate of the "hot" spot in the image, relative to the
                 image's anchor.
+            `acceleration` : int
+                Uses hardware acceleration for the cursor so it does not rely
+                on software rendering.
         """
+        self.cursor = None
+        self.image = image
         self.texture = image.get_texture()
         self.hot_x = hot_x
         self.hot_y = hot_y
+
+        if acceleration:
+            self.drawable = False
+        self.acceleration = acceleration
 
     def draw(self, x, y):
         gl.glPushAttrib(gl.GL_ENABLE_BIT | gl.GL_CURRENT_BIT)


### PR DESCRIPTION
Current implementation relies on blitting an image to the screen to display an image cursor. Since you're at the mercy of the rendering pipeline, if it's slowed, or interrupted in anyway, your cursor will stop moving or move slowly. Also depending on how high end your mouse is, the movement can appear to be sluggish since it's possible it's polling faster than 60 FPS in the OS. 

This is changed by adding an acceleration keyword to the ImageMouseCursor. Usage is the same:
```
image = pyglet.image.load("cursor.png")
cursor = pyglet.window.ImageMouseCursor(image, 12, 12)
```
Enabled by default but can be disabled by: `cursor = pyglet.window.ImageMouseCursor(image, 12, 12, acceleration=False)` Debatable on whether it should be default or not.

One possible issue is that, once the icon is created, it would need to be re-created if you change x/y hotspots, or even the image of the cursor. However, I am not sure if the intention was to be able to change everything after cursor creation or to have separate cursor instances for differences. I can make these changes but not sure which ways are intended usage.

By default it turns the drawing attribute off so you do not get two cursors. However, this implementation also allows you to use drawable and acceleration together if you subclass and overwrite the draw function (if you choose).
For instance you may want something drawing with the accelerated cursor, in my usage, I have a label drawing and following the cursor to display information. The label only draws depending on which cursor I am using.

Currently Windows only but thought I'd open this for discussion atleast and get the implementation going since I've been sitting on it for a while.