### PR TITLE
Properly implement ffmpeg file-like loading.

### DIFF
--- a/pyglet/media/codecs/ffmpeg_lib/libavformat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavformat.py
@@ -54,6 +54,8 @@ AVSEEK_FLAG_BACKWARD = 1  # ///< seek backward
 AVSEEK_FLAG_BYTE = 2  # ///< seeking based on position in bytes
 AVSEEK_FLAG_ANY = 4  # ///< seek to any frame, even non-keyframes
 AVSEEK_FLAG_FRAME = 8  # ///< seeking based on frame number
+AVSEEK_SIZE = 0x10000
+AVFMT_FLAG_CUSTOM_IO = 0x0080
 
 MAX_REORDER_DELAY = 16
 
@@ -334,6 +336,19 @@ avformat.avformat_seek_file.argtypes = [POINTER(AVFormatContext),
 avformat.av_guess_frame_rate.restype = AVRational
 avformat.av_guess_frame_rate.argtypes = [POINTER(AVFormatContext),
                                          POINTER(AVStream), POINTER(AVFrame)]
+
+ffmpeg_read_func = CFUNCTYPE(c_int, c_void_p, POINTER(c_char), c_int)
+ffmpeg_write_func = CFUNCTYPE(c_int, c_void_p, POINTER(c_char), c_int)
+ffmpeg_seek_func = CFUNCTYPE(c_int64, c_void_p, c_int64, c_int)
+
+avformat.avio_alloc_context.restype = POINTER(AVIOContext)
+avformat.avio_alloc_context.argtypes = [c_char_p, c_int, c_int, c_void_p, ffmpeg_read_func, c_void_p, ffmpeg_seek_func]
+
+avformat.avformat_alloc_context.restype = POINTER(AVFormatContext)
+avformat.avformat_alloc_context.argtypes = []
+
+avformat.avformat_free_context.restype = c_void_p
+avformat.avformat_free_context.argtypes = [POINTER(AVFormatContext)]
 
 __all__ = [
     'avformat',

--- a/pyglet/media/codecs/ffmpeg_lib/libavutil.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavutil.py
@@ -214,6 +214,10 @@ avutil.av_dict_set.argtypes = [POINTER(POINTER(AVDictionary)),
 avutil.av_dict_free.argtypes = [POINTER(POINTER(AVDictionary))]
 avutil.av_log_set_level.restype = c_int
 avutil.av_log_set_level.argtypes = [c_uint]
+avutil.av_malloc.restype = c_void_p
+avutil.av_malloc.argtypes = [c_int]
+avutil.av_freep.restype = c_void_p
+avutil.av_freep.argtypes = [c_void_p]
 
 __all__ = [
     'avutil',


### PR DESCRIPTION
Remove temporary files for playing file-object files.
Temporary files have issues with certain OS's and was just a quick fix to get it working.

This properly implements loading sources from memory, utilizing ctypes callbacks to properly play them. Uses python to seek and read the file objects.