### PR TITLE
docs: Fix simple typo, auxilliary -> auxiliary

### DIFF
--- a/doc/programming_guide/context.rst
+++ b/doc/programming_guide/context.rst
@@ -222,11 +222,11 @@ created based on the values of these properties:
         If you require an accumulation buffer, specify ``8`` for each
         of these attributes (the alpha component is optional, of course).
     ``aux_buffers``
-        Each auxilliary buffer is configured the same as the colour buffer.
-        Up to four auxilliary buffers can typically be created.  Specify ``0``
-        if you do not require any auxilliary buffers.
+        Each auxiliary buffer is configured the same as the colour buffer.
+        Up to four auxiliary buffers can typically be created.  Specify ``0``
+        if you do not require any auxiliary buffers.
 
-        Like the accumulation buffer, auxilliary buffers are used less often
+        Like the accumulation buffer, auxiliary buffers are used less often
         nowadays as more efficient techniques such as render-to-texture are
         available.  They are almost universally available on older hardware,
         though, where the newer techniques are not possible.
@@ -337,7 +337,7 @@ template as a minimum specification, but you can supply an "empty" template
 (one with no attributes set) to get a list of all configurations supported by
 the screen.
 
-In the following example, all configurations with either an auxilliary buffer
+In the following example, all configurations with either an auxiliary buffer
 or an accumulation buffer are printed::
 
     display = pyglet.canvas.get_display()

--- a/doc/programming_guide/image.rst
+++ b/doc/programming_guide/image.rst
@@ -630,7 +630,7 @@ A framebuffer consists of
   :py:class:`~pyglet.image.DepthBufferImage`
 * An optional stencil buffer, with each bit represented by
   :py:class:`~pyglet.image.BufferImageMask`
-* Any number of auxilliary buffers, also represented by
+* Any number of auxiliary buffers, also represented by
   :py:class:`~pyglet.image.ColorBufferImage`
 
 You cannot create the buffer images directly; instead you must obtain
@@ -658,9 +658,9 @@ When a depth buffer is converted to a texture, the class used will be a
 :py:class:`~pyglet.image.DepthTexture`, suitable for use with shadow map
 techniques.
 
-The auxilliary buffers and stencil bits are obtained by requesting one, which
+The auxiliary buffers and stencil bits are obtained by requesting one, which
 will then be marked as "in-use".  This permits multiple libraries and your
-application to work together without clashes in stencil bits or auxilliary
+application to work together without clashes in stencil bits or auxiliary
 buffer names.  For example, to obtain a free stencil bit::
 
     mask = buffers.get_buffer_mask()
@@ -669,11 +669,11 @@ The buffer manager maintains a weak reference to the buffer mask, so that when
 you release all references to it, it will be returned to the pool of available
 masks.
 
-Similarly, a free auxilliary buffer is obtained::
+Similarly, a free auxiliary buffer is obtained::
 
     aux_buffer = buffers.get_aux_buffer()
 
-When using the stencil or auxilliary buffers, make sure you explicitly request
+When using the stencil or auxiliary buffers, make sure you explicitly request
 these when creating the window.  See `OpenGL configuration options` for
 details.
 

--- a/pyglet/gl/base.py
+++ b/pyglet/gl/base.py
@@ -42,7 +42,7 @@ class Config:
     """Graphics configuration.
 
     A Config stores the preferences for OpenGL attributes such as the
-    number of auxilliary buffers, size of the colour and depth buffers,
+    number of auxiliary buffers, size of the colour and depth buffers,
     double buffering, stencilling, multi- and super-sampling, and so on.
 
     Different platforms support a different set of attributes, so these
@@ -56,7 +56,7 @@ class Config:
         `buffer_size` : int
             Total bits per sample per color buffer.
         `aux_buffers` : int
-            The number of auxilliary color buffers.
+            The number of auxiliary color buffers.
         `sample_buffers` : int
             The number of multisample buffers.
         `samples` : int


### PR DESCRIPTION
There is a small typo in doc/programming_guide/context.rst, doc/programming_guide/image.rst, pyglet/gl/base.py.

Should read `auxiliary` rather than `auxilliary`.

