### PR TITLE
Suppress errors when gl resources are deleted

### DIFF
--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -229,7 +229,7 @@ class Shader:
             glDeleteShader(self._id)
             if _debug_gl_shaders:
                 print(f"Destroyed {self.type} Shader '{self._id}'")
-        except (ImportError, AttributeError, ArgumentError):
+        except Exception:
             # Interpreter is shutting down,
             # or Shader failed to compile.
             pass
@@ -331,7 +331,7 @@ class ShaderProgram:
     def __del__(self):
         try:
             glDeleteProgram(self._id)
-        except (ImportError, AttributeError, GLException):
+        except Exception:
             # Interpreter is shutting down,
             # or ShaderProgram failed to link.
             pass

--- a/pyglet/graphics/vertexarray.py
+++ b/pyglet/graphics/vertexarray.py
@@ -62,7 +62,10 @@ class VertexArray:
         glBindVertexArray(0)
 
     def delete(self):
-        glDeleteVertexArrays(1, self._id)
+        try:
+            glDeleteVertexArrays(1, self._id)
+        except Exception:
+            pass
 
     __enter__ = bind
 

--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -244,7 +244,10 @@ class BufferObject(AbstractBuffer):
 
     def delete(self):
         buffer_id = GLuint(self.id)
-        glDeleteBuffers(1, buffer_id)
+        try:
+            glDeleteBuffers(1, buffer_id)
+        except Exception:
+            pass
         self.id = None
 
     def resize(self, size):

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1318,7 +1318,7 @@ class Texture(AbstractImage):
     def __del__(self):
         try:
             self._context.delete_texture(self.id)
-        except:
+        except Exception:
             pass
 
     @classmethod

--- a/pyglet/image/buffer.py
+++ b/pyglet/image/buffer.py
@@ -88,7 +88,7 @@ class Renderbuffer:
         try:
             glDeleteRenderbuffers(1, self._id)
         # Python interpreter is shutting down:
-        except ImportError:
+        except Exception:
             pass
 
     def __repr__(self):
@@ -139,7 +139,10 @@ class Framebuffer:
             self.unbind()
 
     def delete(self):
-        glDeleteFramebuffers(1, self._id)
+        try:
+            glDeleteFramebuffers(1, self._id)
+        except Exception:
+            pass
 
     @property
     def is_complete(self):
@@ -238,7 +241,7 @@ class Framebuffer:
         try:
             glDeleteFramebuffers(1, self._id)
         # Python interpreter is shutting down:
-        except ImportError:
+        except Exception:
             pass
 
     def __repr__(self):


### PR DESCRIPTION
When not using a shadow context we'll get pages errors when the window is destroyed.

I'm not sure if this is the safest option, but possibly an acceptable solution for now.