### PR TITLE
Add error code to exception glError exception

### DIFF
--- a/pyglet/gl/lib.py
+++ b/pyglet/gl/lib.py
@@ -103,7 +103,7 @@ def errcheck(result, func, arguments):
     error = gl.glGetError()
     if error:
         msg = ctypes.cast(gl.gluErrorString(error), ctypes.c_char_p).value
-        raise GLException(msg)
+        raise GLException('(0x%x): %s' % (error, msg))
     return result
 
 


### PR DESCRIPTION
The GLException is not sufficient. Sometimes gluErrorString doesn't have an error message for a given error, in which case the message is None which leaves the user high and dry when trying to figure out how to fix the problem. I ran into this issue with GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT, which raised the not-so-helpful GLException(None).

This change adds the GL error code in hex to the error message so the user can look it up manually. Hex for convenience since that's how the GL headers define the error constants.