### PR TITLE
Allow alignment of text within width for a single line.

### DIFF
--- a/pyglet/text/layout.py
+++ b/pyglet/text/layout.py
@@ -1623,6 +1623,13 @@ class TextLayout:
         line = _Line(start)
         font = font_iterator[0]
 
+        if self._width:
+            align_iterator = runlist.FilteredRunIterator(
+                self._document.get_style_runs('align'),
+                lambda value: value in ('left', 'right', 'center'),
+                'left')
+            line.align = align_iterator[start]
+
         for start, end, owner in owner_iterator:
             font = font_iterator[start]
             width = 0


### PR DESCRIPTION
Docs state:

> Horizontal alignment of text on a line, only applies if width is supplied. One of ``"left"``, ``"center"`` or ``"right"``.

However this does not work unless multiline is enabled. This PR allows a single line (multiline=False) to still have it's alignment adjusted.