### PR TITLE
Fix duplicate screens in get_modes()

### DIFF
--- a/pyglet/canvas/win32.py
+++ b/pyglet/canvas/win32.py
@@ -129,7 +129,12 @@ class Win32ScreenMode(ScreenMode):
         self.height = mode.dmPelsHeight
         self.depth = mode.dmBitsPerPel
         self.rate = mode.dmDisplayFrequency
+        self.scaling = mode.dmDisplayFixedOutput
 
+    def __repr__(self):
+        return '%s(width=%r, height=%r, depth=%r, rate=%r, scaling=%r)' % (
+            self.__class__.__name__,
+            self.width, self.height, self.depth, self.rate, self.scaling)
 
 class Win32Canvas(Canvas):
     def __init__(self, display, hwnd, hdc):

--- a/pyglet/libs/win32/types.py
+++ b/pyglet/libs/win32/types.py
@@ -334,15 +334,8 @@ class MONITORINFOEX(Structure):
     __slots__ = [f[0] for f in _fields_]
 
 
-class DEVMODE(Structure):
+class _DUMMYSTRUCTNAME(Structure):
     _fields_ = [
-        ('dmDeviceName', BCHAR * CCHDEVICENAME),
-        ('dmSpecVersion', WORD),
-        ('dmDriverVersion', WORD),
-        ('dmSize', WORD),
-        ('dmDriverExtra', WORD),
-        ('dmFields', DWORD),
-        # Just using largest union member here
         ('dmOrientation', c_short),
         ('dmPaperSize', c_short),
         ('dmPaperLength', c_short),
@@ -351,6 +344,34 @@ class DEVMODE(Structure):
         ('dmCopies', c_short),
         ('dmDefaultSource', c_short),
         ('dmPrintQuality', c_short),
+    ]
+
+class _DUMMYSTRUCTNAME2(Structure):
+    _fields_ = [
+        ('dmPosition', POINTL),
+        ('dmDisplayOrientation', DWORD),
+        ('dmDisplayFixedOutput', DWORD)
+    ]
+
+class _DUMMYDEVUNION(Union):
+    _anonymous_ = ('_dummystruct1', '_dummystruct2')
+    _fields_ = [
+        ('_dummystruct1', _DUMMYSTRUCTNAME),
+        ('dmPosition', POINTL),
+        ('_dummystruct2', _DUMMYSTRUCTNAME2),
+    ]
+
+class DEVMODE(Structure):
+    _anonymous_ = ('_dummyUnion',)
+    _fields_ = [
+        ('dmDeviceName', BCHAR * CCHDEVICENAME),
+        ('dmSpecVersion', WORD),
+        ('dmDriverVersion', WORD),
+        ('dmSize', WORD),
+        ('dmDriverExtra', WORD),
+        ('dmFields', DWORD),
+        # Just using largest union member here
+        ('_dummyUnion', _DUMMYDEVUNION),
         # End union
         ('dmColor', c_short),
         ('dmDuplex', c_short),


### PR DESCRIPTION
Test script to get available screen modes using Pyglet:

```
import pyglet
from operator import attrgetter

display = pyglet.canvas.get_display()
screen = display.get_default_screen()

modes = list(reversed(sorted(screen.get_modes(), key=attrgetter('width'))))

print(modes)
```

My result is this:
```
[Win32ScreenMode(width=1920, height=1080, depth=32, rate=60), Win32ScreenMode(width=1920, height=1080, depth=32, rate=48), Win32ScreenMode(width=1680, height=1050, depth=32, rate=60), Win32ScreenMode(width=1680, height=1050, depth=32, rate=60), Win32ScreenMode(width=1680, height=1050, depth=32, rate=60), Win32ScreenMode(width=1680, height=1050, depth=32, rate=48), Win32ScreenMode(width=1680, height=1050, depth=32, rate=48), Win32ScreenMode(width=1680, height=1050, depth=32, rate=48), Win32ScreenMode(width=1600, height=900, depth=32, rate=60), Win32ScreenMode(width=1600, height=900, depth=32, rate=60), Win32ScreenMode(width=1600, height=900, depth=32, rate=60), Win32ScreenMode(width=1600, height=900, depth=32, rate=48), Win32ScreenMode(width=1600, height=900, depth=32, rate=48), Win32ScreenMode(width=1600, height=900, depth=32, rate=48), Win32ScreenMode(width=1440, height=900, depth=32, rate=60), Win32ScreenMode(width=1440, height=900, depth=32, rate=60), Win32ScreenMode(width=1440, height=900, depth=32, rate=60), Win32ScreenMode(width=1440, height=900, depth=32, rate=48), Win32ScreenMode(width=1440, height=900, depth=32, rate=48), Win32ScreenMode(width=1440, height=900, depth=32, rate=48), Win32ScreenMode(width=1400, height=1050, depth=32, rate=60), Win32ScreenMode(width=1400, height=1050, depth=32, rate=60), Win32ScreenMode(width=1400, height=1050, depth=32, rate=60), Win32ScreenMode(width=1400, height=1050, depth=32, rate=48), Win32ScreenMode(width=1400, height=1050, depth=32, rate=48), Win32ScreenMode(width=1400, height=1050, depth=32, rate=48), Win32ScreenMode(width=1366, height=768, depth=32, rate=60), Win32ScreenMode(width=1366, height=768, depth=32, rate=60), Win32ScreenMode(width=1366, height=768, depth=32, rate=60), Win32ScreenMode(width=1366, height=768, depth=32, rate=48), Win32ScreenMode(width=1366, height=768, depth=32, rate=48), Win32ScreenMode(width=1366, height=768, depth=32, rate=48), Win32ScreenMode(width=1360, height=768, depth=32, rate=60), Win32ScreenMode(width=1360, height=768, depth=32, rate=60), Win32ScreenMode(width=1360, height=768, depth=32, rate=60), Win32ScreenMode(width=1360, height=768, depth=32, rate=48), Win32ScreenMode(width=1360, height=768, depth=32, rate=48), Win32ScreenMode(width=1360, height=768, depth=32, rate=48), Win32ScreenMode(width=1280, height=1024, depth=32, rate=60), Win32ScreenMode(width=1280, height=1024, depth=32, rate=60), Win32ScreenMode(width=1280, height=1024, depth=32, rate=60), Win32ScreenMode(width=1280, height=1024, depth=32, rate=48), Win32ScreenMode(width=1280, height=1024, depth=32, rate=48), Win32ScreenMode(width=1280, height=1024, depth=32, rate=48), Win32ScreenMode(width=1280, height=960, depth=32, rate=60), Win32ScreenMode(width=1280, height=960, depth=32, rate=60), Win32ScreenMode(width=1280, height=960, depth=32, rate=60), Win32ScreenMode(width=1280, height=960, depth=32, rate=48), Win32ScreenMode(width=1280, height=960, depth=32, rate=48), Win32ScreenMode(width=1280, height=960, depth=32, rate=48), Win32ScreenMode(width=1280, height=800, depth=32, rate=60), Win32ScreenMode(width=1280, height=800, depth=32, rate=60), Win32ScreenMode(width=1280, height=800, depth=32, rate=60), Win32ScreenMode(width=1280, height=800, depth=32, rate=48), Win32ScreenMode(width=1280, height=800, depth=32, rate=48), Win32ScreenMode(width=1280, height=800, depth=32, rate=48), Win32ScreenMode(width=1280, height=768, depth=32, rate=60), Win32ScreenMode(width=1280, height=768, depth=32, rate=60), Win32ScreenMode(width=1280, height=768, depth=32, rate=60), Win32ScreenMode(width=1280, height=768, depth=32, rate=48), Win32ScreenMode(width=1280, height=768, depth=32, rate=48), Win32ScreenMode(width=1280, height=768, depth=32, rate=48), Win32ScreenMode(width=1280, height=720, depth=32, rate=60), Win32ScreenMode(width=1280, height=720, depth=32, rate=60), Win32ScreenMode(width=1280, height=720, depth=32, rate=60), Win32ScreenMode(width=1280, height=720, depth=32, rate=48), Win32ScreenMode(width=1280, height=720, depth=32, rate=48), Win32ScreenMode(width=1280, height=720, depth=32, rate=48), Win32ScreenMode(width=1280, height=600, depth=32, rate=60), Win32ScreenMode(width=1280, height=600, depth=32, rate=60), Win32ScreenMode(width=1280, height=600, depth=32, rate=60), Win32ScreenMode(width=1280, height=600, depth=32, rate=48), Win32ScreenMode(width=1280, height=600, depth=32, rate=48), Win32ScreenMode(width=1280, height=600, depth=32, rate=48), Win32ScreenMode(width=1152, height=864, depth=32, rate=60), Win32ScreenMode(width=1152, height=864, depth=32, rate=60), Win32ScreenMode(width=1152, height=864, depth=32, rate=60), Win32ScreenMode(width=1152, height=864, depth=32, rate=48), Win32ScreenMode(width=1152, height=864, depth=32, rate=48), Win32ScreenMode(width=1152, height=864, depth=32, rate=48), Win32ScreenMode(width=1024, height=768, depth=32, rate=60), Win32ScreenMode(width=1024, height=768, depth=32, rate=60), Win32ScreenMode(width=1024, height=768, depth=32, rate=60), Win32ScreenMode(width=1024, height=768, depth=32, rate=48), Win32ScreenMode(width=1024, height=768, depth=32, rate=48), Win32ScreenMode(width=1024, height=768, depth=32, rate=48), Win32ScreenMode(width=800, height=600, depth=32, rate=60), Win32ScreenMode(width=800, height=600, depth=32, rate=60), Win32ScreenMode(width=800, height=600, depth=32, rate=60), Win32ScreenMode(width=800, height=600, depth=32, rate=48), Win32ScreenMode(width=800, height=600, depth=32, rate=48), Win32ScreenMode(width=800, height=600, depth=32, rate=48), Win32ScreenMode(width=640, height=480, depth=32, rate=60), Win32ScreenMode(width=640, height=480, depth=32, rate=60), Win32ScreenMode(width=640, height=480, depth=32, rate=60), Win32ScreenMode(width=640, height=480, depth=32, rate=48), Win32ScreenMode(width=640, height=480, depth=32, rate=48), Win32ScreenMode(width=640, height=480, depth=32, rate=48), Win32ScreenMode(width=640, height=400, depth=32, rate=60), Win32ScreenMode(width=640, height=400, depth=32, rate=60), Win32ScreenMode(width=640, height=400, depth=32, rate=60), Win32ScreenMode(width=640, height=400, depth=32, rate=48), Win32ScreenMode(width=640, height=400, depth=32, rate=48), Win32ScreenMode(width=640, height=400, depth=32, rate=48), Win32ScreenMode(width=512, height=384, depth=32, rate=60), Win32ScreenMode(width=512, height=384, depth=32, rate=60), Win32ScreenMode(width=512, height=384, depth=32, rate=60), Win32ScreenMode(width=512, height=384, depth=32, rate=48), Win32ScreenMode(width=512, height=384, depth=32, rate=48), Win32ScreenMode(width=512, height=384, depth=32, rate=48), Win32ScreenMode(width=400, height=300, depth=32, rate=60), Win32ScreenMode(width=400, height=300, depth=32, rate=60), Win32ScreenMode(width=400, height=300, depth=32, rate=60), Win32ScreenMode(width=400, height=300, depth=32, rate=48), Win32ScreenMode(width=400, height=300, depth=32, rate=48), Win32ScreenMode(width=400, height=300, depth=32, rate=48), Win32ScreenMode(width=320, height=240, depth=32, rate=60), Win32ScreenMode(width=320, height=240, depth=32, rate=60), Win32ScreenMode(width=320, height=240, depth=32, rate=60), Win32ScreenMode(width=320, height=240, depth=32, rate=48), Win32ScreenMode(width=320, height=240, depth=32, rate=48), Win32ScreenMode(width=320, height=240, depth=32, rate=48), Win32ScreenMode(width=320, height=200, depth=32, rate=60), Win32ScreenMode(width=320, height=200, depth=32, rate=60), Win32ScreenMode(width=320, height=200, depth=32, rate=60), Win32ScreenMode(width=320, height=200, depth=32, rate=48), Win32ScreenMode(width=320, height=200, depth=32, rate=48), Win32ScreenMode(width=320, height=200, depth=32, rate=48)]
```

If you look closely you will see A LOT of duplicates for some reason, up to 3. 

If you search `Win32ScreenMode(width=1680, height=1050, depth=32, rate=60)` you will see 3 popup with no rhyme or reason as to what they are. This makes it annoying to actually know what *are* these other modes, or why are there duplicates? After some research these are extra scaling modes.

After this fix it will now let you see which are actually different. 
```
[Win32ScreenMode(width=1920, height=1080, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1920, height=1080, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1680, height=1050, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1680, height=1050, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1680, height=1050, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1680, height=1050, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1680, height=1050, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1680, height=1050, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1600, height=900, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1600, height=900, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1600, height=900, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1600, height=900, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1600, height=900, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1600, height=900, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1440, height=900, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1440, height=900, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1440, height=900, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1440, height=900, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1440, height=900, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1440, height=900, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1400, height=1050, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1400, height=1050, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1400, height=1050, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1400, height=1050, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1400, height=1050, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1400, height=1050, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1366, height=768, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1366, height=768, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1366, height=768, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1366, height=768, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1366, height=768, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1366, height=768, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1360, height=768, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1360, height=768, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1360, height=768, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1360, height=768, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1360, height=768, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1360, height=768, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1280, height=1024, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1280, height=1024, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1280, height=1024, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1280, height=1024, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1280, height=1024, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1280, height=1024, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1280, height=960, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1280, height=960, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1280, height=960, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1280, height=960, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1280, height=960, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1280, height=960, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1280, height=800, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1280, height=800, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1280, height=800, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1280, height=800, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1280, height=800, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1280, height=800, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1280, height=768, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1280, height=768, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1280, height=768, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1280, height=768, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1280, height=768, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1280, height=768, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1280, height=720, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1280, height=720, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1280, height=720, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1280, height=720, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1280, height=720, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1280, height=720, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1280, height=600, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1280, height=600, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1280, height=600, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1280, height=600, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1280, height=600, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1280, height=600, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1152, height=864, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1152, height=864, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1152, height=864, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1152, height=864, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1152, height=864, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1152, height=864, depth=32, rate=48, scaling=0), Win32ScreenMode(width=1024, height=768, depth=32, rate=60, scaling=2), Win32ScreenMode(width=1024, height=768, depth=32, rate=60, scaling=1), Win32ScreenMode(width=1024, height=768, depth=32, rate=60, scaling=0), Win32ScreenMode(width=1024, height=768, depth=32, rate=48, scaling=2), Win32ScreenMode(width=1024, height=768, depth=32, rate=48, scaling=1), Win32ScreenMode(width=1024, height=768, depth=32, rate=48, scaling=0), Win32ScreenMode(width=800, height=600, depth=32, rate=60, scaling=2), Win32ScreenMode(width=800, height=600, depth=32, rate=60, scaling=1), Win32ScreenMode(width=800, height=600, depth=32, rate=60, scaling=0), Win32ScreenMode(width=800, height=600, depth=32, rate=48, scaling=2), Win32ScreenMode(width=800, height=600, depth=32, rate=48, scaling=1), Win32ScreenMode(width=800, height=600, depth=32, rate=48, scaling=0), Win32ScreenMode(width=640, height=480, depth=32, rate=60, scaling=2), Win32ScreenMode(width=640, height=480, depth=32, rate=60, scaling=1), Win32ScreenMode(width=640, height=480, depth=32, rate=60, scaling=0), Win32ScreenMode(width=640, height=480, depth=32, rate=48, scaling=2), Win32ScreenMode(width=640, height=480, depth=32, rate=48, scaling=1), Win32ScreenMode(width=640, height=480, depth=32, rate=48, scaling=0), Win32ScreenMode(width=640, height=400, depth=32, rate=60, scaling=2), Win32ScreenMode(width=640, height=400, depth=32, rate=60, scaling=1), Win32ScreenMode(width=640, height=400, depth=32, rate=60, scaling=0), Win32ScreenMode(width=640, height=400, depth=32, rate=48, scaling=2), Win32ScreenMode(width=640, height=400, depth=32, rate=48, scaling=1), Win32ScreenMode(width=640, height=400, depth=32, rate=48, scaling=0), Win32ScreenMode(width=512, height=384, depth=32, rate=60, scaling=2), Win32ScreenMode(width=512, height=384, depth=32, rate=60, scaling=1), Win32ScreenMode(width=512, height=384, depth=32, rate=60, scaling=0), Win32ScreenMode(width=512, height=384, depth=32, rate=48, scaling=2), Win32ScreenMode(width=512, height=384, depth=32, rate=48, scaling=1), Win32ScreenMode(width=512, height=384, depth=32, rate=48, scaling=0), Win32ScreenMode(width=400, height=300, depth=32, rate=60, scaling=2), Win32ScreenMode(width=400, height=300, depth=32, rate=60, scaling=1), Win32ScreenMode(width=400, height=300, depth=32, rate=60, scaling=0), Win32ScreenMode(width=400, height=300, depth=32, rate=48, scaling=2), Win32ScreenMode(width=400, height=300, depth=32, rate=48, scaling=1), Win32ScreenMode(width=400, height=300, depth=32, rate=48, scaling=0), Win32ScreenMode(width=320, height=240, depth=32, rate=60, scaling=2), Win32ScreenMode(width=320, height=240, depth=32, rate=60, scaling=1), Win32ScreenMode(width=320, height=240, depth=32, rate=60, scaling=0), Win32ScreenMode(width=320, height=240, depth=32, rate=48, scaling=2), Win32ScreenMode(width=320, height=240, depth=32, rate=48, scaling=1), Win32ScreenMode(width=320, height=240, depth=32, rate=48, scaling=0), Win32ScreenMode(width=320, height=200, depth=32, rate=60, scaling=2), Win32ScreenMode(width=320, height=200, depth=32, rate=60, scaling=1), Win32ScreenMode(width=320, height=200, depth=32, rate=60, scaling=0), Win32ScreenMode(width=320, height=200, depth=32, rate=48, scaling=2), Win32ScreenMode(width=320, height=200, depth=32, rate=48, scaling=1), Win32ScreenMode(width=320, height=200, depth=32, rate=48, scaling=0)]
```

Now if you search `Win32ScreenMode(width=1680, height=1050, depth=32, rate=60` you can see which modes are which.

I don't know if other platforms have this, but something to look into. 

The modes are: 0 = Default, 1 = Centered, 2 = Stretched.