### PR TITLE
Fix issue #274

### DIFF
--- a/pyglet/gl/cocoa.py
+++ b/pyglet/gl/cocoa.py
@@ -68,6 +68,10 @@ mavericks:      13.0 -> 13.4
 yosemite:       14.0 -> 14.5
 el_capitan:     15.0 -> 15.6
 sierra:         16.0 -> 16.6
+high_sierra:    17.0 -> 17.7
+mojave:         18.0 -> 18.2
+catalina:       19.0 -> 19.6
+big_sur:        20.0 ->
 """
 os_x_release = {
     'pre-release':      (0,1),
@@ -85,7 +89,11 @@ os_x_release = {
     'yosemite':         (14,),
     'el_capitan':       (15,),
     'sierra':           (16,),
-    }
+    'high_sierra':      (17,),
+    'mojave':           (18,),
+    'catalina':         (19,),
+    'big_sur':          (20,)
+}
 
 def os_x_version():
     version = tuple([int(v) for v in platform.release().split('.')])

--- a/pyglet/gl/lib_agl.py
+++ b/pyglet/gl/lib_agl.py
@@ -40,8 +40,8 @@ from pyglet.gl.lib import missing_function, decorate_function
 
 __all__ = ['link_GL', 'link_GLU', 'link_AGL']
 
-gl_lib = pyglet.lib.load_library(framework='/System/Library/Frameworks/OpenGL.framework')
-agl_lib = pyglet.lib.load_library(framework='/System/Library/Frameworks/AGL.framework')
+gl_lib = pyglet.lib.load_library(framework='OpenGL')
+agl_lib = pyglet.lib.load_library(framework='AGL')
 
 
 def link_GL(name, restype, argtypes, requires=None, suggestions=None):

--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -42,7 +42,6 @@ import re
 import sys
 
 import ctypes
-import ctypes.util
 
 import pyglet
 
@@ -248,39 +247,17 @@ class MachOLibraryLoader(LibraryLoader):
         return None
 
     @staticmethod
-    def find_framework(path):
-        """Implement runtime framework search as described by:
-
-        http://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkBinding.html
-        """
-
-        # e.g. path == '/System/Library/Frameworks/OpenGL.framework'
-        #      name == 'OpenGL'
-        # return '/System/Library/Frameworks/OpenGL.framework/OpenGL'
-        name = os.path.splitext(os.path.split(path)[1])[0]
-
-        realpath = os.path.join(path, name) 
-        if os.path.exists(realpath):
-            return realpath
-
-        for directory in ('/Library/Frameworks', '/System/Library/Frameworks'):
-            realpath = os.path.join(directory, '%s.framework' % name, name)
-            if os.path.exists(realpath):
-                return realpath
-
-        return None
-
-    def load_framework(self, path):
-        realpath = self.find_framework(path)
-        if realpath:
-            lib = ctypes.cdll.LoadLibrary(realpath)
+    def load_framework(name):
+        path = ctypes.util.find_library(name)
+        if path:
+            lib = ctypes.cdll.LoadLibrary(path)
             if _debug_lib:
-                print(realpath)
+                print(path)
             if _debug_trace:
                 lib = _TraceLibrary(lib)
             return lib
 
-        raise ImportError("Can't find framework %s." % path)
+        raise ImportError("Can't find framework %s." % name)
 
 
 class LinuxLibraryLoader(LibraryLoader):

--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -42,6 +42,7 @@ import re
 import sys
 
 import ctypes
+import ctypes.util
 
 import pyglet
 

--- a/pyglet/media/drivers/openal/lib_alc.py
+++ b/pyglet/media/drivers/openal/lib_alc.py
@@ -47,7 +47,7 @@ import pyglet.lib
 
 _lib = pyglet.lib.load_library('openal',
                                win32='openal32',
-                               framework='/System/Library/Frameworks/OpenAL.framework')
+                               framework='OpenAL')
 
 _int_types = (c_int16, c_int32)
 if hasattr(ctypes, 'c_int64'):

--- a/pyglet/media/drivers/openal/lib_openal.py
+++ b/pyglet/media/drivers/openal/lib_openal.py
@@ -52,7 +52,7 @@ import pyglet.lib
 
 _lib = pyglet.lib.load_library('openal',
                                win32='openal32',
-                               framework='/System/Library/Frameworks/OpenAL.framework')
+                               framework='OpenAL')
 
 _int_types = (c_int16, c_int32)
 if hasattr(ctypes, 'c_int64'):


### PR DESCRIPTION
This should fix #274. This is still broken when using official python releases, but the version of python bundled with the macOS 11 Beta (a modified version of 3.8.2) has fixes for some of the issues caused by changes in Big Sur. The appropriate version of python should be found in `/usr/bin/python3`.