### PR TITLE
Add get_data_path to resource

### DIFF
--- a/pyglet/resource.py
+++ b/pyglet/resource.py
@@ -232,7 +232,7 @@ def get_data_path(name):
         if 'XDG_DATA_HOME' in os.environ:
             return os.path.join(os.environ['XDG_DATA_HOME'], name)
         else:
-            return os.path.expanduser('~/.config/share/%s' % name)
+            return os.path.expanduser('~/.local/share/%s' % name)
     else:
         return os.path.expanduser('~/.%s' % name)
 

--- a/pyglet/resource.py
+++ b/pyglet/resource.py
@@ -196,6 +196,47 @@ def get_settings_path(name):
         return os.path.expanduser('~/.%s' % name)
 
 
+def get_data_path(name):
+    """Get a directory to save user data.
+
+    For a Posix or Linux based system many distributions have a separate
+    directory to store user data for a specific application and this 
+    function returns the path to that location.  Note that the returned 
+    path may not exist: applications should use ``os.makedirs`` to 
+    construct it if desired.
+
+    On Linux, a directory `name` in the user's data directory is returned 
+    (usually under ``~/.local/share``).
+
+    On Windows (including under Cygwin) the `name` directory in the user's
+    ``Application Settings`` directory is returned.
+
+    On Mac OS X the `name` directory under ``~/Library/Application Support``
+    is returned.
+
+    :Parameters:
+        `name` : str
+            The name of the application.
+
+    :rtype: str
+    """
+
+    if pyglet.compat_platform in ('cygwin', 'win32'):
+        if 'APPDATA' in os.environ:
+            return os.path.join(os.environ['APPDATA'], name)
+        else:
+            return os.path.expanduser('~/%s' % name)
+    elif pyglet.compat_platform == 'darwin':
+        return os.path.expanduser('~/Library/Application Support/%s' % name)
+    elif pyglet.compat_platform.startswith('linux'):
+        if 'XDG_DATA_HOME' in os.environ:
+            return os.path.join(os.environ['XDG_DATA_HOME'], name)
+        else:
+            return os.path.expanduser('~/.config/share/%s' % name)
+    else:
+        return os.path.expanduser('~/.%s' % name)
+
+
 class Location:
     """Abstract resource location.
 

--- a/pyglet/text/layout.py
+++ b/pyglet/text/layout.py
@@ -562,7 +562,7 @@ layout_fragment_source = """#version 330 core
 
     void main()
     {   
-        final_colors = vec4(text_colors.rgb, texture(text, texture_coords).a);
+        final_colors = vec4(text_colors.rgb, texture(text, texture_coords).a * text_colors.a);
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom


### PR DESCRIPTION
For linux and posix type systems that follow the following specification there is a separate data directory for an application under XDG_DATA_HOME or if the user or system admin has not set the environment variable the location is set to "./local/share/Application-Name"  the added function returns that name to the caller.  For non-linux system platforms I used the same directories returned by get_settings_path as I do not own or know those platforms, but I figure that anyone who uses this path will know what they need it for.

https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html