### PR TITLE
Replace all remaining instances of find_library (Big Sur)

### DIFF
--- a/pyglet/input/darwin_hid.py
+++ b/pyglet/input/darwin_hid.py
@@ -45,14 +45,13 @@ from .base import DeviceExclusiveException
 from pyglet.libs.darwin.cocoapy import CFSTR, CFIndex, CFTypeID, known_cftypes
 from pyglet.libs.darwin.cocoapy import kCFRunLoopDefaultMode, CFAllocatorRef, cf
 from pyglet.libs.darwin.cocoapy import cfset_to_set, cftype_to_value, cfarray_to_list
+from pyglet.lib import load_library
 
 __LP64__ = (sys.maxsize > 2 ** 32)
 
 # Uses the HID API introduced in Mac OS X version 10.5
 # http://developer.apple.com/library/mac/#technotes/tn2007/tn2187.html
-
-# Load iokit framework
-iokit = cdll.LoadLibrary(util.find_library('IOKit'))
+iokit = load_library(framework='IOKit')
 
 # IOKit constants from
 # /System/Library/Frameworks/IOKit.framework/Headers/hid/IOHIDKeys.h

--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -250,10 +250,11 @@ class MachOLibraryLoader(LibraryLoader):
         if path is None:
             frameworks = {
                 'AGL': '/System/Library/Frameworks/AGL.framework/AGL',
+                'IOKit': '/System/Library/Frameworks/IOKit.framework/IOKit',
                 'OpenAL': '/System/Library/Frameworks/OpenAL.framework/OpenAL',
                 'OpenGL': '/System/Library/Frameworks/OpenGL.framework/OpenGL'
             }
-            path = frameworks.get(name, None)
+            path = frameworks.get(name)
 
         if path:
             lib = ctypes.cdll.LoadLibrary(path)

--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -4,12 +4,16 @@ from ctypes import util
 from .runtime import send_message, ObjCInstance
 from .cocoatypes import *
 
-
 ######################################################################
 
 # CORE FOUNDATION
+lib = util.find_library('CoreFoundation')
 
-cf = cdll.LoadLibrary(util.find_library('CoreFoundation'))
+# Hack for compatibility with macOS > 11.0
+if lib is None:
+    lib = '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
+
+cf = cdll.LoadLibrary(lib)
 
 kCFStringEncodingUTF8 = 0x08000100
 
@@ -337,8 +341,13 @@ NSApplicationActivationPolicyProhibited = 2
 ######################################################################
 
 # QUARTZ / COREGRAPHICS
+lib = util.find_library('Quartz')
 
-quartz = cdll.LoadLibrary(util.find_library('quartz'))
+# Hack for compatibility with macOS > 11.0
+if lib is None:
+    lib = '/System/Library/Frameworks/Quartz.framework/Quartz'
+
+quartz = cdll.LoadLibrary(lib)
 
 CGDirectDisplayID = c_uint32     # CGDirectDisplay.h
 CGError = c_int32                # CGError.h
@@ -487,7 +496,13 @@ quartz.CGContextSetShouldAntialias.argtypes = [c_void_p, c_bool]
 ######################################################################
 
 # CORETEXT
-ct = cdll.LoadLibrary(util.find_library('CoreText'))
+lib = util.find_library('CoreText')
+
+# Hack for compatibility with macOS > 11.0
+if lib is None:
+    lib = '/System/Library/Frameworks/CoreText.framework/CoreText'
+
+ct = cdll.LoadLibrary(lib)
 
 # Types
 CTFontOrientation = c_uint32      # CTFontDescriptor.h
@@ -546,8 +561,13 @@ ct.CTFontDescriptorCreateWithAttributes.argtypes = [c_void_p]
 ######################################################################
 
 # FOUNDATION
+lib = util.find_library('Foundation')
 
-foundation = cdll.LoadLibrary(util.find_library('Foundation'))
+# Hack for compatibility with macOS > 11.0
+if lib is None:
+    lib = '/System/Library/Frameworks/Foundation.framework/Foundation'
+
+foundation = cdll.LoadLibrary(lib)
 
 foundation.NSMouseInRect.restype = c_bool
 foundation.NSMouseInRect.argtypes = [NSPoint, NSRect, c_bool]

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -48,7 +48,13 @@ elif sizeof(c_void_p) == 8:
 
 ######################################################################
 
-objc = cdll.LoadLibrary(util.find_library('objc'))
+lib = util.find_library('objc')
+
+# Hack for compatibility with macOS > 11.0
+if lib is None:
+    lib = '/usr/lib/libobjc.dylib'
+
+objc = cdll.LoadLibrary(lib)
 
 ######################################################################
 


### PR DESCRIPTION
## Purpose
This should fix all of the remaining instances of util.find_library to work with existing python version for users on macOS Big Sur. More specifically, this should fix #331.

## Notes
* I noticed that frameworks quartz and Quartz existed in macOS < 11.0, but only Quartz exists in macOS > 11.0. I'm not sure if these are the same libraries or not so I took a chance and changed it to 'Quartz'
* I am unable to test this to verify that this works
* I think 'objc' and 'quartz' are the main ones that needed to be changed based on the stack trace, but I can't say this definitively