### PR TITLE
Fix synthesis test on big endian architectures

### DIFF
--- a/tests/unit/media/test_synthesis.py
+++ b/tests/unit/media/test_synthesis.py
@@ -1,6 +1,7 @@
 from ctypes import sizeof
 from io import BytesIO
 import unittest
+import wave
 
 from pyglet.media.synthesis import *
 
@@ -65,9 +66,8 @@ class SynthesisSourceTest:
         source_name = self.source_class.__name__.lower()
         filename = "synthesis_{0}_{1}_{2}_1ch.wav".format(source_name, sample_size, sample_rate)
 
-        with open(get_test_data_file('media', filename), 'rb') as f:
-            # discard the wave header:
-            loaded_bytes = f.read()[44:]
+        with wave.open(get_test_data_file('media', filename)) as f:
+            loaded_bytes = f.readframes(-1)
             source.seek(0)
             generated_data = source.get_audio_data(source._max_offset)
             bytes_buffer = BytesIO(generated_data.data).getvalue()


### PR DESCRIPTION
I would like to revive issue https://github.com/pyglet/pyglet/issues/278.  I maintain the sympy package for Fedora, and it depends on pyglet, so I would like to fix the endianness issue so we can have sympy on s390x.  The WAV RIFF format is little endian:

- https://stackoverflow.com/questions/1111539/is-the-endianness-of-format-params-guaranteed-in-riff-wav-files
- https://en.wikipedia.org/wiki/Resource_Interchange_File_Format

That means that the test files are correct, and it is the unit tests that need adjusting.  I do not have physical access to an s390x machine, so I cannot test by listening, but I do have shell access to such a machine.  I ran flac over the test WAV files on the s390x.  The flac binary ran without error.  I copied the FLAC output files to an x86_64 machine, then played each original WAV file followed immediately by the corresponding FLAC file.  They sounded the same.  This lends further support to the theory that the WAV files are correct.

Python's WAV encoder swaps bytes if the sample width is greater than 1 and the machine is big endian.  The problem here is that the unit test does not use the WAV encoder, but examines the bytes that would have been fed to it; i.e., they are in host order.  This commit is one way of dealing with the issue.
