### PR TITLE
Fix seeking crash on 32bit WMF

### DIFF
--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -337,7 +337,7 @@ class IMFSourceReader(com.IUnknown):
         ('SetCurrentMediaType',
          com.STDMETHOD(DWORD, POINTER(DWORD), IMFMediaType)),
         ('SetCurrentPosition',
-         com.STDMETHOD(com.REFIID, PROPVARIANT)),
+         com.STDMETHOD(com.REFIID, POINTER(PROPVARIANT))),
         ('ReadSample',
          com.STDMETHOD(DWORD, DWORD, POINTER(DWORD), POINTER(DWORD), POINTER(c_longlong), POINTER(IMFSample))),
         ('Flush',


### PR DESCRIPTION
`PROPVARIANT` should be a `POINTER(PROPVARIANT)`.

This fixes the exception that occurs in 32 bit.