### PR TITLE
Fix data type for text_input.py example.

### DIFF
--- a/examples/text_input.py
+++ b/examples/text_input.py
@@ -17,8 +17,8 @@ class Rectangle:
     def __init__(self, x1, y1, x2, y2, batch):
         self.vertex_list = batch.add_indexed(4, pyglet.gl.GL_TRIANGLES, None,
                                              [0, 1, 2, 0, 2, 3],
-                                             ('vertices2i', [x1, y1, x2, y1, x2, y2, x1, y2]),
-                                             ('colors4Bn', [200, 200, 220, 255] * 4))
+                                             ('v2i', [x1, y1, x2, y1, x2, y2, x1, y2]),
+                                             ('c4Bn', [200, 200, 220, 255] * 4))
 
 
 class TextWidget:


### PR DESCRIPTION
The (older?) `vertices2i` and `colors4Bn` type specifiers were causing this example to blow up for me. This patch fixes the text_input.py script.