### PR TITLE
Using super for set_size on window classes

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1019,8 +1019,10 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         """
         if self._fullscreen:
             raise WindowException('Cannot set size of fullscreen window.')
-        self._width = max(width, 1)
-        self._height = max(height, 1)
+        if width < 1 or height < 1:
+            raise ValueError('width and height must both be positive integers')
+
+        self._width, self._height = width, height
 
     def get_pixel_ratio(self):
         """Return the framebuffer/window size ratio.

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1020,7 +1020,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         if self._fullscreen:
             raise WindowException('Cannot set size of fullscreen window.')
         if width < 1 or height < 1:
-            raise ValueError('width and height must both be positive integers')
+            raise ValueError('width and height must be positive integers')
 
         self._width, self._height = width, height
 

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1002,7 +1002,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         """
         raise NotImplementedError('abstract')
 
-    def set_size(self, width, height):
+    def set_size(self, width: int, height: int):
         """Resize the window.
 
         The behaviour is undefined if the window is not resizable, or if
@@ -1017,7 +1017,10 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
                 New height of the window, in pixels.
 
         """
-        raise NotImplementedError('abstract')
+        if self._fullscreen:
+            raise WindowException('Cannot set size of fullscreen window.')
+        self._width = max(width, 1)
+        self._height = max(height, 1)
 
     def get_pixel_ratio(self):
         """Return the framebuffer/window size ratio.

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1002,7 +1002,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         """
         raise NotImplementedError('abstract')
 
-    def set_size(self, width: int, height: int):
+    def set_size(self, width: int, height: int) -> None:
         """Resize the window.
 
         The behaviour is undefined if the window is not resizable, or if

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -408,7 +408,7 @@ class CocoaWindow(BaseWindow):
         bounds = view.convertRectToBacking_(view.bounds()).size
         return int(bounds.width), int(bounds.height)
 
-    def set_size(self, width: int, height: int):
+    def set_size(self, width: int, height: int) -> None:
         super().set_size(width, height)
         # Move frame origin down so that top-left corner of window doesn't move.
         window_frame = self._nswindow.frame()

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -408,11 +408,8 @@ class CocoaWindow(BaseWindow):
         bounds = view.convertRectToBacking_(view.bounds()).size
         return int(bounds.width), int(bounds.height)
 
-    def set_size(self, width, height):
-        if self._fullscreen:
-            raise WindowException('Cannot set size of fullscreen window.')
-        self._width = max(1, int(width))
-        self._height = max(1, int(height))
+    def set_size(self, width: int, height: int):
+        super().set_size(width, height)
         # Move frame origin down so that top-left corner of window doesn't move.
         window_frame = self._nswindow.frame()
         rect = self._nswindow.contentRectForFrameRect_(window_frame)

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -371,7 +371,7 @@ class Win32Window(BaseWindow):
         _user32.ClientToScreen(self._hwnd, byref(point))
         return point.x, point.y
 
-    def set_size(self, width: int, height: int):
+    def set_size(self, width: int, height: int) -> None:
         super().set_size(width, height)
         width, height = self._client_to_window_size(width, height)
         _user32.SetWindowPos(self._hwnd, 0, 0, 0, width, height,

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -371,9 +371,8 @@ class Win32Window(BaseWindow):
         _user32.ClientToScreen(self._hwnd, byref(point))
         return point.x, point.y
 
-    def set_size(self, width, height):
-        if self._fullscreen:
-            raise WindowException('Cannot set size of fullscreen window.')
+    def set_size(self, width: int, height: int):
+        super().set_size(width, height)
         width, height = self._client_to_window_size(width, height)
         _user32.SetWindowPos(self._hwnd, 0, 0, 0, width, height,
                              (SWP_NOZORDER |

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -134,8 +134,6 @@ class XlibWindow(BaseWindow):
 
     _x = 0
     _y = 0                          # Last known window position
-    _width = 0
-    _height = 0                     # Last known window size
     _mouse_exclusive_client = None  # x,y of "real" mouse during exclusive
     _mouse_buttons = [False] * 6    # State of each xlib button
     _active = True

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -558,11 +558,8 @@ class XlibWindow(BaseWindow):
     def get_caption(self):
         return self._caption
 
-    def set_size(self, width, height):
-        if self._fullscreen:
-            raise WindowException('Cannot set size of fullscreen window.')
-        self._width = width
-        self._height = height
+    def set_size(self, width: int, height: int):
+        super().set_size(width, height)
         if not self._resizable:
             self.set_minimum_size(width, height)
             self.set_maximum_size(width, height)

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -558,7 +558,7 @@ class XlibWindow(BaseWindow):
     def get_caption(self):
         return self._caption
 
-    def set_size(self, width: int, height: int):
+    def set_size(self, width: int, height: int) -> None:
         super().set_size(width, height)
         if not self._resizable:
             self.set_minimum_size(width, height)


### PR DESCRIPTION
### Purpose
This PR uses super to simplify the implementation of `set_size` for all BaseWindow sub-classes. I also added type hinting to the `set_size` functions

### Changes
* Using type hints for all instances of `set_size` in window classes
* Using super to reduce reused code for `set_size`
* Removed `_window` and `_height` from XlibWindow as these are defined in BaseWindow