### PR TITLE
DirectWrite fixes

### DIFF
--- a/pyglet/font/base.py
+++ b/pyglet/font/base.py
@@ -150,11 +150,12 @@ class Glyph(image.TextureRegion):
             left-side bearing at the baseline.
 
     """
-
+    baseline = 0
+    lsb = 0
     advance = 0
     vertices = (0, 0, 0, 0)
 
-    def set_bearings(self, baseline, left_side_bearing, advance):
+    def set_bearings(self, baseline, left_side_bearing, advance, x_offset=0, y_offset=0):
         """Set metrics for this glyph.
 
         :Parameters:
@@ -165,15 +166,20 @@ class Glyph(image.TextureRegion):
                 Distance to add to the left edge of the glyph.
             `advance` : int
                 Distance to move the horizontal advance to the next glyph.
-
+            `offset_x` : int
+                Distance to move the glyph horizontally from it's default position.
+            `offset_y` : int
+                Distance to move the glyph vertically from it's default position.
         """
         self.baseline = baseline
+        self.lsb = left_side_bearing
         self.advance = advance
+
         self.vertices = (
-            left_side_bearing,
-            -baseline,
-            left_side_bearing + self.width,
-            -baseline + self.height)
+            left_side_bearing + x_offset,
+            -baseline + y_offset,
+            left_side_bearing + self.width + x_offset,
+            -baseline + self.height + y_offset)
 
     def draw(self):
         """Debug method.


### PR DESCRIPTION
Support for glyph offsets which fixes issues with diacritics and other special characters not being rendered.
Fix for advance cache being shared among instances and a crash. This should solve some spacing issues as well.
Fixes some LSB issue and storing LSB in glyph.
Fixes a crash when using render to image.