### PR TITLE
* Set proper default orientation for XAudio2's listener.

### DIFF
--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -567,6 +567,16 @@ class XAudio2Listener:
         self.xa2_driver = weakref.proxy(driver)
         self.listener = lib.X3DAUDIO_LISTENER()
 
+        # Default listener orientations for DirectSound/XAudio2:
+        # Front: (0, 0, 1), Up: (0, 1, 0)
+        self.listener.OrientFront.x = 0
+        self.listener.OrientFront.y = 0
+        self.listener.OrientFront.z = 1
+
+        self.listener.OrientTop.x = 0
+        self.listener.OrientTop.y = 1
+        self.listener.OrientTop.z = 0
+
     def __del__(self):
         self.delete()
 


### PR DESCRIPTION
By default it doesn't have an orientation like the other drivers since it's a client created listener rather than from the driver. This just sets the correct orientation on creation.