### PR TITLE
Fix DirectInputDevice.open crash

### DIFF
--- a/pyglet/input/directinput.py
+++ b/pyglet/input/directinput.py
@@ -155,7 +155,7 @@ class DirectInputDevice(base.Device):
             if not pyglet.app.windows:
                 return
             # Pick any open window
-            window = pyglet.app.windows[0]
+            window = next(iter(pyglet.app.windows))
 
         flags = dinput.DISCL_BACKGROUND
         if exclusive:


### PR DESCRIPTION
Sets are not subscriptable. Make an iterator instead and pull the first value.

I didn't check if 1.5-maintenance also have this issue.