### PR TITLE
Fix getattr

### DIFF
--- a/pyglet/image/codecs/pil.py
+++ b/pyglet/image/codecs/pil.py
@@ -135,7 +135,10 @@ class PILImageEncoder(ImageEncoder):
 
         # fromstring is deprecated, replaced by frombytes in Pillow (PIL fork)
         # (1.1.7) PIL still uses it
-        image_from_fn = getattr(Image, "frombytes", getattr(Image, "fromstring"))
+        try:
+            image_from_fn = getattr(image, "tobytes")
+        except AttributeError:
+            image_from_fn = getattr(image, "tostring")
         pil_image = image_from_fn(fmt, (image.width, image.height), image.get_data(fmt, pitch))
 
         try:

--- a/pyglet/image/codecs/pil.py
+++ b/pyglet/image/codecs/pil.py
@@ -75,7 +75,10 @@ class PILImageDecoder(ImageDecoder):
 
         # tostring is deprecated, replaced by tobytes in Pillow (PIL fork)
         # (1.1.7) PIL still uses it
-        image_data_fn = getattr(image, "tobytes", getattr(image, "tostring"))
+        try:
+            image_data_fn = getattr(image, "tostring")
+        except AttributeError:
+            image_data_fn = getattr(image, "tobytes")
         return ImageData(width, height, image.mode, image_data_fn())
 
     # def decode_animation(self, file, filename):

--- a/pyglet/image/codecs/pil.py
+++ b/pyglet/image/codecs/pil.py
@@ -136,9 +136,9 @@ class PILImageEncoder(ImageEncoder):
         # fromstring is deprecated, replaced by frombytes in Pillow (PIL fork)
         # (1.1.7) PIL still uses it
         try:
-            image_from_fn = getattr(image, "tobytes")
+            image_from_fn = getattr(Image, "frombytes")
         except AttributeError:
-            image_from_fn = getattr(image, "tostring")
+            image_from_fn = getattr(Image, "fromstring")
         pil_image = image_from_fn(fmt, (image.width, image.height), image.get_data(fmt, pitch))
 
         try:

--- a/pyglet/image/codecs/pil.py
+++ b/pyglet/image/codecs/pil.py
@@ -76,9 +76,9 @@ class PILImageDecoder(ImageDecoder):
         # tostring is deprecated, replaced by tobytes in Pillow (PIL fork)
         # (1.1.7) PIL still uses it
         try:
-            image_data_fn = getattr(image, "tostring")
-        except AttributeError:
             image_data_fn = getattr(image, "tobytes")
+        except AttributeError:
+            image_data_fn = getattr(image, "tostring")
         return ImageData(width, height, image.mode, image_data_fn())
 
     # def decode_animation(self, file, filename):


### PR DESCRIPTION
When loading a texture in a headless server, we get an AttributeError:

```
 File "/home/circleci/project/src/project/graphics.py", line 90, in load_texture
    img = pyglet.image.load(tex_path)
  File "/home/circleci/.local/lib/python3.7/site-packages/pyglet/image/__init__.py", line 190, in load
    image = decoder.decode(file, filename)
  File "/home/circleci/.local/lib/python3.7/site-packages/pyglet/image/codecs/pil.py", line 78, in decode
    image_data_fn = getattr(image, "tobytes", getattr(image, "tostring"))
AttributeError: 'Image' object has no attribute 'tostring'
```

The `default` part of `getattr` should not be run if the first attribute is found.