### PR TITLE
Promote get_size to BaseWindow

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -124,6 +124,7 @@ above, "Working with multiple screens")::
 """
 
 import sys
+from typing import Tuple
 
 import pyglet
 from pyglet import gl
@@ -1050,15 +1051,15 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         """
         return self.get_framebuffer_size()[0] / self.width
 
-    def get_size(self):
+    def get_size(self) -> Tuple[int, int]:
         """Return the current size of the window.
 
-        The window size does not include the border or title bar.
+        This does not include the windows' border or title bar.
 
         :rtype: (int, int)
         :return: The width and height of the window, in pixels.
         """
-        raise NotImplementedError('abstract')
+        return self._width, self._height
 
     def get_framebuffer_size(self):
         """Return the size in actual pixels of the Window framebuffer.

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -36,7 +36,6 @@
 from ctypes import *
 
 import pyglet
-from pyglet import gl
 from pyglet.window import BaseWindow
 from pyglet.window import MouseCursor, DefaultMouseCursor
 from pyglet.event import EventDispatcher

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -34,10 +34,11 @@
 # ----------------------------------------------------------------------------
 
 from ctypes import *
+from typing import Tuple
 
 import pyglet
 from pyglet import gl
-from pyglet.window import BaseWindow, WindowException
+from pyglet.window import BaseWindow
 from pyglet.window import MouseCursor, DefaultMouseCursor
 from pyglet.event import EventDispatcher
 
@@ -47,7 +48,6 @@ from pyglet.libs.darwin import cocoapy, CGPoint
 
 from .systemcursor import SystemCursor
 from .pyglet_delegate import PygletDelegate
-from .pyglet_textview import PygletTextView
 from .pyglet_window import PygletWindow, PygletToolWindow
 from .pyglet_view import PygletView
 
@@ -395,7 +395,7 @@ class CocoaWindow(BaseWindow):
         origin = cocoapy.NSPoint(x, screen_height - y - rect.size.height)
         self._nswindow.setFrameOrigin_(origin)
 
-    def get_size(self):
+    def get_size(self) -> Tuple[int, int]:
         window_frame = self._nswindow.frame()
         rect = self._nswindow.contentRectForFrameRect_(window_frame)
         return int(rect.size.width), int(rect.size.height)

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -34,7 +34,6 @@
 # ----------------------------------------------------------------------------
 
 from ctypes import *
-from typing import Tuple
 
 import pyglet
 from pyglet import gl

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -395,11 +395,6 @@ class CocoaWindow(BaseWindow):
         origin = cocoapy.NSPoint(x, screen_height - y - rect.size.height)
         self._nswindow.setFrameOrigin_(origin)
 
-    def get_size(self) -> Tuple[int, int]:
-        window_frame = self._nswindow.frame()
-        rect = self._nswindow.contentRectForFrameRect_(window_frame)
-        return int(rect.size.width), int(rect.size.height)
-
     def get_framebuffer_size(self):
         view = self.context._nscontext.view()
         bounds = view.convertRectToBacking_(view.bounds()).size

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -377,12 +377,6 @@ class Win32Window(BaseWindow):
                               SWP_NOMOVE |
                               SWP_NOOWNERZORDER))
 
-    def get_size(self):
-        # rect = RECT()
-        # _user32.GetClientRect(self._hwnd, byref(rect))
-        # return rect.right - rect.left, rect.bottom - rect.top
-        return self._width, self._height
-
     def activate(self):
         _user32.SetForegroundWindow(self._hwnd)
 

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -568,13 +568,6 @@ class XlibWindow(BaseWindow):
     def _update_view_size(self):
         xlib.XResizeWindow(self._x_display, self._view, self._width, self._height)
 
-    def get_size(self):
-        # XGetGeometry and XWindowAttributes seem to always return the
-        # original size of the window, which is wrong after the user
-        # has resized it.
-        # XXX this is probably fixed now, with fix of resize.
-        return self._width, self._height
-
     def set_location(self, x, y):
         if self._is_reparented():
             # Assume the window manager has reparented our top-level window


### PR DESCRIPTION
## Purpose
Promotes `get_size` function in XlibWindow and Win32Window to BaseWindow. CocoaWindow is left untouched besides adding type hints