### PR TITLE
Atlas border fix and enhancement

### DIFF
--- a/pyglet/image/atlas.py
+++ b/pyglet/image/atlas.py
@@ -178,7 +178,7 @@ class Allocator:
 class TextureAtlas:
     """Collection of images within a texture."""
 
-    def __init__(self, width=2048, height=2048, border=False):
+    def __init__(self, width=2048, height=2048, border=0):
         """Create a texture atlas of the given size.
 
         :Parameters:
@@ -186,9 +186,9 @@ class TextureAtlas:
                 Width of the underlying texture.
             `height` : int
                 Height of the underlying texture.
-            `border` : bool
-                If True, one pixel of blank space is left
-                around each image added to the Atlas.
+            `border` : int
+                Leaves specified pixels of blank space around
+                each image added to the Atlas.
 
         """
         max_texture_size = pyglet.image.get_max_texture_size()
@@ -197,7 +197,7 @@ class TextureAtlas:
 
         self.texture = pyglet.image.Texture.create(width, height, GL_RGBA, rectangle=True)
         self.allocator = Allocator(width, height)
-        self._border = 1 if border else 0
+        self._border = border
 
     def add(self, img):
         """Add an image to the atlas.
@@ -229,7 +229,7 @@ class TextureBin:
     ones as necessary to accommodate images added to the bin.
     """
 
-    def __init__(self, texture_width=2048, texture_height=2048, border=False):
+    def __init__(self, texture_width=2048, texture_height=2048, border=0):
         """Create a texture bin for holding atlases of the given size.
 
         :Parameters:
@@ -237,9 +237,9 @@ class TextureBin:
                 Width of texture atlases to create.
             `texture_height` : int
                 Height of texture atlases to create.
-            `border` : bool
-                If True, one pixel of blank space is left
-                around each image added to the Atlases.
+            `border` : int
+                Leaves specified pixels of blank space around
+                each image added to the Atlases.
 
         """
         max_texture_size = pyglet.image.get_max_texture_size()
@@ -274,6 +274,6 @@ class TextureBin:
                 if img.width < 64 and img.height < 64:
                     self.atlases.remove(atlas)
 
-        atlas = TextureAtlas(self.texture_width, self.texture_height)
+        atlas = TextureAtlas(self.texture_width, self.texture_height, self._border)
         self.atlases.append(atlas)
         return atlas.add(img)

--- a/pyglet/resource.py
+++ b/pyglet/resource.py
@@ -496,7 +496,7 @@ class Loader:
         file = self.file(name)
         font.add_file(file)
 
-    def _alloc_image(self, name, atlas=True):
+    def _alloc_image(self, name, atlas=True, atlas_border=1):
         file = self.file(name)
         try:
             img = pyglet.image.load(name, file=file)
@@ -507,13 +507,13 @@ class Loader:
             return img.get_texture(True)
 
         # find an atlas suitable for the image
-        bin = self._get_texture_atlas_bin(img.width, img.height)
+        bin = self._get_texture_atlas_bin(img.width, img.height, atlas_border)
         if bin is None:
             return img.get_texture(True)
 
         return bin.add(img)
 
-    def _get_texture_atlas_bin(self, width, height):
+    def _get_texture_atlas_bin(self, width, height, border):
         """A heuristic for determining the atlas bin to use for a given image
         size.  Returns None if the image should not be placed in an atlas (too
         big), otherwise the bin (a list of TextureAtlas).
@@ -533,12 +533,12 @@ class Loader:
         try:
             texture_bin = self._texture_atlas_bins[bin_size]
         except KeyError:
-            texture_bin = pyglet.image.atlas.TextureBin(border=True)
+            texture_bin = pyglet.image.atlas.TextureBin(border=border)
             self._texture_atlas_bins[bin_size] = texture_bin
 
         return texture_bin
 
-    def image(self, name, flip_x=False, flip_y=False, rotate=0, atlas=True):
+    def image(self, name, flip_x=False, flip_y=False, rotate=0, atlas=True, atlas_border=1):
         """Load an image with optional transformation.
 
         This is similar to `texture`, except the resulting image will be
@@ -560,6 +560,9 @@ class Loader:
                 pyglet. If atlas loading is not appropriate for specific
                 texturing reasons (e.g. border control is required) then set
                 this argument to False.
+            `atlas_border` : int
+                Leaves specified pixels of blank space around each image in
+                an atlas, which may help reduce texture bleeding.
 
         :rtype: `Texture`
         :return: A complete texture if the image is large or not in an atlas,
@@ -569,7 +572,7 @@ class Loader:
         if name in self._cached_images:
             identity = self._cached_images[name]
         else:
-            identity = self._cached_images[name] = self._alloc_image(name, atlas=atlas)
+            identity = self._cached_images[name] = self._alloc_image(name, atlas=atlas, atlas_border=atlas_border)
 
         if not rotate and not flip_x and not flip_y:
             return identity

--- a/pyglet/resource.py
+++ b/pyglet/resource.py
@@ -579,7 +579,7 @@ class Loader:
 
         return identity.get_transform(flip_x, flip_y, rotate)
 
-    def animation(self, name, flip_x=False, flip_y=False, rotate=0):
+    def animation(self, name, flip_x=False, flip_y=False, rotate=0, atlas_border=1):
         """Load an animation with optional transformation.
 
         Animations loaded from the same source but with different
@@ -595,7 +595,10 @@ class Loader:
             `rotate` : int
                 The returned image will be rotated clockwise by the given
                 number of degrees (a multiple of 90).
-
+            `atlas_border` : int
+                Leaves specified pixels of blank space around each image in
+                an atlas, which may help reduce texture bleeding.
+                
         :rtype: :py:class:`~pyglet.image.Animation`
         """
         self._require_index()
@@ -604,7 +607,8 @@ class Loader:
         except KeyError:
             animation = pyglet.image.load_animation(name, self.file(name))
             bin = self._get_texture_atlas_bin(animation.get_max_width(),
-                                              animation.get_max_height())
+                                              animation.get_max_height(),
+                                              atlas_border)
             if bin:
                 animation.add_to_texture_bin(bin)
 


### PR DESCRIPTION
Fix issue where `TextureBin` was not passing border attribute to `TextureAtlas`. Resource module not actually utilizing borders because of that, as `border` is false by default.

Added `atlas_border` attribute to the `resource.image` function if you wish to specify if it adds pixel borders.

Made change where border attribute is the amount of pixels to separate, rather than enabled as true or false. This allows more pixels to be padded in rarer cases where 1 pixel is not enough of a border. 0 can still be set for no border if you wish to save texture memory and don't have any bleeding/filtering.

