### PR TITLE
Fix the NoReturn type being infered for every GL function

### DIFF
--- a/pyglet/gl/lib_glx.py
+++ b/pyglet/gl/lib_glx.py
@@ -34,6 +34,7 @@
 # ----------------------------------------------------------------------------
 
 from ctypes import *
+from typing import Any, Callable
 
 import pyglet.lib
 from pyglet.gl.lib import missing_function, decorate_function
@@ -54,7 +55,7 @@ except AttributeError:
     _have_getprocaddress = False
 
 
-def link_GL(name, restype, argtypes, requires=None, suggestions=None):
+def link_GL(name, restype, argtypes, requires=None, suggestions=None) -> Callable[..., Any]:
     try:
         func = getattr(gl_lib, name)
         func.restype = restype


### PR DESCRIPTION
Per discussion on Discord: https://discord.com/channels/438622377094414346/463526340168122368/838782790978764870

This should stop Pylance (and any other type-checker) from incorrectly infering `typing.NoReturn`, resulting in any code positioned after a GL call to be considered unreachable (which isn't true at runtime).