### PR TITLE
Fix for issue regarding numba.

### DIFF
--- a/pyglet/image/codecs/wic.py
+++ b/pyglet/image/codecs/wic.py
@@ -289,7 +289,7 @@ class WICDecoder(ImageDecoder):
         try:
             ole32.CoInitializeEx(None, COINIT_MULTITHREADED)
         except OSError as err:
-            warnings.warn(err)
+            warnings.warn(str(err))
 
         ole32.CoCreateInstance(CLSID_WICImagingFactory,
                                None,

--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -770,7 +770,7 @@ class WMFSource(Source):
         try:
             self._source_reader.SetCurrentPosition(pos_com, prop)
         except OSError as err:
-            warnings.warn(err)
+            warnings.warn(str(err))
 
         ole32.PropVariantClear(ctypes.byref(prop))
 
@@ -835,7 +835,7 @@ class WMFDecoder(MediaDecoder):
             # Coinitialize supposed to be called for COMs?
             ole32.CoInitializeEx(None, COINIT_MULTITHREADED)
         except OSError as err:
-            warnings.warn(err)
+            warnings.warn(str(err))
 
         try:
             MFStartup(MF_VERSION, 0)


### PR DESCRIPTION
Converts `<class 'OSError'>` into `str(err)` when calling `warnings.warn(err)`.

Relevant gist: https://gist.github.com/Torxed/10f3bd35ddbd8ceabda8f7a002fdff6c

Code to reproduce:
```py
import pyglet
import numba

game_window = pyglet.window.Window(600, 400)
icon = pyglet.image.load("test.png")
game_window.set_icon(icon)
pyglet.app.run()
```

Original report: https://stackoverflow.com/questions/62383035/error-while-import-numba-module-in-pyglet-projects