### PR TITLE
Fixed: AttributeError: 'MissingFunctionException' object has no attribute 'message'

### DIFF
--- a/pyglet/gl/xlib.py
+++ b/pyglet/gl/xlib.py
@@ -247,7 +247,7 @@ class BaseXlibContext(Context):
             elif self._have_SGI_swap_control:
                 glxext_arb.glXSwapIntervalSGI(interval)
         except lib.MissingFunctionException as e:
-            warnings.warn(e.message)
+            warnings.warn(e)
 
     def get_vsync(self):
         return self._vsync

--- a/pyglet/gl/xlib.py
+++ b/pyglet/gl/xlib.py
@@ -247,7 +247,7 @@ class BaseXlibContext(Context):
             elif self._have_SGI_swap_control:
                 glxext_arb.glXSwapIntervalSGI(interval)
         except lib.MissingFunctionException as e:
-            warnings.warn(e)
+            warnings.warn(str(e))
 
     def get_vsync(self):
         return self._vsync


### PR DESCRIPTION
Running on a Raspberry Pi. This triggered an error.
Mainly when I coded wrong, this would trigger and cause another exception than the one I should have been seeing : )