### PR TITLE
Enable/Disable pyglet.gui Widgets

### DIFF
--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -73,6 +73,17 @@ class WidgetBase(EventDispatcher):
     @property
     def aabb(self):
         return self._x, self._y, self._x + self._width, self._y + self._height
+    
+    # The value property should be overridden in such a way that the widget
+    # can be 'activated' or changed without requiring user input.
+    # The normal events for control activation should NOT be triggered.
+    @property
+    def value(self):
+        raise NotImplementedError("Value depends on control type!")
+    
+    @value.setter
+    def value(self, value):
+        raise NotImplementedError("Value depends on control type!")
 
     def _check_hit(self, x, y):
         return self._x < x < self._x + self._width and self._y < y < self._y + self._height
@@ -124,6 +135,17 @@ class PushButton(WidgetBase):
         self._sprite = pyglet.sprite.Sprite(self._depressed_img, x, y, batch=batch, group=bg_group)
 
         self._pressed = False
+
+    # Override
+    @property
+    def value(self):
+        return self._pressed
+    
+    # Override
+    @value.setter
+    def value(self, value):
+        self._pressed = value
+        self._sprite.image = self._pressed_img if self._pressed else self._depressed_img
 
     def update_groups(self, order):
         self._sprite.group = OrderedGroup(order + 1, self._user_group)
@@ -200,6 +222,18 @@ class Slider(WidgetBase):
 
         self._value = 0
         self._in_update = False
+    
+    # Override
+    @property
+    def value(self):
+        return self._value
+    
+    # Override
+    @value.setter
+    def value(self, value):
+        self._value = value
+        x = (self._max_knob_x - self._min_knob_x) * value / 100 + self._min_knob_x + self._half_knob_width
+        self._knob_spr.x = max(self._min_knob_x, min(x - self._half_knob_width, self._max_knob_x))
 
     def update_groups(self, order):
         self._base_spr.group = OrderedGroup(order + 1, self._user_group)
@@ -276,6 +310,16 @@ class TextEntry(WidgetBase):
         self._focus = False
 
         super().__init__(x, y, width, height)
+    
+    # Override
+    @property
+    def value(self):
+        return self._doc.text
+    
+    # Override
+    @value.setter
+    def value(self, value):
+        self._doc.text = value
 
     def _check_hit(self, x, y):
         return self._x < x < self._x + self._width and self._y < y < self._y + self._height

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -54,7 +54,7 @@ class WidgetBase(EventDispatcher):
         self._height = height
         self._bg_group = None
         self._fg_group = None
-        self._enabled = True
+        self.enabled = True
 
     def update_groups(self, order):
         pass
@@ -116,22 +116,6 @@ class WidgetBase(EventDispatcher):
     @value.setter
     def value(self, value):
         raise NotImplementedError("Value depends on control type!")
-    
-    @property
-    def enabled(self):
-        """Enable or disable user interaction with this Widget.
-        
-        Subclasses should check this property before handling any events, and
-        return if it is False.
-        
-        :type: bool
-        """
-        return self._enabled
-    
-    @enabled.setter
-    def enabled(self, value):
-        assert type(value) is bool, "enabled must be True or False"
-        self._enabled = value
 
     def _check_hit(self, x, y):
         return self._x < x < self._x + self._width and self._y < y < self._y + self._height
@@ -221,34 +205,26 @@ class PushButton(WidgetBase):
         self._sprite.group = OrderedGroup(order + 1, self._user_group)
 
     def on_mouse_press(self, x, y, buttons, modifiers):
-        if not self._enabled:
-            return
-        if not self._check_hit(x, y):
+        if not self.enabled or not self._check_hit(x, y):
             return
         self._sprite.image = self._pressed_img
         self._pressed = True
         self.dispatch_event('on_press')
 
     def on_mouse_release(self, x, y, buttons, modifiers):
-        if not self._enabled:
-            return
-        if not self._pressed:
+        if not self.enabled or not self._pressed:
             return
         self._sprite.image = self._hover_img if self._check_hit(x, y) else self._depressed_img
         self._pressed = False
         self.dispatch_event('on_release')
 
     def on_mouse_motion(self, x, y, dx, dy):
-        if not self._enabled:
-            return
-        if self._pressed:
+        if not self.enabled or self._pressed:
             return
         self._sprite.image = self._hover_img if self._check_hit(x, y) else self._depressed_img
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
-        if not self._enabled:
-            return
-        if self._pressed:
+        if not self.enabled or self._pressed:
             return
         self._sprite.image = self._hover_img if self._check_hit(x, y) else self._depressed_img
 
@@ -267,18 +243,14 @@ class ToggleButton(PushButton):
         return self._hover_img if self._check_hit(x, y) else self._depressed_img
 
     def on_mouse_press(self, x, y, buttons, modifiers):
-        if not self._enabled:
-            return
-        if not self._check_hit(x, y):
+        if not self.enabled or not self._check_hit(x, y):
             return
         self._pressed = not self._pressed
         self._sprite.image = self._pressed_img if self._pressed else self._get_release_image(x, y)
         self.dispatch_event('on_toggle', self._pressed)
 
     def on_mouse_release(self, x, y, buttons, modifiers):
-        if not self._enabled:
-            return
-        if self._pressed:
+        if not self.enabled or self._pressed:
             return
         self._sprite.image = self._get_release_image(x, y)
 
@@ -372,26 +344,26 @@ class Slider(WidgetBase):
         self.dispatch_event('on_change', self._value)
 
     def on_mouse_press(self, x, y, buttons, modifiers):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._check_hit(x, y):
             self._in_update = True
             self._update_knob(x)
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._in_update:
             self._update_knob(x)
 
     def on_mouse_scroll(self, x, y, mouse, direction):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._check_hit(x, y):
             self._update_knob(self._knob_spr.x + self._half_knob_width + direction)
 
     def on_mouse_release(self, x, y, buttons, modifiers):
-        if not self._enabled:
+        if not self.enabled:
             return
         self._in_update = False
 
@@ -470,26 +442,26 @@ class TextEntry(WidgetBase):
         self._layout.group = OrderedGroup(order + 2, self._user_group)
 
     def on_mouse_motion(self, x, y, dx, dy):
-        if not self._enabled:
+        if not self.enabled:
             return
         if not self._check_hit(x, y):
             self._set_focus(False)
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._focus:
             self._caret.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
 
     def on_mouse_press(self, x, y, buttons, modifiers):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._check_hit(x, y):
             self._set_focus(True)
             self._caret.on_mouse_press(x, y, buttons, modifiers)
 
     def on_text(self, text):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._focus:
             if text in ('\r', '\n'):
@@ -499,19 +471,19 @@ class TextEntry(WidgetBase):
             self._caret.on_text(text)
 
     def on_text_motion(self, motion):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._focus:
             self._caret.on_text_motion(motion)
 
     def on_text_motion_select(self, motion):
-        if not self._enabled:
+        if not self.enabled:
             return
         if self._focus:
             self._caret.on_text_motion_select(motion)
 
     def on_commit(self, text):
-        if not self._enabled:
+        if not self.enabled:
             return
         """Text has been commited via Enter/Return key."""
 

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -54,6 +54,7 @@ class WidgetBase(EventDispatcher):
         self._height = height
         self._bg_group = None
         self._fg_group = None
+        self._enabled = True
 
     def update_groups(self, order):
         pass
@@ -115,6 +116,22 @@ class WidgetBase(EventDispatcher):
     @value.setter
     def value(self, value):
         raise NotImplementedError("Value depends on control type!")
+    
+    @property
+    def enabled(self):
+        """Enable or disable user interaction with this Widget.
+        
+        Subclasses should check this property before handling any events, and
+        return if it is False.
+        
+        :type: bool
+        """
+        return self._enabled
+    
+    @enabled.setter
+    def enabled(self, value):
+        assert type(value) is bool, "enabled must be True or False"
+        self._enabled = value
 
     def _check_hit(self, x, y):
         return self._x < x < self._x + self._width and self._y < y < self._y + self._height
@@ -204,6 +221,8 @@ class PushButton(WidgetBase):
         self._sprite.group = OrderedGroup(order + 1, self._user_group)
 
     def on_mouse_press(self, x, y, buttons, modifiers):
+        if not self._enabled:
+            return
         if not self._check_hit(x, y):
             return
         self._sprite.image = self._pressed_img
@@ -211,6 +230,8 @@ class PushButton(WidgetBase):
         self.dispatch_event('on_press')
 
     def on_mouse_release(self, x, y, buttons, modifiers):
+        if not self._enabled:
+            return
         if not self._pressed:
             return
         self._sprite.image = self._hover_img if self._check_hit(x, y) else self._depressed_img
@@ -218,11 +239,15 @@ class PushButton(WidgetBase):
         self.dispatch_event('on_release')
 
     def on_mouse_motion(self, x, y, dx, dy):
+        if not self._enabled:
+            return
         if self._pressed:
             return
         self._sprite.image = self._hover_img if self._check_hit(x, y) else self._depressed_img
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+        if not self._enabled:
+            return
         if self._pressed:
             return
         self._sprite.image = self._hover_img if self._check_hit(x, y) else self._depressed_img
@@ -242,6 +267,8 @@ class ToggleButton(PushButton):
         return self._hover_img if self._check_hit(x, y) else self._depressed_img
 
     def on_mouse_press(self, x, y, buttons, modifiers):
+        if not self._enabled:
+            return
         if not self._check_hit(x, y):
             return
         self._pressed = not self._pressed
@@ -249,6 +276,8 @@ class ToggleButton(PushButton):
         self.dispatch_event('on_toggle', self._pressed)
 
     def on_mouse_release(self, x, y, buttons, modifiers):
+        if not self._enabled:
+            return
         if self._pressed:
             return
         self._sprite.image = self._get_release_image(x, y)
@@ -343,19 +372,27 @@ class Slider(WidgetBase):
         self.dispatch_event('on_change', self._value)
 
     def on_mouse_press(self, x, y, buttons, modifiers):
+        if not self._enabled:
+            return
         if self._check_hit(x, y):
             self._in_update = True
             self._update_knob(x)
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+        if not self._enabled:
+            return
         if self._in_update:
             self._update_knob(x)
 
     def on_mouse_scroll(self, x, y, mouse, direction):
+        if not self._enabled:
+            return
         if self._check_hit(x, y):
             self._update_knob(self._knob_spr.x + self._half_knob_width + direction)
 
     def on_mouse_release(self, x, y, buttons, modifiers):
+        if not self._enabled:
+            return
         self._in_update = False
 
 
@@ -433,19 +470,27 @@ class TextEntry(WidgetBase):
         self._layout.group = OrderedGroup(order + 2, self._user_group)
 
     def on_mouse_motion(self, x, y, dx, dy):
+        if not self._enabled:
+            return
         if not self._check_hit(x, y):
             self._set_focus(False)
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+        if not self._enabled:
+            return
         if self._focus:
             self._caret.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
 
     def on_mouse_press(self, x, y, buttons, modifiers):
+        if not self._enabled:
+            return
         if self._check_hit(x, y):
             self._set_focus(True)
             self._caret.on_mouse_press(x, y, buttons, modifiers)
 
     def on_text(self, text):
+        if not self._enabled:
+            return
         if self._focus:
             if text in ('\r', '\n'):
                 self.dispatch_event('on_commit', self._layout.document.text)
@@ -454,14 +499,20 @@ class TextEntry(WidgetBase):
             self._caret.on_text(text)
 
     def on_text_motion(self, motion):
+        if not self._enabled:
+            return
         if self._focus:
             self._caret.on_text_motion(motion)
 
     def on_text_motion_select(self, motion):
+        if not self._enabled:
+            return
         if self._focus:
             self._caret.on_text_motion_select(motion)
 
     def on_commit(self, text):
+        if not self._enabled:
+            return
         """Text has been commited via Enter/Return key."""
 
 

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -73,12 +73,17 @@ class WidgetBase(EventDispatcher):
     @property
     def aabb(self):
         return self._x, self._y, self._x + self._width, self._y + self._height
-    
-    # The value property should be overridden in such a way that the widget
-    # can be 'activated' or changed without requiring user input.
-    # The normal events for control activation should NOT be triggered.
+
     @property
     def value(self):
+        """Query or set the Widget's value.
+        
+        This property allows you to set the value of a Widget directly, without any
+        user input.  This could be used, for example, to restore Widgets to a
+        previous state, or if some event in your program is meant to naturally
+        change the same value that the Widget controls.  Note that events are not
+        dispatched when changing this property.
+        """
         raise NotImplementedError("Value depends on control type!")
     
     @value.setter
@@ -136,14 +141,13 @@ class PushButton(WidgetBase):
 
         self._pressed = False
 
-    # Override
     @property
     def value(self):
         return self._pressed
     
-    # Override
     @value.setter
     def value(self, value):
+        assert type(value) is bool, "This Widget's value must be True or False."
         self._pressed = value
         self._sprite.image = self._pressed_img if self._pressed else self._depressed_img
 
@@ -222,15 +226,14 @@ class Slider(WidgetBase):
 
         self._value = 0
         self._in_update = False
-    
-    # Override
+
     @property
     def value(self):
         return self._value
-    
-    # Override
+
     @value.setter
     def value(self, value):
+        assert type(value) in (int, float), "This Widget's value must be an int or float."
         self._value = value
         x = (self._max_knob_x - self._min_knob_x) * value / 100 + self._min_knob_x + self._half_knob_width
         self._knob_spr.x = max(self._min_knob_x, min(x - self._half_knob_width, self._max_knob_x))
@@ -310,15 +313,14 @@ class TextEntry(WidgetBase):
         self._focus = False
 
         super().__init__(x, y, width, height)
-    
-    # Override
+
     @property
     def value(self):
         return self._doc.text
-    
-    # Override
+
     @value.setter
     def value(self, value):
+        assert type(value) is str, "This Widget's value must be a string."
         self._doc.text = value
 
     def _check_hit(self, x, y):


### PR DESCRIPTION
Per discussion in [issue 408](https://github.com/pyglet/pyglet/issues/408) and [pull request 410](https://github.com/pyglet/pyglet/pull/410), added the ability to enable and disable pyglet.gui Widgets.  The base class only has a new variable, `_enabled`, and a new property, `enabled`.  The subclasses all honor this property by checking it at the start of event handlers and returning if it is False.

Something I've noticed while looking at this PR's commits is that it has the commits from the last PR, then the re-merge I did, then the actual new commit.  Is that a problem?  Is there a better way to go about this so that those old commits don't show up in PR?  I can create a new PR if needed.