### PR TITLE
Added support for horizontal scrolling using xlib

### DIFF
--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -1464,6 +1464,10 @@ class XlibWindow(BaseWindow):
                 self.dispatch_event('on_mouse_scroll', x, y, 0, 1)
             elif ev.xbutton.button == 5:
                 self.dispatch_event('on_mouse_scroll', x, y, 0, -1)
+            elif ev.xbutton.button == 6:
+                self.dispatch_event('on_mouse_scroll', x, y, -1, 0)
+            elif ev.xbutton.button == 7:
+                self.dispatch_event('on_mouse_scroll', x, y, 1, 0)
             elif ev.xbutton.button < len(self._mouse_buttons):
                 self._mouse_buttons[ev.xbutton.button] = True
                 self.dispatch_event('on_mouse_press', x, y, button, modifiers)


### PR DESCRIPTION
I noticed horizontal scrolling was not generating any events for me within pyglet on my installation of Debian Buster using the Synaptic Touchpad driver using a Macbook 2015 with a Broadcom Touchpad. 

After enabling horizontal scrolling in xorg-conf, I found that scrolling worked in firefox but not my pyglet application. Using xev to test, I discovered that touchpad scrolling was generating button events, two of which are handled already in pyglet: scrolling up (button 4) and scrolling down (button 5). After adding two more cases for both horizontal directions, it is working fine. (button 6 = left scroll, button=7 right scroll)