### PR TITLE
Image format incorrect for WMF playback.

### DIFF
--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -752,7 +752,7 @@ class WMFSource(Source):
 
             # This is made with the assumption that the video frame will be blitted into the player texture immediately
             # after, and then cleared next frame attempt.
-            return image.ImageData(width, height, 'RGBA', video_data, self._stride)
+            return image.ImageData(width, height, 'BGRA', video_data, self._stride)
 
         return None
 


### PR DESCRIPTION
Despite format saying RGB, Windows is almost always BGRA . This fixes the color issues where blue's and reds are incorrect.

#186 