### PR TITLE
Add `transparent_background` option and implement it on xlib

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -394,6 +394,9 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
     #: A window style without any decoration.
     WINDOW_STYLE_BORDERLESS = 'borderless'
 
+    #: The default background opacity.
+    TRANSPARENT_BACKGROUND_DEFAULT = False
+
     #: The default mouse cursor.
     CURSOR_DEFAULT = None
     #: A crosshair mouse cursor.
@@ -468,6 +471,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
     _caption = None
     _resizable = False
     _style = WINDOW_STYLE_DEFAULT
+    _transparent_background = TRANSPARENT_BACKGROUND_DEFAULT
     _fullscreen = False
     _visible = False
     _vsync = False
@@ -503,6 +507,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
                  caption=None,
                  resizable=False,
                  style=WINDOW_STYLE_DEFAULT,
+                 transparent_background=TRANSPARENT_BACKGROUND_DEFAULT,
                  fullscreen=False,
                  visible=True,
                  vsync=True,
@@ -545,6 +550,9 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
             `style` : int
                 One of the ``WINDOW_STYLE_*`` constants specifying the
                 border style of the window.
+            `transparent_background` : bool
+                If True, the window background will be transparent, if False,
+                the window background will be opaque.
             `fullscreen` : bool
                 If True, the window will cover the entire screen rather
                 than floating.  Defaults to False.
@@ -621,6 +629,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
             if height is None:
                 height = self._default_height
 
+        self._transparent_background = transparent_background
         self._width = width
         self._height = height
         self._resizable = resizable

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -229,6 +229,8 @@ class XlibWindow(BaseWindow):
             root = xlib.XRootWindow(self._x_display, self._x_screen_id)
 
             visual_info = self.config.get_visual_info()
+            depth = 32 if self._transparent_background else 24
+            xlib.XMatchVisualInfo(self._x_display, self._x_screen_id, depth, xlib.TrueColor, visual_info)
 
             visual = visual_info.visual
             visual_id = xlib.XVisualIDFromVisual(visual)
@@ -242,12 +244,13 @@ class XlibWindow(BaseWindow):
                 window_attributes.colormap = xlib.XDefaultColormap(self._x_display,
                                                                    self._x_screen_id)
             window_attributes.bit_gravity = xlib.StaticGravity
-
+            window_attributes.border_pixel = 0
+            window_attributes.background_pixel = 0
             # Issue 287: Compiz on Intel/Mesa doesn't draw window decoration
             #            unless CWBackPixel is given in mask.  Should have
             #            no effect on other systems, so it's set
             #            unconditionally.
-            mask = xlib.CWColormap | xlib.CWBitGravity | xlib.CWBackPixel
+            mask = xlib.CWColormap | xlib.CWBitGravity | xlib.CWBackPixel | xlib.CWBorderPixel
 
             if self._fullscreen:
                 width, height = self.screen.width, self.screen.height


### PR DESCRIPTION
This PR adds the `transparent_background` option to the window and is a first try of implementing it on xlib.

Related issue: #246

I don't have any computer running on Microsoft Windows or MacOS, so I can't work on adding support for these systems, but I will be very happy to see contributions for this.

Code sample:

```py
from pyglet import app, window, shapes

win = window.Window(width=400, height=400,
                    style=window.Window.WINDOW_STYLE_BORDERLESS, transparent_background=True)

@win.event
def on_draw():
    win.clear()

    circle = shapes.Circle(x=200, y=200, radius=200, color=(255, 255, 255))
    circle.draw()

if __name__ == '__main__':
    app.run()
```

![2020-07-16_21-07-1594926233](https://user-images.githubusercontent.com/1665542/87712966-c06d2400-c7a9-11ea-9f4e-bdcb3abafcc0.jpg)

Reviews welcome!

Thanks to @Goutte for the pair-programming session on this.

**TODO**
- [ ] when setting the disc color to `(128, 128, 128)`, the disc appears half-transparent instead of opaque grey;
- [ ] ability to define the color alpha channel with `color(r, g, b, a)`.