### PR TITLE
Fixing shift and exclusive mouse mode

### DIFF
--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -106,6 +106,8 @@ class Win32Window(BaseWindow):
     _exclusive_mouse_lpos = None
     _exclusive_mouse_buttons = 0
     _mouse_platform_visible = True
+    _pending_click = False
+    _in_title_bar = False
     
     _keyboard_state = {0x02A: False, 0x036: False}  # For shift keys.
 
@@ -217,6 +219,7 @@ class Win32Window(BaseWindow):
                 self._window_class.hInstance,
                 0)
 
+            # View Hwnd is for the client area so certain events (mouse events) don't trigger outside of area.
             self._view_hwnd = _user32.CreateWindowExW(
                 0,
                 self._view_window_class.lpszClassName,
@@ -227,6 +230,10 @@ class Win32Window(BaseWindow):
                 0,
                 self._view_window_class.hInstance,
                 0)
+
+            if not self._view_hwnd:
+                last_error = _kernel32.GetLastError()
+                raise Exception("Failed to create handle", self, last_error, self._view_hwnd, self._hwnd)
 
             self._dc = _user32.GetDC(self._view_hwnd)
 
@@ -239,12 +246,13 @@ class Win32Window(BaseWindow):
                     _user32.ChangeWindowMessageFilterEx(self._hwnd, WM_COPYGLOBALDATA, MSGFLT_ALLOW, None)
 
                 _shell32.DragAcceptFiles(self._hwnd, True)
-                
-            # Register raw input keyboard to allow the window to receive input events.
-            raw_keyboard = RAWINPUTDEVICE(0x01, 0x06, 0, self._view_hwnd)
+
+            # Set the raw keyboard to handle shift state. This is required as legacy events cannot handle shift states
+            # when both keys are used together. View Hwnd as none changes focus to follow keyboard.
+            raw_keyboard = RAWINPUTDEVICE(0x01, 0x06, 0, None)
             if not _user32.RegisterRawInputDevices(
-                byref(raw_keyboard), 1, sizeof(RAWINPUTDEVICE)):
-                    print("Warning: Failed to register raw input keyboard. on_key events for shift keys will not be called.")
+                    byref(raw_keyboard), 1, sizeof(RAWINPUTDEVICE)):
+                print("Warning: Failed to unregister raw input keyboard.")
         else:
             # Window already exists, update it with new style
 
@@ -465,6 +473,11 @@ class Win32Window(BaseWindow):
         if platform_visible == self._mouse_platform_visible:
             return
 
+        self._set_cursor_visibility(platform_visible)
+
+        self._mouse_platform_visible = platform_visible
+
+    def _set_cursor_visibility(self, platform_visible):
         # Avoid calling ShowCursor with the current visibility (which would
         # push the counter too far away from zero).
         global _win32_cursor_visible
@@ -472,21 +485,24 @@ class Win32Window(BaseWindow):
             _user32.ShowCursor(platform_visible)
             _win32_cursor_visible = platform_visible
 
-        self._mouse_platform_visible = platform_visible
+    def _update_clipped_cursor(self):
+        # Clip to client area, to prevent large mouse movements taking
+        # it outside the client area.
+        if self._in_title_bar or self._pending_click:
+            return
 
-    def _reset_exclusive_mouse_screen(self):
-        """Recalculate screen coords of mouse warp point for exclusive
-        mouse."""
-        p = POINT()
         rect = RECT()
         _user32.GetClientRect(self._view_hwnd, byref(rect))
-        _user32.MapWindowPoints(self._view_hwnd, HWND_DESKTOP, byref(rect), 2)
-        p.x = (rect.left + rect.right) // 2
-        p.y = (rect.top + rect.bottom) // 2
+        _user32.MapWindowPoints(self._view_hwnd, HWND_DESKTOP,
+                                byref(rect), 2)
 
-        # This is the point the mouse will be kept at while in exclusive
-        # mode.
-        self._exclusive_mouse_screen = p.x, p.y
+        # For some reason borders can be off 1 pixel, allowing cursor into frame/minimize/exit buttons?
+        rect.top += 1
+        rect.left += 1
+        rect.right -= 1
+        rect.bottom -= 1
+
+        _user32.ClipCursor(byref(rect))
 
     def set_exclusive_mouse(self, exclusive=True):
         if self._exclusive_mouse == exclusive and \
@@ -495,10 +511,7 @@ class Win32Window(BaseWindow):
 
         # Mouse: UsagePage = 1, Usage = 2
         raw_mouse = RAWINPUTDEVICE(0x01, 0x02, 0, None)
-        if exclusive:
-            raw_mouse.dwFlags = RIDEV_NOLEGACY
-            raw_mouse.hwndTarget = self._view_hwnd
-        else:
+        if not exclusive:
             raw_mouse.dwFlags = RIDEV_REMOVE
             raw_mouse.hwndTarget = None
 
@@ -509,15 +522,7 @@ class Win32Window(BaseWindow):
 
         self._exclusive_mouse_buttons = 0
         if exclusive and self._has_focus:
-            # Clip to client area, to prevent large mouse movements taking
-            # it outside the client area.
-            rect = RECT()
-            _user32.GetClientRect(self._view_hwnd, byref(rect))
-            _user32.MapWindowPoints(self._view_hwnd, HWND_DESKTOP,
-                                    byref(rect), 2)
-            _user32.ClipCursor(byref(rect))
-            # Release mouse capture in case is was acquired during mouse click
-            _user32.ReleaseCapture()
+            self._update_clipped_cursor()
         else:
             # Release clip
             _user32.ClipCursor(None)
@@ -766,6 +771,7 @@ class Win32Window(BaseWindow):
             modifiers |= key.MOD_NUMLOCK
         if _user32.GetKeyState(VK_SCROLL) & 0x00ff:  # toggle
             modifiers |= key.MOD_SCROLLLOCK
+
         if key_lParam:
             if key_lParam & (1 << 29):
                 modifiers |= key.MOD_ALT
@@ -803,7 +809,7 @@ class Win32Window(BaseWindow):
             symbol = key.RCTRL
         elif symbol == key.LALT and lParam & (1 << 24):
             symbol = key.RALT
-                    
+
         if wParam == VK_SHIFT:
             return  # Let raw input handle this instead.
 
@@ -826,6 +832,29 @@ class Win32Window(BaseWindow):
         else:
             return None
 
+    @Win32EventHandler(WM_WINDOWPOSCHANGED)
+    def _event_window_pos_changed(self, msg, wParam, lParam):
+        if self._exclusive_mouse:
+            self._update_clipped_cursor()
+        return 0
+
+    @Win32EventHandler(WM_NCLBUTTONDOWN)
+    def _event_ncl_button_down(self, msg, wParam, lParam):
+        self._in_title_bar = True
+
+    @Win32EventHandler(WM_CAPTURECHANGED)
+    def _event_capture_changed(self, msg, wParam, lParam):
+        self._in_title_bar = False
+
+        if self._exclusive_mouse:
+            state = _user32.GetAsyncKeyState(VK_LBUTTON)
+            if not state & 0x8000:  # released
+                if self._pending_click:
+                    self._pending_click = False
+
+                if self._has_focus or not self._hidden:
+                    self._update_clipped_cursor()
+
     @Win32EventHandler(WM_CHAR)
     def _event_char(self, msg, wParam, lParam):
         text = chr(wParam)
@@ -833,7 +862,6 @@ class Win32Window(BaseWindow):
             self.dispatch_event('on_text', text)
         return 0
 
-    @ViewEventHandler
     @Win32EventHandler(WM_INPUT)
     def _event_raw_input(self, msg, wParam, lParam):
         hRawInput = cast(lParam, HRAWINPUT)
@@ -845,37 +873,8 @@ class Win32Window(BaseWindow):
         if inp.header.dwType == RIM_TYPEMOUSE:
             if not self._exclusive_mouse:
                 return 0
-                
-            rmouse = inp.data.mouse
 
-            if rmouse.usButtonFlags & RI_MOUSE_LEFT_BUTTON_DOWN:
-                self.dispatch_event('on_mouse_press', 0, 0, mouse.LEFT,
-                                    self._get_modifiers())
-                self._exclusive_mouse_buttons |= mouse.LEFT
-            if rmouse.usButtonFlags & RI_MOUSE_LEFT_BUTTON_UP:
-                self.dispatch_event('on_mouse_release', 0, 0, mouse.LEFT,
-                                    self._get_modifiers())
-                self._exclusive_mouse_buttons &= ~mouse.LEFT
-            if rmouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN:
-                self.dispatch_event('on_mouse_press', 0, 0, mouse.RIGHT,
-                                    self._get_modifiers())
-                self._exclusive_mouse_buttons |= mouse.RIGHT
-            if rmouse.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_UP:
-                self.dispatch_event('on_mouse_release', 0, 0, mouse.RIGHT,
-                                    self._get_modifiers())
-                self._exclusive_mouse_buttons &= ~mouse.RIGHT
-            if rmouse.usButtonFlags & RI_MOUSE_MIDDLE_BUTTON_DOWN:
-                self.dispatch_event('on_mouse_press', 0, 0, mouse.MIDDLE,
-                                    self._get_modifiers())
-                self._exclusive_mouse_buttons |= mouse.MIDDLE
-            if rmouse.usButtonFlags & RI_MOUSE_MIDDLE_BUTTON_UP:
-                self.dispatch_event('on_mouse_release', 0, 0, mouse.MIDDLE,
-                                    self._get_modifiers())
-                self._exclusive_mouse_buttons &= ~mouse.MIDDLE
-            if rmouse.usButtonFlags & RI_MOUSE_WHEEL:
-                delta = SHORT(rmouse.usButtonData).value
-                self.dispatch_event('on_mouse_scroll',
-                                    0, 0, 0, delta / float(WHEEL_DELTA))
+            rmouse = inp.data.mouse
 
             if rmouse.usFlags & 0x01 == MOUSE_MOVE_RELATIVE:
                 if rmouse.lLastX != 0 or rmouse.lLastY != 0:
@@ -907,13 +906,13 @@ class Win32Window(BaseWindow):
                         self.dispatch_event('on_mouse_motion', 0, 0,
                                             rel_x, rel_y)
                     self._exclusive_mouse_lpos = rmouse.lLastX, rmouse.lLastY
-                    
+
         elif inp.header.dwType == RIM_TYPEKEYBOARD:
             if inp.data.keyboard.VKey == 255:
                 return 0
 
             key_up = inp.data.keyboard.Flags & RI_KEY_BREAK
-  
+
             if inp.data.keyboard.MakeCode == 0x02A:  # LEFT_SHIFT
                 if not key_up and not self._keyboard_state[0x02A]:
                     self._keyboard_state[0x02A] = True
@@ -927,10 +926,10 @@ class Win32Window(BaseWindow):
                 if not key_up and not self._keyboard_state[0x036]:
                     self._keyboard_state[0x036] = True
                     self.dispatch_event('on_key_press', key.RSHIFT, self._get_modifiers())
-                    
+
                 elif key_up and self._keyboard_state[0x036]:
                     self._keyboard_state[0x036] = False
-                    self.dispatch_event('on_key_release', key.RSHIFT, self._get_modifiers())        
+                    self.dispatch_event('on_key_release', key.RSHIFT, self._get_modifiers())
 
         return 0
 
@@ -1123,44 +1122,62 @@ class Win32Window(BaseWindow):
         self.dispatch_event('on_move', x, y)
         return 0
 
-    @Win32EventHandler(WM_EXITSIZEMOVE)
-    def _event_entersizemove(self, msg, wParam, lParam):
+    @Win32EventHandler(WM_SETCURSOR)
+    def _event_setcursor(self, msg, wParam, lParam):
+        if self._exclusive_mouse and not self._mouse_platform_visible:
+            lo, hi = self._get_location(lParam)
+            if lo == HTCLIENT:  # In frame
+                self._set_cursor_visibility(False)
+                return 1
+            elif lo in (HTCAPTION, HTCLOSE, HTMAXBUTTON, HTMINBUTTON):  # Allow in
+                self._set_cursor_visibility(True)
+                return 1
+
+    @Win32EventHandler(WM_ENTERSIZEMOVE)
+    def _event_exitsizemove(self, msg, wParam, lParam):
+        self._moving = True
         from pyglet import app
         if app.event_loop is not None:
             app.event_loop.exit_blocking()
 
-    """
-    # Alternative to using WM_SETFOCUS and WM_KILLFOCUS.  Which
-    # is better?
+    @Win32EventHandler(WM_EXITSIZEMOVE)
+    def _event_exitsizemove(self, msg, wParam, lParam):
+        self._moving = False
+        from pyglet import app
+        if app.event_loop is not None:
+            app.event_loop.exit_blocking()
 
-    @Win32EventHandler(WM_ACTIVATE)
-    def _event_activate(self, msg, wParam, lParam):
-        if wParam & 0xffff == WA_INACTIVE:
-            self.dispatch_event('on_deactivate')
-        else:
-            self.dispatch_event('on_activate')
-            _user32.SetFocus(self._hwnd)
-        return 0
-    """
+        if self._exclusive_mouse:
+            self._update_clipped_cursor()
 
     @Win32EventHandler(WM_SETFOCUS)
     def _event_setfocus(self, msg, wParam, lParam):
         self.dispatch_event('on_activate')
         self._has_focus = True
 
+        if self._exclusive_mouse:
+            if _user32.GetAsyncKeyState(VK_LBUTTON):
+                self._pending_click = True
+
         self.set_exclusive_keyboard(self._exclusive_keyboard)
         self.set_exclusive_mouse(self._exclusive_mouse)
+
         return 0
 
     @Win32EventHandler(WM_KILLFOCUS)
     def _event_killfocus(self, msg, wParam, lParam):
         self.dispatch_event('on_deactivate')
         self._has_focus = False
+
         exclusive_keyboard = self._exclusive_keyboard
         exclusive_mouse = self._exclusive_mouse
         # Disable both exclusive keyboard and mouse
         self.set_exclusive_keyboard(False)
         self.set_exclusive_mouse(False)
+
+        # Reset shift state on Window focus loss.
+        for symbol in self._keyboard_state:
+            self._keyboard_state[symbol] = False
 
         # But save desired state and note that we lost focus
         # This will allow to reset the correct mode once we regain focus
@@ -1173,12 +1190,14 @@ class Win32Window(BaseWindow):
     @Win32EventHandler(WM_GETMINMAXINFO)
     def _event_getminmaxinfo(self, msg, wParam, lParam):
         info = MINMAXINFO.from_address(lParam)
+
         if self._minimum_size:
             info.ptMinTrackSize.x, info.ptMinTrackSize.y = \
                 self._client_to_window_size(*self._minimum_size)
         if self._maximum_size:
             info.ptMaxTrackSize.x, info.ptMaxTrackSize.y = \
                 self._client_to_window_size(*self._maximum_size)
+
         return 0
 
     @Win32EventHandler(WM_ERASEBKGND)


### PR DESCRIPTION
Fixes an issue with shift not being called correctly on multiple windows. It now follows where your keyboard is focused. Also resets shift state when the focus is lost (will be gained again if still being held on return to window)

Fix multiple issues with exclusive mode:
1) If the window were to lose focus and you clicked in the title bar, the ClipCursor no longer was bound to the window, and the cursor was unhidden.
2) Unable to drag and move the window.
3) Unable to maximize/minimize the Window
4) Unable to close the window with the X button.
5) When mouse button is pushed down (not a click) on frame components, it would disappear.
6) Mouse could sometimes go out of the bounds of the view area into the close and minimize button resulting in issues with the window.

Removed the raw input requiring the view_hwnd, it just goes off of where your keyboard has focus.

Added a raise exception to show information on possible NULL issue with the `_view_hwnd`. 

Was tested in Windows 10. Any feedback and additional testing appreciated.

Note:
There is still an issue with random hierarchy issues where the mouse can become visible again in exclusive mode, if the window rapidly loses/gains focus, but it seems pretty rare. It seems some libraries (SDL2) just have a schedule that checks every so often if the ClipCursor area was superseded by another window and then re-applies it. Not sure we need to go that intensive on it.