### PR TITLE
Add visible property to groups to reduce rendering calls when not in use.

### DIFF
--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -159,6 +159,7 @@ video drivers, and requires indexed vertex lists.
 """
 
 import ctypes
+import weakref
 
 import pyglet
 from pyglet.gl import *
@@ -469,6 +470,8 @@ class Batch:
             if group.parent not in self.group_children:
                 self.group_children[group.parent] = []
             self.group_children[group.parent].append(group)
+            
+        group._assigned_batches.add(self)
         self._draw_list_dirty = True
 
     def _update_draw_list(self):
@@ -494,13 +497,15 @@ class Batch:
             if children:
                 children.sort()
                 for child in list(children):
-                    draw_list.extend(visit(child))
+                    if child.visible:
+                        draw_list.extend(visit(child))
 
             if children or domain_map:
                 return [group.set_state] + draw_list + [group.unset_state]
             else:
                 # Remove unused group from batch
                 del self.group_map[group]
+                group._assigned_batches.remove(self)
                 if group.parent:
                     self.group_children[group.parent].remove(group)
                 try:
@@ -511,13 +516,15 @@ class Batch:
                     self.top_groups.remove(group)
                 except ValueError:
                     pass
+                    
                 return []
 
         self._draw_list = []
 
         self.top_groups.sort()
         for group in list(self.top_groups):
-            self._draw_list.extend(visit(group))
+            if group.visible:
+                self._draw_list.extend(visit(group))
 
         self._draw_list_dirty = False
 
@@ -588,13 +595,15 @@ class Batch:
             if children:
                 children.sort()
                 for child in children:
-                    visit(child)
+                    if child.visible:
+                        visit(child)
 
             group.unset_state()
 
         self.top_groups.sort()
         for group in self.top_groups:
-            visit(group)
+            if group.visible:
+                visit(group)
 
 
 class Group:
@@ -613,10 +622,30 @@ class Group:
             `parent` : `~pyglet.graphics.Group`
                 Group to contain this group; its state will be set before this
                 state's.
-
+            `visible` : bool
+                Determines whether this group is visible in any of the batches it is assigned to.
+            `batches` : list
+                Read Only. A list of which batches this group is a part of. 
         """
         self.parent = parent
-
+        self._visible = True
+        self._assigned_batches = weakref.WeakSet()
+    
+    @property
+    def visible(self):
+        return self._visible
+        
+    @visible.setter
+    def visible(self, value):
+        self._visible = value
+        
+        for batch in self._assigned_batches:
+            batch.invalidate()
+            
+    @property
+    def batches(self):
+        return [batch for batch in self._assigned_batches]
+    
     def __lt__(self, other):
         return hash(self) < hash(other)
 


### PR DESCRIPTION
This addition adds a weak reference in Groups to the batches they are in. This way you can remove entire groups from being rendered in cases where you need to affect thousands of objects or just hide things not in use. This will save you the performance cost of things not being seen, but still being called by the batch.  Even if you hide sprites in those groups, you still get the performance penalty since you have to iterate over the sprites to change their vertices, and even then it's still a separate draw call. This removes the Group entirely from rendering without changing any of the grouped objects.

Use cases: You may have multiple groups of Sprites or objects that are either not visible, or not in use all the time. In my example, in my GUI I have a scrollbox, which requires you to create a separate group to clip the sprites inside. However, these Scrollboxes are rarely up all the time or even at once, and was still affecting my performance.

Also added a batches read-only

 property for additional information when troubleshooting Groups.

This also works with parenting. You can either set children visible or the main parent to affect all children.

Here is what I used to test the various ways a group can be set or called. Let me know if I missed anything.
```import pyglet
import random
import time

window = pyglet.window.Window()


img = pyglet.image.load("examples/pyglet.png")

global group1
global group2
global group3
group1 = pyglet.graphics.Group()
group2 = pyglet.graphics.Group()
group3 = pyglet.graphics.Group(group1)


global batch1
global batch2
batch1 = pyglet.graphics.Batch()
batch2 = pyglet.graphics.Batch()

batches = [batch1, batch2]
groups = [group1, group2]

sprites = []
for i in range(200):
    for j in range(200):
        # Test child group
        #sprite = pyglet.sprite.Sprite(img, x=i*25, y=j*25, group=group3, batch=batch1)
        sprite = pyglet.sprite.Sprite(img, x=i*25, y=j*25, group=group1, batch=batch1)
        sprite.scale = 0.3
        sprites.append(sprite)


import sys
@window.event
def on_draw():
    window.clear()
    
    batch1.draw()
    
    batch2.draw()
    
    
@window.event
def on_key_press(symbol, modifiers):
    global group1
    global group2
    global batch1
    global batch2
    if symbol == pyglet.window.key.A:
        print(sprites[0].group._assigned_batches._pending_removals)
        print([batch for batch in sprites[0].group._assigned_batches])
    elif symbol == pyglet.window.key.X:
        sprites[0].group = group2
    elif symbol == pyglet.window.key.SPACE:
        global batch2
        sprites[0].batch = batch2
        print("SPRITE 0 TO BATCH2")
    elif symbol == pyglet.window.key.RETURN:
        global batch1
        sprites[0].batch = batch1
        print("SPRITE 0 TO BATCH1")
    elif symbol == pyglet.window.key.M:
        print("REF COUNT", sys.getrefcount(batch2))
        del batch2
    elif symbol == pyglet.window.key.N:
        sprite = sprites.pop(0)
        del sprite
    elif symbol == pyglet.window.key.RIGHT:
        t1 = time.perf_counter()
        group1.visible = False
        print("TIME TO HIDE GROUP", time.perf_counter() - t1)
    elif symbol == pyglet.window.key.LEFT:
        t1 = time.perf_counter()
        group1.visible = True
        print("TIME TO SHOW GROUP", time.perf_counter() - t1)
    elif symbol == pyglet.window.key.PERIOD:
        t1 = time.perf_counter()
        group3.visible = not group3.visible
        print("TIME TO SHOW CHILD GROUP", time.perf_counter() - t1)
    elif symbol == pyglet.window.key.UP:
        t1 = time.perf_counter()
        for sprite in sprites:
            sprite.visible = False
        print("TIME TO HIDE 10000 SPRITES", time.perf_counter() - t1)
    elif symbol == pyglet.window.key.DOWN:
        t1 = time.perf_counter()
        for sprite in sprites:
            sprite.visible = True
        print("TIME TO SHOW 10000 SPRITES", time.perf_counter() - t1)
        
    elif symbol == pyglet.window.key.L:
        print("BATCH1", len(batch1.top_groups))
        print("BATCH2", len(batch2.top_groups))
        
    elif symbol == pyglet.window.key.K:
        batch1.invalidate()
        batch2.invalidate()
    
pyglet.app.run()```
