### PR TITLE
Removes some of the unused imports

### DIFF
--- a/contrib/model/examples/tree_test.py
+++ b/contrib/model/examples/tree_test.py
@@ -6,8 +6,6 @@
 __docformat__ = 'restructuredtext'
 __version__ = '$Id: gl_tree_test.py 114 2006-10-22 09:46:11Z r1chardj0n3s $'
 
-import math
-import random
 from pyglet.window import *
 from pyglet.window import mouse
 from pyglet import clock

--- a/contrib/model/model/obj_batch.py
+++ b/contrib/model/model/obj_batch.py
@@ -25,7 +25,7 @@ import os
 import logging
 
 from pyglet.gl import *
-from pyglet import image, resource, graphics
+from pyglet import graphics
 
 
 class Material(graphics.Group):

--- a/examples/game/version2/asteroid.py
+++ b/examples/game/version2/asteroid.py
@@ -1,5 +1,5 @@
-import pyglet, random, math
-from game import load, player, resources
+import pyglet
+from game import load, player
 
 # Set up a window
 game_window = pyglet.window.Window(800, 600)

--- a/examples/game/version3/asteroid.py
+++ b/examples/game/version3/asteroid.py
@@ -1,5 +1,5 @@
-import pyglet, random, math
-from game import load, player, resources
+import pyglet
+from game import load, player
 
 # Set up a window
 game_window = pyglet.window.Window(800, 600)

--- a/examples/game/version3/game/util.py
+++ b/examples/game/version3/game/util.py
@@ -1,4 +1,4 @@
-import pyglet, math
+import math
 
 
 def distance(point_1=(0, 0), point_2=(0, 0)):

--- a/examples/game/version4/asteroid.py
+++ b/examples/game/version4/asteroid.py
@@ -1,5 +1,5 @@
-import pyglet, random, math
-from game import load, player, resources
+import pyglet
+from game import load, player
 
 # Set up a window
 game_window = pyglet.window.Window(800, 600)

--- a/examples/game/version4/game/util.py
+++ b/examples/game/version4/game/util.py
@@ -1,4 +1,4 @@
-import pyglet, math
+import math
 
 
 def distance(point_1=(0, 0), point_2=(0, 0)):

--- a/examples/game/version5/asteroid.py
+++ b/examples/game/version5/asteroid.py
@@ -1,5 +1,5 @@
-import pyglet, random, math
-from game import asteroid, load, player, resources
+import pyglet
+from game import asteroid, load, player
 
 # Set up a window
 game_window = pyglet.window.Window(800, 600)

--- a/examples/game/version5/game/util.py
+++ b/examples/game/version5/game/util.py
@@ -1,4 +1,4 @@
-import pyglet, math
+import math
 
 
 def distance(point_1=(0, 0), point_2=(0, 0)):

--- a/examples/opengl/opengl_core.py
+++ b/examples/opengl/opengl_core.py
@@ -1,4 +1,3 @@
-import os
 import pyglet
 from pyglet.gl import *
 

--- a/experimental/svg_test.py
+++ b/experimental/svg_test.py
@@ -7,8 +7,6 @@
 __docformat__ = 'restructuredtext'
 __version__ = '$Id$'
 
-import math
-import random
 import re
 import os.path
 import pyglet

--- a/pyglet/app/xlib.py
+++ b/pyglet/app/xlib.py
@@ -39,7 +39,6 @@ import threading
 
 from pyglet import app
 from pyglet.app.base import PlatformEventLoop
-from pyglet.util import asbytes
 
 
 class XlibSelectDevice:

--- a/pyglet/canvas/win32.py
+++ b/pyglet/canvas/win32.py
@@ -35,7 +35,7 @@
 
 from .base import Display, Screen, ScreenMode, Canvas
 
-from pyglet.libs.win32 import _kernel32, _user32, types, constants
+from pyglet.libs.win32 import _user32
 from pyglet.libs.win32.constants import *
 from pyglet.libs.win32.types import *
 

--- a/pyglet/gl/base.py
+++ b/pyglet/gl/base.py
@@ -33,7 +33,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 
-from pyglet import gl, compat_platform
+from pyglet import gl
 from pyglet.gl import gl_info
 
 

--- a/pyglet/gl/cocoa.py
+++ b/pyglet/gl/cocoa.py
@@ -38,8 +38,6 @@ from ctypes import c_uint32, c_int, byref
 from pyglet.gl.base import Config, CanvasConfig, Context
 
 from pyglet.gl import ContextException
-from pyglet.gl import gl
-from pyglet.gl import agl
 
 from pyglet.canvas.cocoa import CocoaCanvas
 

--- a/pyglet/image/codecs/pil.py
+++ b/pyglet/image/codecs/pil.py
@@ -41,7 +41,7 @@ from pyglet.image.codecs import *
 try:
     import Image
 except ImportError:
-    from PIL import Image, ImageSequence
+    from PIL import Image
 
 
 class PILImageDecoder(ImageDecoder):

--- a/pyglet/input/evdev.py
+++ b/pyglet/input/evdev.py
@@ -42,7 +42,7 @@ import ctypes
 import pyglet
 
 from pyglet.app.xlib import XlibSelectDevice
-from .base import Device, Control, RelativeAxis, AbsoluteAxis, Button, Joystick, GameController
+from .base import Device, RelativeAxis, AbsoluteAxis, Button, Joystick, GameController
 from .base import DeviceOpenException
 from .evdev_constants import *
 from .gamecontroller import is_game_controller

--- a/pyglet/input/wintab.py
+++ b/pyglet/input/wintab.py
@@ -37,7 +37,7 @@ import ctypes
 
 import pyglet
 from pyglet.input.base import DeviceOpenException
-from pyglet.input.base import Tablet, TabletCursor, TabletCanvas
+from pyglet.input.base import Tablet, TabletCanvas
 
 from pyglet.libs.win32 import libwintab as wintab
 

--- a/pyglet/input/x11_xinput.py
+++ b/pyglet/input/x11_xinput.py
@@ -35,8 +35,8 @@
 
 import ctypes
 import pyglet
-from pyglet.input.base import Device, DeviceException, DeviceOpenException
-from pyglet.input.base import Control, Button, RelativeAxis, AbsoluteAxis
+from pyglet.input.base import Device, DeviceOpenException
+from pyglet.input.base import Button, RelativeAxis, AbsoluteAxis
 from pyglet.libs.x11 import xlib
 from pyglet.util import asstr
 

--- a/pyglet/media/codecs/wave.py
+++ b/pyglet/media/codecs/wave.py
@@ -38,7 +38,7 @@
 
 import wave
 
-from ..exceptions import MediaDecodeException, MediaEncodeException
+from ..exceptions import MediaDecodeException
 from .base import StreamingSource, AudioData, AudioFormat, StaticSource
 from . import MediaEncoder, MediaDecoder
 

--- a/pyglet/media/devices/win32.py
+++ b/pyglet/media/devices/win32.py
@@ -1,4 +1,3 @@
-import pyglet
 from pyglet import com
 from pyglet.libs.win32 import _ole32 as ole32
 from pyglet.libs.win32.constants import CLSCTX_INPROC_SERVER

--- a/pyglet/media/drivers/openal/interface.py
+++ b/pyglet/media/drivers/openal/interface.py
@@ -39,7 +39,6 @@ from collections import namedtuple
 
 from . import lib_openal as al
 from . import lib_alc as alc
-import pyglet
 from pyglet.util import debug_print
 from pyglet.media.exceptions import MediaException
 

--- a/pyglet/media/drivers/pulse/adaptation.py
+++ b/pyglet/media/drivers/pulse/adaptation.py
@@ -37,12 +37,11 @@ import weakref
 
 from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer
 from pyglet.media.events import MediaEvent
-from pyglet.media.exceptions import MediaException
 from pyglet.media.drivers.listener import AbstractListener
 from pyglet.util import debug_print
 
 from . import lib_pulseaudio as pa
-from .interface import PulseAudioContext, PulseAudioMainLoop, PulseAudioStream
+from .interface import PulseAudioMainLoop
 
 
 _debug = debug_print('debug_media')

--- a/pyglet/media/drivers/xaudio2/lib_xaudio2.py
+++ b/pyglet/media/drivers/xaudio2/lib_xaudio2.py
@@ -1,12 +1,9 @@
-from pyglet.media.events import MediaEvent
-
-import pyglet
 import ctypes
+import platform
+import os
 from pyglet.libs.win32.constants import *
 from pyglet.libs.win32.types import *
 from pyglet import com
-import platform
-import os
 from pyglet.util import debug_print
 
 _debug = debug_print('debug_media')

--- a/pyglet/model/codecs/gltf.py
+++ b/pyglet/model/codecs/gltf.py
@@ -40,7 +40,7 @@ import pyglet
 from pyglet.gl import GL_BYTE, GL_UNSIGNED_BYTE, GL_SHORT, GL_UNSIGNED_SHORT, GL_FLOAT
 from pyglet.gl import GL_UNSIGNED_INT, GL_ELEMENT_ARRAY_BUFFER, GL_ARRAY_BUFFER, GL_TRIANGLES
 
-from .. import Model, Material, MaterialGroup, TexturedMaterialGroup
+from .. import Model, Material, MaterialGroup
 from . import ModelDecodeException, ModelDecoder
 
 

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -39,7 +39,7 @@ from ctypes import *
 from functools import lru_cache
 
 import pyglet
-from pyglet.window import WindowException, NoSuchDisplayException, MouseCursorException
+from pyglet.window import WindowException, MouseCursorException
 from pyglet.window import MouseCursor, DefaultMouseCursor, ImageMouseCursor
 from pyglet.window import BaseWindow, _PlatformEventHandler, _ViewEventHandler
 

--- a/tools/al_info.py
+++ b/tools/al_info.py
@@ -15,7 +15,6 @@ import sys
 
 from pyglet.util import asbytes
 from pyglet.media.drivers import openal
-from pyglet.media.drivers.openal.interface import al
 from pyglet.media.drivers.openal.interface import alc
 
 


### PR DESCRIPTION
This PR removes some of the unused imports flagged by LGTM. I'm assuming that it's fine to remove pyglet imports from files, though I'm not sure why it wouldn't be. This should hopefully reduce the number of alerts in LGTM