### PR TITLE
Warn when gl < 2.0

### DIFF
--- a/pyglet/canvas/base.py
+++ b/pyglet/canvas/base.py
@@ -32,6 +32,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
+import warnings
 
 from pyglet import gl
 from pyglet import app
@@ -192,7 +193,18 @@ class Screen:
             configs = self.get_matching_configs(template)
         if not configs:
             raise window.NoSuchConfigException()
-        return configs[0]
+
+        best = configs[0]
+        if best.major_version < 2:
+            version = best.major_version, best.minor_version
+            warnings.warn(
+                f"OpenGL version lower than 2.0 {version!r}. "
+                f"Many features may not work if batching fails. "
+                f"If your hardware should support a higher version, your "
+                f"drivers or OS may be at fault."
+            )
+
+        return best
 
     def get_matching_configs(self, template):
         """Get a list of configs that match a specification.


### PR DESCRIPTION
An updated version of #383 to address #375 . Attempts to warn the user when a screen supports a GL version less than 2.0.