### PR TITLE
Fix some blending and alpha issues

### DIFF
--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1303,6 +1303,7 @@ class Texture(AbstractImage):
     region_class = None  # Set to TextureRegion after it's defined
     tex_coords = (0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0)
     tex_coords_order = (0, 1, 2, 3)
+    colors = (0, 0, 0, 0) * 4
     level = 0
     images = 1
     x = y = z = 0
@@ -1421,7 +1422,8 @@ class Texture(AbstractImage):
 
         pyglet.graphics.draw_indexed(4, GL_TRIANGLES, [0, 1, 2, 0, 2, 3],
                                      ('position3f', vertices),
-                                     ('tex_coords3f', self.tex_coords))
+                                     ('tex_coords3f', self.tex_coords),
+                                     ('colors4Bn', self.colors))
 
         glBindTexture(self.target, 0)
 

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -235,7 +235,10 @@ class ImageMouseCursor(MouseCursor):
         self.hw_drawable = acceleration
 
     def draw(self, x, y):
+        gl.glEnable(gl.GL_BLEND)
+        gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
         self.texture.blit(x - self.hot_x, y - self.hot_y, 0)
+        gl.glDisable(gl.GL_BLEND)
 
 
 def _PlatformEventHandler(data):


### PR DESCRIPTION
Fix blit attribute data not having a default color attached causing alpha to be white (since the default shader adds the colors)
Add blending for ImageMouseCursor.