### PR TITLE
Remove dict subclass from KeyStateHandler and MouseStateHandler

### DIFF
--- a/pyglet/window/key.py
+++ b/pyglet/window/key.py
@@ -64,7 +64,7 @@ Usage::
 from pyglet import compat_platform
 
 
-class KeyStateHandler(dict):
+class KeyStateHandler:
     """Simple handler that tracks the state of keys on the keyboard. If a
     key is pressed then this handler holds a True value for it.
 
@@ -82,14 +82,17 @@ class KeyStateHandler(dict):
         False
 
     """
+    def __init__(self):
+        self.data = {}
+
     def on_key_press(self, symbol, modifiers):
-        self[symbol] = True
+        self.data[symbol] = True
 
     def on_key_release(self, symbol, modifiers):
-        self[symbol] = False
+        self.data[symbol] = False
 
     def __getitem__(self, key):
-        return self.get(key, False)
+        return self.data.get(key, False)
 
 
 def modifiers_string(modifiers):

--- a/pyglet/window/mouse.py
+++ b/pyglet/window/mouse.py
@@ -37,7 +37,7 @@
 """
 
 
-class MouseStateHandler(dict):
+class MouseStateHandler:
     """Simple handler that tracks the state of buttons from the mouse. If a
     button is pressed then this handler holds a True value for it.
 
@@ -57,25 +57,27 @@ class MouseStateHandler(dict):
     """
 
     def __init__(self):
-        self["x"] = 0
-        self["y"] = 0
+        self.data = {
+            "x": 0,
+            "y": 0,
+        }
 
     def on_mouse_press(self, x, y, button, modifiers):
-        self[button] = True
+        self.data[button] = True
 
     def on_mouse_release(self, x, y, button, modifiers):
-        self[button] = False
+        self.data[button] = False
 
     def on_mouse_motion(self, x, y, dx, dy):
-        self["x"] = x
-        self["y"] = y
+        self.data["x"] = x
+        self.data["y"] = y
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
-        self["x"] = x
-        self["y"] = y
+        self.data["x"] = x
+        self.data["y"] = y
 
     def __getitem__(self, key):
-        return self.get(key, False)
+        return self.data.get(key, False)
 
 
 def buttons_string(buttons):


### PR DESCRIPTION
This PR makes KeyStateHandler and MouseStateHandler be their own classes which do not subclass `dict`. 

Sub-classing dict causes problems with WeakRef when sub-classing Window, essentially making it impossible to these classes inside of a subclassed Window object.

This also caused problems with function names inherited from dict, like for example `dict.update()` which if you had an event handler for an update function, would try to use this function, which obviously isn't intended for it.

The solution to this is adding a `data` attribute to the classes, and having the functions work on that attribute rather than on `self` attribute directly. This is roughly the same kind of implementation found in the [UserDict](https://docs.python.org/3/library/collections.html#userdict-objects) class in Python. I've tested this somewhat extensively and I haven't been able to find anything within Pyglet that this breaks.

However this could potentially effect user code that is attempting to use this class directly as a dict, however my guess is that no one is doing that, or if so it's very few and far between. At worst this could just only be included 2.0.

This primarily serves to make it easier to use these classes in [Arcade](https://github.com/pythonarcade/arcade), and I've tested extensively from within Arcade as well and none of our existing code/examples/test suite broke with it.