### PR TITLE
Promote set_vsync to BaseWindow

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1133,7 +1133,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         """
         raise NotImplementedError('abstract')
 
-    def set_vsync(self, vsync):
+    def set_vsync(self, vsync: bool) -> None:
         """Enable or disable vertical sync control.
 
         When enabled, this option ensures flips from the back to the front
@@ -1154,7 +1154,7 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
                 If True, vsync is enabled, otherwise it is disabled.
 
         """
-        raise NotImplementedError('abstract')
+        self._vsync = vsync
 
     def set_mouse_visible(self, visible=True):
         """Show or hide the mouse cursor.

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -461,10 +461,12 @@ class CocoaWindow(BaseWindow):
         if self._nswindow is not None:
             self._nswindow.zoom_(None)
 
-    def set_vsync(self, vsync):
+    def set_vsync(self, vsync: bool) -> None:
         if pyglet.options['vsync'] is not None:
             vsync = pyglet.options['vsync']
-        self._vsync = vsync  # _recreate depends on this
+
+        super().set_vsync(vsync)
+
         if self.context:
             self.context.set_vsync(vsync)
 

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -466,9 +466,7 @@ class CocoaWindow(BaseWindow):
             vsync = pyglet.options['vsync']
 
         super().set_vsync(vsync)
-
-        if self.context:
-            self.context.set_vsync(vsync)
+        self.context.set_vsync(vsync)
 
     def _mouse_in_content_rect(self):
         # Returns true if mouse is inside the window's content rectangle.

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -339,8 +339,9 @@ class Win32Window(BaseWindow):
                 # This seems odd, as vsync is normally a bool
                 # Win32Context.set_vsync casts vsync to an int anyways
                 # so this should probably be changed
-                vsync = 0
+                vsync = False
 
+        super().set_vsync(vsync)
         self.context.set_vsync(vsync)
 
     def switch_to(self):

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -327,7 +327,7 @@ class Win32Window(BaseWindow):
 
     vsync = property(_get_vsync)  # overrides BaseWindow property
 
-    def set_vsync(self, vsync):
+    def set_vsync(self, vsync: bool) -> None:
         if pyglet.options['vsync'] is not None:
             vsync = pyglet.options['vsync']
 

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -336,9 +336,6 @@ class Win32Window(BaseWindow):
         if not self._fullscreen:
             # Disable interval if composition is enabled to avoid conflict with DWM.
             if self._always_dwm or self._dwm_composition_enabled():
-                # This seems odd, as vsync is normally a bool
-                # Win32Context.set_vsync casts vsync to an int anyways
-                # so this should probably be changed
                 vsync = False
 
         super().set_vsync(vsync)

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -336,7 +336,10 @@ class Win32Window(BaseWindow):
         if not self._fullscreen:
             # Disable interval if composition is enabled to avoid conflict with DWM.
             if self._always_dwm or self._dwm_composition_enabled():
-                vsync = 0 # This seems odd, as vsync is normally a bool
+                # This seems odd, as vsync is normally a bool
+                # Win32Context.set_vsync casts vsync to an int anyways
+                # so this should probably be changed
+                vsync = 0
 
         self.context.set_vsync(vsync)
 

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -336,7 +336,7 @@ class Win32Window(BaseWindow):
         if not self._fullscreen:
             # Disable interval if composition is enabled to avoid conflict with DWM.
             if self._always_dwm or self._dwm_composition_enabled():
-                vsync = 0
+                vsync = 0 # This seems odd, as vsync is normally a bool
 
         self.context.set_vsync(vsync)
 

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -525,10 +525,11 @@ class XlibWindow(BaseWindow):
 
         self._sync_resize()
 
-    def set_vsync(self, vsync):
+    def set_vsync(self, vsync: bool) -> None:
         if pyglet.options['vsync'] is not None:
             vsync = pyglet.options['vsync']
-        self._vsync = vsync
+
+        super().set_vsync(vsync)
         self.context.set_vsync(vsync)
 
     def set_caption(self, caption):


### PR DESCRIPTION
## Purpose
Promotes set_vsync to BaseWindow class

## Notes
I didn't make any changes to Win32Window because it doesn't set `_vsync` and it does some weirdness where it sets `vsync` (the argument) to 0. I didn't really want to mess with that without understanding more of what was going on