### PR TITLE
Added CenteredCamera class.

### DIFF
--- a/examples/camera.py
+++ b/examples/camera.py
@@ -128,3 +128,39 @@ class Camera:
 
     def __exit__(self, exception_type, exception_value, traceback):
         self.end()
+
+
+class CentredCamera(Camera):
+    """A simple 2D camera class. 0, 0 will be the centre of the screen, as opposed to the bottom left."""
+
+    def __init__(self, window: pyglet.window.Window, *args, **kwargs):
+        self.window = window
+        super().__init__(*args, **kwargs)
+
+    def begin(self):
+        x = -self.window.width//2/self._zoom + self.offset_x
+        y = -self.window.height//2/self._zoom + self.offset_y
+
+        pyglet.gl.glTranslatef(
+            -x * self._zoom,
+            -y * self._zoom, 0
+        )
+
+        pyglet.gl.glScalef(
+            self._zoom,
+            self._zoom, 1
+        )
+
+    def end(self):
+        x = -self.window.width//2/self._zoom + self.offset_x
+        y = -self.window.height//2/self._zoom + self.offset_y
+
+        pyglet.gl.glScalef(
+            1 / self._zoom,
+            1 / self._zoom, 1
+        )
+
+        pyglet.gl.glTranslatef(
+            x * self._zoom,
+            y * self._zoom, 0
+        )

--- a/examples/camera.py
+++ b/examples/camera.py
@@ -96,20 +96,32 @@ class Camera:
     def begin(self):
         # Set the current camera offset so you can draw your scene.
         # Translate using the zoom and the offset.
-        pyglet.gl.glTranslatef(-self.offset_x * self._zoom, -self.offset_y * self._zoom, 0)
+        pyglet.gl.glTranslatef(
+            -self.offset_x * self._zoom,
+            -self.offset_y * self._zoom, 0
+        )
 
         # Scale by zoom level.
-        pyglet.gl.glScalef(self._zoom, self._zoom, 1)
+        pyglet.gl.glScalef(
+            self._zoom,
+            self._zoom, 1
+        )
 
     def end(self):
         # Since this is a matrix, you will need to reverse the translate after rendering otherwise
         # it will multiply the current offset every draw update pushing it further and further away.
 
         # Reverse scale, since that was the last transform.
-        pyglet.gl.glScalef(1 / self._zoom, 1 / self._zoom, 1)
+        pyglet.gl.glScalef(
+            1 / self._zoom,
+            1 / self._zoom, 1
+        )
 
         # Reverse translate.
-        pyglet.gl.glTranslatef(self.offset_x * self._zoom, self.offset_y * self._zoom, 0)
+        pyglet.gl.glTranslatef(
+            self.offset_x * self._zoom,
+            self.offset_y * self._zoom, 0
+        )
 
     def __enter__(self):
         self.begin()

--- a/examples/camera.py
+++ b/examples/camera.py
@@ -130,7 +130,7 @@ class Camera:
         self.end()
 
 
-class CentredCamera(Camera):
+class CenteredCamera(Camera):
     """A simple 2D camera class. 0, 0 will be the centre of the screen, as opposed to the bottom left."""
 
     def __init__(self, window: pyglet.window.Window, *args, **kwargs):

--- a/examples/camera.py
+++ b/examples/camera.py
@@ -96,32 +96,20 @@ class Camera:
     def begin(self):
         # Set the current camera offset so you can draw your scene.
         # Translate using the zoom and the offset.
-        pyglet.gl.glTranslatef(
-            -self.offset_x * self._zoom,
-            -self.offset_y * self._zoom, 0
-        )
+        pyglet.gl.glTranslatef(-self.offset_x * self._zoom, -self.offset_y * self._zoom, 0)
 
         # Scale by zoom level.
-        pyglet.gl.glScalef(
-            self._zoom,
-            self._zoom, 1
-        )
+        pyglet.gl.glScalef(self._zoom, self._zoom, 1)
 
     def end(self):
         # Since this is a matrix, you will need to reverse the translate after rendering otherwise
         # it will multiply the current offset every draw update pushing it further and further away.
 
         # Reverse scale, since that was the last transform.
-        pyglet.gl.glScalef(
-            1 / self._zoom,
-            1 / self._zoom, 1
-        )
+        pyglet.gl.glScalef(1 / self._zoom, 1 / self._zoom, 1)
 
         # Reverse translate.
-        pyglet.gl.glTranslatef(
-            self.offset_x * self._zoom,
-            self.offset_y * self._zoom, 0
-        )
+        pyglet.gl.glTranslatef(self.offset_x * self._zoom, self.offset_y * self._zoom, 0)
 
     def __enter__(self):
         self.begin()
@@ -141,26 +129,14 @@ class CenteredCamera(Camera):
         x = -self.window.width//2/self._zoom + self.offset_x
         y = -self.window.height//2/self._zoom + self.offset_y
 
-        pyglet.gl.glTranslatef(
-            -x * self._zoom,
-            -y * self._zoom, 0
-        )
+        pyglet.gl.glTranslatef(-x * self._zoom, -y * self._zoom, 0)
 
-        pyglet.gl.glScalef(
-            self._zoom,
-            self._zoom, 1
-        )
+        pyglet.gl.glScalef(self._zoom, self._zoom, 1)
 
     def end(self):
         x = -self.window.width//2/self._zoom + self.offset_x
         y = -self.window.height//2/self._zoom + self.offset_y
 
-        pyglet.gl.glScalef(
-            1 / self._zoom,
-            1 / self._zoom, 1
-        )
+        pyglet.gl.glScalef(1 / self._zoom, 1 / self._zoom, 1)
 
-        pyglet.gl.glTranslatef(
-            x * self._zoom,
-            y * self._zoom, 0
-        )
+        pyglet.gl.glTranslatef(x * self._zoom, y * self._zoom, 0)


### PR DESCRIPTION
This class has `(0, 0)` located in the center of the screen, as opposed to the original class having `(0, 0)` at the bottom left.
It sub-classes the standard `Camera` class for simplicity, modifying `begin` and `end`.

Note that the new class requires access to a Window reference to function, this is so that it knows the dimensions of the viewport.