### PR TITLE
cocoa: set internal window size in setFramSize

### DIFF
--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -179,6 +179,7 @@ class PygletView_Implementation:
         width, height = int(size.width), int(size.height)
         self._window.switch_to()
         self._window.context.update_geometry()
+        self._window._width, self._window._height = width, height
         self._window.dispatch_event("on_resize", width, height)
         self._window.dispatch_event("on_expose")
         # Can't get app.event_loop.enter_blocking() working with Cocoa, because


### PR DESCRIPTION
#340 broke window size for the cocoa window since the custom `get_size()` was removed and nothing was added to update the internal `width` and `height` values in the `BaseWindow`.

I'm not sure if this is the right way to go, but at least it's somewhat similar to win32 version except that we're not querying the real surface size. Can look into that but just wanted a branch with a fix to get this started because it's a blocker for arcade 2.6.