### PR TITLE
TextLayout: return no lines if no glyphs present (#485)

### DIFF
--- a/pyglet/text/layout.py
+++ b/pyglet/text/layout.py
@@ -1239,6 +1239,8 @@ class TextLayout:
     def _get_lines(self):
         len_text = len(self._document.text)
         glyphs = self._get_glyphs()
+        if not glyphs:
+            return []
         owner_runs = runlist.RunList(len_text, None)
         self._get_owner_runs(owner_runs, glyphs, 0, len_text)
         lines = [line for line in self._flow_glyphs(glyphs, owner_runs, 0, len_text)]


### PR DESCRIPTION
Hey, first pull request to this repository, so I wasn't sure which branch to merge to for the "2.0" version.

With regards to the fix, the issue seemed to be in TextLayout._get_lines: if no glyphs are present, no lines should be returned (at least from my understanding).

I verified by setting the text as per #485, and ran through the pytest modules without issue.

Let me know if a unit test for this is needed, or if this is too broad of a stroke to fix the issue. Another option would be to handle empty glyphs in _get_owner_runs, but this seemed more fitting.