### PR TITLE
Fix shared context issue with Intel GPU

### DIFF
--- a/pyglet/gl/__init__.py
+++ b/pyglet/gl/__init__.py
@@ -188,7 +188,16 @@ def _create_shadow_window():
         return
 
     from pyglet.window import Window
-    _shadow_window = Window(width=1, height=1, visible=False)
+
+    class ShadowWindow(Window):
+        def __init__(self):
+            super().__init__(width=1, height=1, visible=False)
+
+        def _create_projection(self):
+            """Shadow window does not need a projection."""
+            pass
+
+    _shadow_window = ShadowWindow()
     _shadow_window.switch_to()
 
     from pyglet import app

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -594,13 +594,16 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
             self.set_visible(True)
             self.activate()
 
+        self._create_projection()
+
+    def _create_projection(self):
         self._default_program = shader.ShaderProgram(shader.Shader(self._default_vertex_source, 'vertex'))
         self.ubo = self._default_program.uniform_blocks['WindowBlock'].create_ubo()
 
         self.view = pyglet.math.Mat4()
 
         self._viewport = 0, 0, *self.get_framebuffer_size()
-        self.projection = Mat4.orthogonal_projection(0, width, 0, height, -255, 255)
+        self.projection = Mat4.orthogonal_projection(0, self._width, 0, self._height, -255, 255)
 
     def __del__(self):
         # Always try to clean up the window when it is dereferenced.


### PR DESCRIPTION
With the latest master branch I get the following issue with my integrated Intel GPU: `pyglet.gl.ContextException: Unable to share contexts.`

After reading up on `wglShareLists` it says it's highly likely it will fail if you try to do any sort of OpenGL calls before hand. So I did a debug and saw that we are making a shader and uniform block for the projection... including the shadow window as well. Once I cleared that up, it worked fine. 

Below is my solution to fix the issue. Let me know what you think and make sure this fix works for the other OS's.