### PR TITLE
Fix support for GL warnings

### DIFF
--- a/pyglet/canvas/base.py
+++ b/pyglet/canvas/base.py
@@ -32,8 +32,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
-import warnings
-
 from pyglet import gl
 from pyglet import app
 from pyglet import window

--- a/pyglet/canvas/base.py
+++ b/pyglet/canvas/base.py
@@ -194,17 +194,7 @@ class Screen:
         if not configs:
             raise window.NoSuchConfigException()
 
-        best = configs[0]
-        if best.major_version < 2:
-            version = best.major_version, best.minor_version
-            warnings.warn(
-                f"OpenGL version lower than 2.0 {version!r}. "
-                f"Many features may not work if batching fails. "
-                f"If your hardware should support a higher version, your "
-                f"drivers or OS may be at fault."
-            )
-
-        return best
+        return configs[0]
 
     def get_matching_configs(self, template):
         """Get a list of configs that match a specification.

--- a/pyglet/gl/gl_info.py
+++ b/pyglet/gl/gl_info.py
@@ -212,12 +212,8 @@ class GLInfo:
                 or self.major_version is None:
             return False
 
-        ver = '%s.0.0' % self.version.strip().split(' ', 1)[0]
-        imajor, iminor, irelease = [int(v) for v in ver.split('.', 3)[:3]]
-
-        return (imajor > major or
-                (imajor == major and iminor >= minor) or
-                (imajor == major and iminor == minor))
+        return (self.major_version > major or
+                (self.major_version == major and self.minor_version >= minor))
 
     def get_renderer(self):
         """Determine the renderer string of the OpenGL context.

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -125,6 +125,7 @@ above, "Working with multiple screens")::
 
 import sys
 import math
+import warnings
 
 import pyglet
 import pyglet.window.key
@@ -648,9 +649,21 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         self._create()
 
         self.switch_to()
+
         if visible:
             self.set_visible(True)
             self.activate()
+
+        # Warn when features might break due to odd GL support
+        info = self._context.get_info()
+        if info.major_version < 2:
+            version = info.major_version, info.minor_version
+            warnings.warn(
+                f"OpenGL version lower than 2.0 {version!r}. "
+                f"Batching may fail and break many features. "
+                f"If your hardware should support a higher version, your "
+                f"drivers or OS may be at fault."
+            )
 
     def __del__(self):
         # Always try to clean up the window when it is dereferenced.

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -657,9 +657,8 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
         # Warn when features might break due to odd GL support
         info = self._context.get_info()
         if info.major_version < 2:
-            version = info.major_version, info.minor_version
             warnings.warn(
-                f"OpenGL version lower than 2.0 {version!r}. "
+                f"OpenGL version lower than 2.0 ({info.version}). "
                 f"Batching may fail and break many features. "
                 f"If your hardware should support a higher version, your "
                 f"drivers or OS may be at fault."


### PR DESCRIPTION
### Summary of Actions
1. Remove the broken warning from `canvas/base.py`
2. Improve encapsulation for detecting and providing GL version information in `GLInfo` objects
3. Add a working warning for GL < 2 as a finale to `BaseWindow.__init__` after the context is created and set as active
4. Ran minimal window creation on local system with `shadow_window` both on and off

### What's needed before merging
- [ ] Run it on a non-windows system
- [x] Run it against a windows host reporting GL 1.1
- [ ] Figure out ways to test it against examples to make sure it doesn't break things
- [ ] Feedback on code quality
- [ ] Feedback on error message placement

### Additional Concerns / Comments
I looked for tests of Context, GLInfo, and Window, but didn't see meaningful ones related to this issue. Should I add them given this is a maintenance branch?
Also, I might be able to get a windows VM up if Ben can't get to it in the next few days.

If this passes sniff checks, it should close #383 