### PR TITLE
GUI Tweaks

### DIFF
--- a/pyglet/gui/__init__.py
+++ b/pyglet/gui/__init__.py
@@ -33,5 +33,5 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 
-from .widgets import *
-from .frame import *
+from .widgets import WidgetBase, PushButton, ToggleButton, Slider
+from .frame import Frame


### PR DESCRIPTION
# Added
- Adjusted imports for `pyglet.gui.__init__.py` to be more explicit, and allowing linters and doc preview tools.
- Added `position` and `real_position` (see below) properties.
- I have also added a "parent" feature that allows users to set widgets to have positions relative to other widgets.
  - New properties `real_x`, `real_y` and `real_position`.
  - NOTE: The slider is untested with the new parent options.

# Things that need to be added/improved:
- Automatically updating sprites when widgets are moved.
- Automatically updating child widgets when a parent widget is moved.
- Ability to choose an anchor point on the parent widget:
  - The user could choose "top" and "left", and `0, 0` for the child widget would be at the top-left of the parent widget.
  - Maybe have two kwargs `anchor_y` and `anchor_x`.
    - `anchor_x` choice between `left`, `centre` and `right`. (Default to `left`?)
    - `anchor_y` choice between `top`, `centre` and `bottom`. (Default to `bottom`?)