### PR TITLE
_keyboard_exclusive and _mouse_exclusive alignment for all platforms

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -407,6 +407,8 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
     _windowed_size = None
     _windowed_location = None
 
+    _keyboard_exclusive = False
+
     # Subclasses should update these after relevant events
     _mouse_cursor = DefaultMouseCursor()
     _mouse_x = 0
@@ -1202,7 +1204,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
                 If True, exclusive mouse is enabled, otherwise it is disabled.
 
         """
-        raise NotImplementedError('abstract')
+        self._mouse_exclusive = exclusive
 
     def set_exclusive_keyboard(self, exclusive=True):
         """Prevent the user from switching away from this window using
@@ -1219,7 +1221,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
                 disabled.
 
         """
-        raise NotImplementedError('abstract')
+        self._keyboard_exclusive = exclusive
 
     def get_system_mouse_cursor(self, name):
         """Obtain a system mouse cursor.

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -575,7 +575,7 @@ class CocoaWindow(BaseWindow):
             quartz.CGDisplayMoveCursorToPoint(displayID, cocoapy.NSPoint(x, y))
 
     def set_exclusive_mouse(self, exclusive=True):
-        super().set_exclusive_mouse()
+        super().set_exclusive_mouse(exclusive)
         if exclusive:
             # Skip the next motion event, which would return a large delta.
             self._mouse_ignore_motion = True
@@ -599,7 +599,7 @@ class CocoaWindow(BaseWindow):
 
         # This flag is queried by window delegate to determine whether
         # the quit menu item is active.
-        super().set_exclusive_keyboard()
+        super().set_exclusive_keyboard(exclusive)
 
         if exclusive:
             # "Be nice! Don't disable force-quit!"

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -87,11 +87,8 @@ class CocoaWindow(BaseWindow):
     _minimum_size = None
     _maximum_size = None
 
-    _is_mouse_exclusive = False
     _mouse_platform_visible = True
     _mouse_ignore_motion = False
-
-    _is_keyboard_exclusive = False
 
     # Flag set during close() method.
     _was_closed = False
@@ -498,7 +495,7 @@ class CocoaWindow(BaseWindow):
         # look like.
         else:
             # If we are in mouse exclusive mode, then hide the mouse cursor.
-            if self._is_mouse_exclusive:
+            if self._mouse_exclusive:
                 SystemCursor.hide()
             # If we aren't inside the window, then always show the mouse
             # and make sure that it is the default cursor.
@@ -578,7 +575,7 @@ class CocoaWindow(BaseWindow):
             quartz.CGDisplayMoveCursorToPoint(displayID, cocoapy.NSPoint(x, y))
 
     def set_exclusive_mouse(self, exclusive=True):
-        self._is_mouse_exclusive = exclusive
+        super().set_exclusive_mouse()
         if exclusive:
             # Skip the next motion event, which would return a large delta.
             self._mouse_ignore_motion = True
@@ -602,7 +599,7 @@ class CocoaWindow(BaseWindow):
 
         # This flag is queried by window delegate to determine whether
         # the quit menu item is active.
-        self._is_keyboard_exclusive = exclusive
+        super().set_exclusive_keyboard()
 
         if exclusive:
             # "Be nice! Don't disable force-quit!"

--- a/pyglet/window/cocoa/pyglet_delegate.py
+++ b/pyglet/window/cocoa/pyglet_delegate.py
@@ -89,7 +89,7 @@ class PygletDelegate_Implementation:
 
     @PygletDelegate.method('v@')
     def applicationDidUnhide_(self, notification):
-        if self._window._is_mouse_exclusive and quartz.CGCursorIsVisible():
+        if self._window._mouse_exclusive and quartz.CGCursorIsVisible():
             # The cursor should be hidden, but for some reason it's not;
             # try to force the cursor to hide (without over-hiding).
             SystemCursor.unhide()
@@ -122,7 +122,7 @@ class PygletDelegate_Implementation:
     @PygletDelegate.method('v@')
     def windowDidResignKey_(self, notification):
         # Pause exclusive mouse mode if it is active.
-        if self._window._is_mouse_exclusive:
+        if self._window._mouse_exclusive:
             self._window.set_exclusive_mouse(False)
             self.did_pause_exclusive_mouse = True
             # We need to prevent the window from being unintentionally dragged
@@ -139,7 +139,7 @@ class PygletDelegate_Implementation:
 
     @PygletDelegate.method('v@')
     def windowDidDeminiaturize_(self, notification):
-        if self._window._is_mouse_exclusive and quartz.CGCursorIsVisible():
+        if self._window._mouse_exclusive and quartz.CGCursorIsVisible():
             # The cursor should be hidden, but for some reason it's not;
             # try to force the cursor to hide (without over-hiding).
             SystemCursor.unhide()
@@ -160,7 +160,7 @@ class PygletDelegate_Implementation:
     def validateMenuItem_(self, menuitem):
         # Disable quitting with command-q when in keyboard exclusive mode.
         if menuitem.action() == get_selector('terminate:'):
-            return not self._window._is_keyboard_exclusive
+            return not self._window._keyboard_exclusive
         return True
 
 

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -363,7 +363,7 @@ class PygletView_Implementation:
     def mouseExited_(self, nsevent):
         x, y = getMousePosition(self, nsevent)
         self._window._mouse_in_window = False
-        if not self._window._is_mouse_exclusive:
+        if not self._window._mouse_exclusive:
             self._window.set_mouse_platform_visible()
         self._window.dispatch_event('on_mouse_leave', x, y)
 
@@ -377,7 +377,7 @@ class PygletView_Implementation:
         # the bottom right corner, the resize control will set the cursor
         # to the default arrow and screw up our cursor tracking.
         self._window._mouse_in_window = True
-        if not self._window._is_mouse_exclusive:
+        if not self._window._mouse_exclusive:
             self._window.set_mouse_platform_visible()
 
 

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -98,9 +98,7 @@ class Win32Window(BaseWindow):
     _hidden = False
     _has_focus = False
 
-    _exclusive_keyboard = False
     _exclusive_keyboard_focus = True
-    _exclusive_mouse = False
     _exclusive_mouse_focus = True
     _exclusive_mouse_screen = None
     _exclusive_mouse_lpos = None
@@ -424,7 +422,7 @@ class Win32Window(BaseWindow):
     def set_mouse_platform_visible(self, platform_visible=None):
         if platform_visible is None:
             platform_visible = (self._mouse_visible and
-                                not self._exclusive_mouse and
+                                not self._mouse_exclusive and
                                 (not self._mouse_cursor.gl_drawable or self._mouse_cursor.hw_drawable)) or \
                                (not self._mouse_in_window or
                                 not self._has_focus)
@@ -467,7 +465,7 @@ class Win32Window(BaseWindow):
         self._exclusive_mouse_screen = p.x, p.y
 
     def set_exclusive_mouse(self, exclusive=True):
-        if self._exclusive_mouse == exclusive and \
+        if self._mouse_exclusive == exclusive and \
                 self._exclusive_mouse_focus == self._has_focus:
             return
 
@@ -500,7 +498,7 @@ class Win32Window(BaseWindow):
             # Release clip
             _user32.ClipCursor(None)
 
-        self._exclusive_mouse = exclusive
+        super().set_exclusive_mouse()
         self._exclusive_mouse_focus = self._has_focus
         self.set_mouse_platform_visible(not exclusive)
 
@@ -516,7 +514,7 @@ class Win32Window(BaseWindow):
         _user32.SetCursorPos(x, y)
 
     def set_exclusive_keyboard(self, exclusive=True):
-        if self._exclusive_keyboard == exclusive and \
+        if self._keyboard_exclusive == exclusive and \
                 self._exclusive_keyboard_focus == self._has_focus:
             return
 
@@ -525,7 +523,7 @@ class Win32Window(BaseWindow):
         else:
             _user32.UnregisterHotKey(self._hwnd, 0)
 
-        self._exclusive_keyboard = exclusive
+        super().set_exclusive_keyboard()
         self._exclusive_keyboard_focus = self._has_focus
 
     def get_system_mouse_cursor(self, name):
@@ -794,7 +792,7 @@ class Win32Window(BaseWindow):
                 self.dispatch_event('on_text_motion', motion)
 
         # Send on to DefWindowProc if not exclusive.
-        if self._exclusive_keyboard:
+        if self._keyboard_exclusive:
             return 0
         else:
             return None
@@ -816,7 +814,7 @@ class Win32Window(BaseWindow):
                                 byref(size), sizeof(RAWINPUTHEADER))
 
         if inp.header.dwType == RIM_TYPEMOUSE:
-            if not self._exclusive_mouse:
+            if not self._mouse_exclusive:
                 return 0
                 
             rmouse = inp.data.mouse
@@ -909,7 +907,7 @@ class Win32Window(BaseWindow):
     @ViewEventHandler
     @Win32EventHandler(WM_MOUSEMOVE)
     def _event_mousemove(self, msg, wParam, lParam):
-        if self._exclusive_mouse and self._has_focus:
+        if self._mouse_exclusive and self._has_focus:
             return 0
 
         x, y = self._get_location(lParam)
@@ -1120,25 +1118,25 @@ class Win32Window(BaseWindow):
         self.dispatch_event('on_activate')
         self._has_focus = True
 
-        self.set_exclusive_keyboard(self._exclusive_keyboard)
-        self.set_exclusive_mouse(self._exclusive_mouse)
+        self.set_exclusive_keyboard(self._keyboard_exclusive)
+        self.set_exclusive_mouse(self._mouse_exclusive)
         return 0
 
     @Win32EventHandler(WM_KILLFOCUS)
     def _event_killfocus(self, msg, wParam, lParam):
         self.dispatch_event('on_deactivate')
         self._has_focus = False
-        exclusive_keyboard = self._exclusive_keyboard
-        exclusive_mouse = self._exclusive_mouse
+        keyboard_exclusive = self._keyboard_exclusive
+        mouse_exclusive = self._mouse_exclusive
         # Disable both exclusive keyboard and mouse
         self.set_exclusive_keyboard(False)
         self.set_exclusive_mouse(False)
 
         # But save desired state and note that we lost focus
         # This will allow to reset the correct mode once we regain focus
-        self._exclusive_keyboard = exclusive_keyboard
+        self._keyboard_exclusive = keyboard_exclusive
         self._exclusive_keyboard_focus = False
-        self._exclusive_mouse = exclusive_mouse
+        self._mouse_exclusive = mouse_exclusive
         self._exclusive_mouse_focus = False
         return 0
 

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -498,7 +498,7 @@ class Win32Window(BaseWindow):
             # Release clip
             _user32.ClipCursor(None)
 
-        super().set_exclusive_mouse()
+        super().set_exclusive_mouse(exclusive)
         self._exclusive_mouse_focus = self._has_focus
         self.set_mouse_platform_visible(not exclusive)
 
@@ -523,7 +523,7 @@ class Win32Window(BaseWindow):
         else:
             _user32.UnregisterHotKey(self._hwnd, 0)
 
-        super().set_exclusive_keyboard()
+        super().set_exclusive_keyboard(exclusive)
         self._exclusive_keyboard_focus = self._has_focus
 
     def get_system_mouse_cursor(self, name):

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -769,14 +769,14 @@ class XlibWindow(BaseWindow):
         if exclusive == self._mouse_exclusive:
             return
 
-        super().set_exclusive_mouse()
+        super().set_exclusive_mouse(exclusive)
         self._update_exclusivity()
 
     def set_exclusive_keyboard(self, exclusive=True):
         if exclusive == self._keyboard_exclusive:
             return
 
-        super().set_exclusive_keyboard()
+        super().set_exclusive_keyboard(exclusive)
         self._update_exclusivity()
 
     def get_system_mouse_cursor(self, name):

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -138,7 +138,6 @@ class XlibWindow(BaseWindow):
     _height = 0                     # Last known window size
     _mouse_exclusive_client = None  # x,y of "real" mouse during exclusive
     _mouse_buttons = [False] * 6    # State of each xlib button
-    _keyboard_exclusive = False
     _active = True
     _applied_mouse_exclusive = False
     _applied_keyboard_exclusive = False
@@ -770,14 +769,14 @@ class XlibWindow(BaseWindow):
         if exclusive == self._mouse_exclusive:
             return
 
-        self._mouse_exclusive = exclusive
+        super().set_exclusive_mouse()
         self._update_exclusivity()
 
     def set_exclusive_keyboard(self, exclusive=True):
         if exclusive == self._keyboard_exclusive:
             return
 
-        self._keyboard_exclusive = exclusive
+        super().set_exclusive_keyboard()
         self._update_exclusivity()
 
     def get_system_mouse_cursor(self, name):


### PR DESCRIPTION
BaseWindow's defines `_mouse_exclusive` (it should also define `_keyboard_exclusive` but doesn't). This property isn't used by any of BaseWindow's sub-classes (except for XlibWindow). This PR makes all BaseWindow derivatives use `_mouse_exclusive` and `_keyboard_exclusive` as defined in BaseWindow