### PR TITLE
Update install and test doc for 2.0 

### DIFF
--- a/doc/internal/testing.rst
+++ b/doc/internal/testing.rst
@@ -50,7 +50,7 @@ The pyglet test suite is based on the `pytest framework <http://pytest.org>`_.
 It is preferred to use a virtual environment to run the tests.
 For instructions to set up virtual environments see :doc:`virtualenv`.
 Make sure the virtual environment for the Python version you want to
-test is active. It is preferred to run the tests on 2.7 and 3.5+
+test is active. It is preferred to run the tests on 3.6+
 to make sure changes are compatible with all supported Python versions.
 
 To run all tests, execute pytest in the root of the pyglet repository::

--- a/doc/internal/virtualenv.rst
+++ b/doc/internal/virtualenv.rst
@@ -3,7 +3,7 @@ Development environment
 
 To develop pyglet, you need an environment with at least the following:
 
-    - Python 3.5+ and Python 2.7
+    - Python 3.6+
     - `pytest <https://pytest.org>`_
     - Your favorite Python editor or IDE
 
@@ -45,39 +45,24 @@ Setting up
 
 Setting up a virtual environment is almost the same for Linux and OS X.
 First, use your OS's package manager (apt, brew, etc) to install the
-following dependencies:
+following dependencies::
 
-    - Python 3.5+ and Python 2.7
-    - pip (for each version of Python)
+    - Python 3.6+
 
 To create virtual environments, ``venv`` is included in the standard
-library since Python 3.3. For Python 2.7, you will need to install the
-``virtualenv`` package (you might need to add sudo)::
+library since Python 3.3.
 
-    pip install virtualenv
+Next, we'll create a virtual environment.::
 
-Make a directory somewhere to hold our virtual environments::
+    python3 -m venv pyglet-venv
 
-    mkdir pyglet-venv
+Once the virtual environment has been created, the next step is to activate
+it. You'll then install the dependencies, which will be isolated
+inside that virtual environment.
 
-Next, we'll create the virtual environments for each version of python.
-We'll put them both inside the "pyglet-venv" folder, to keep things in
-one place.  Remember that the library names are different for
-Python 2 and 3::
+Activate the virtual environment ::
 
-    python2 -m virtualenv pyglet-venv/py2
-    python3 -m venv pyglet-venv/py3
-
-Once the virtual environments have been created, the next step is to activate
-one of them. You'll then install the dependencies, which will be isolated
-inside that virtual environment. Only one can be active at a time,
-so perform the following steps one one at a time
-
-Activate whichever virtual environment you wish to use::
-
-    . pyglet-venv/py2/bin/activate
-    # or
-    . pyglet-venv/py3/bin/activate
+   . pyglet-venv/bin/activate
 
 You will see the name of the virtual environment at the start of the
 command prompt.
@@ -87,7 +72,10 @@ command prompt.
     pip install --upgrade pip
 
 Now install dependencies in ``doc/requirements.txt`` and
-``tests/requirements.txt``
+``tests/requirements.txt``::
+
+    pip install -r doc/requirements.txt
+    pip install -r tests/requirements.txt
 
 Finishing
 '''''''''
@@ -104,39 +92,27 @@ Setting up
 
 Make sure you download and install:
 
-    - `Python 3.5+ and Python 2.7 <http://www.python.org/downloads/windows/>`_
+    - `Python 3.6+  <http://www.python.org/downloads/windows/>`_
 
 Pip should be installed by default with the latest Python installers.
-Make sure you do not uncheck the option.  When finished installing,
-open a command prompt.
+Make sure that the boxes for installing PIP and adding python to PATH are checked.
+
+When finished installing, open a command prompt.
 
 To create virtual environments, ``venv`` is included in the standard library
 since Python 3.3.
-For Python 2.7 only, you will need to install the ``virtualenv`` package::
 
-    py -2 -m pip install virtualenv
+Next, we'll create a virtual environment.::
 
-Make a directory somewhere to hold our virtual environments::
+    python3 -m venv pyglet-venv
 
-    md pyglet-venv
+Once the virtual environment has been created, the next step is to activate
+it. You'll then install the dependencies, which will be isolated
+inside that virtual environment.
 
-Next, we'll create the virtual environments for each version of python.
-We'll put them both inside the "pyglet-venv" folder, to keep things in one
-place. Remember that the library names are different for Python 2 and 3::
+Activate the virtual environment ::
 
-    py -2 -m virtualenv pyglet-venv\py2
-    py -3 -m venv pyglet-venv\py3
-
-Once the virtual environments have been created, the next step is to activate
-one of them. You'll then install the dependencies, which will be isolated
-inside that virtual environment. Only one can be active at a time, so perform
-the following steps one one at a time.
-
-Activate the virtual environment::
-
-   pyglet-venv\py2\Scripts\activate
-   # or
-   pyglet-venv\py3\Scripts\activate
+   . pyglet-venv/bin/activate
 
 You will see the name of the virtual environment at the start of the
 command prompt.
@@ -145,8 +121,12 @@ command prompt.
 
    pip install --upgrade pip
 
+
 Now install dependencies in ``doc/requirements.txt`` and
-``tests/requirements.txt``
+``tests/requirements.txt``::
+
+    pip install -r doc/requirements.txt
+    pip install -r tests/requirements.txt
 
 Finishing
 '''''''''

--- a/doc/internal/virtualenv.rst
+++ b/doc/internal/virtualenv.rst
@@ -45,7 +45,7 @@ Setting up
 
 Setting up a virtual environment is almost the same for Linux and OS X.
 First, use your OS's package manager (apt, brew, etc) to install the
-following dependencies::
+following dependencies:
 
     - Python 3.6+
 

--- a/doc/internal/virtualenv.rst
+++ b/doc/internal/virtualenv.rst
@@ -52,8 +52,20 @@ following dependencies::
 To create virtual environments, ``venv`` is included in the standard
 library since Python 3.3.
 
-Next, we'll create a virtual environment.::
+Depending on your platform, python may be installed as ``python`` or ``python3``.
+You may want to check which command runs python 3 on your system::
 
+    python --version
+    python3 --version
+
+For the rest of the guide, use whichever gives you the correct python version on your system.
+Some linux distros may install python with version numbers such as `python3.6`, so you may need
+to set up an alias.
+
+Next, we'll create a virtual environment.
+Choose the appropriate command for your system to create a virtual environment::
+
+    python -m venv pyglet-venv
     python3 -m venv pyglet-venv
 
 Once the virtual environment has been created, the next step is to activate
@@ -104,7 +116,7 @@ since Python 3.3.
 
 Next, we'll create a virtual environment.::
 
-    python3 -m venv pyglet-venv
+    python -m venv pyglet-venv
 
 Once the virtual environment has been created, the next step is to activate
 it. You'll then install the dependencies, which will be isolated


### PR DESCRIPTION
Same as #384 but rebased off of the tip of `master`.

According to @einarf ,Pyglet 1.5.15 dropped support for Python 3.5, and support for 2.7 was dropped a long time ago:
> [`1.5.15` dropped py35](https://discord.com/channels/438622377094414346/477394331112701952/840023078502531072)

This PR updates the 2,0  install documentation to reflect those changes.