### PR TITLE
Missing pyglet in argument line

### DIFF
--- a/doc/programming_guide/windowing.rst
+++ b/doc/programming_guide/windowing.rst
@@ -210,7 +210,7 @@ You can specify the style of the window in the
 :py:class:`~pyglet.window.Window` constructor.
 Once created, the window style cannot be altered::
 
-    window = pyglet.window.Window(style=window.Window.WINDOW_STYLE_DIALOG)
+    window = pyglet.window.Window(style=pyglet.window.Window.WINDOW_STYLE_DIALOG)
 
 Caption
 ^^^^^^^


### PR DESCRIPTION
line 213     window = pyglet.window.Window(style=window.Window.WINDOW_STYLE_DIALOG) results in "NameError: name 'window' is not defined"