### PR TITLE
Added TYPE_CHECKING for lazy loading

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -370,7 +370,7 @@ if not TYPE_CHECKING:
 
 # Fool py2exe, py2app into including all top-level modules
 # (doesn't understand lazy loading)
-if TYPE_CHECKING:
+else:
     from . import app
     from . import canvas
     from . import clock

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -41,6 +41,8 @@ More information is available at http://www.pyglet.org
 import os
 import sys
 
+from typing import TYPE_CHECKING
+
 #: The release version
 version = '2.0.dev0'
 
@@ -344,7 +346,7 @@ class _ModuleProxy:
             setattr(module, name, value)
 
 
-if True:
+if not TYPE_CHECKING:
     app = _ModuleProxy('app')
     canvas = _ModuleProxy('canvas')
     clock = _ModuleProxy('clock')
@@ -368,7 +370,7 @@ if True:
 
 # Fool py2exe, py2app into including all top-level modules
 # (doesn't understand lazy loading)
-if False:
+if TYPE_CHECKING:
     from . import app
     from . import canvas
     from . import clock


### PR DESCRIPTION
Adresses this issue: #https://github.com/pyglet/pyglet/issues/286

Following the suggestion from one of the pylance maintainers: #https://github.com/microsoft/pylance-release/issues/474

This change makes static analysis tools like pylance able to provide code completion for all of pyglet. Without it they fail to understand the lazy loading and don't work for the  submodules.