### PR TITLE
[WIP] Media player fixes

### DIFF
--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -66,14 +66,20 @@ pyglet.options['debug_media'] = False
 from pyglet.media import buffered_logger as bl
 
 
-def draw_rect(x, y, width, height):
-    glBegin(GL_LINE_LOOP)
-    glVertex2f(x, y)
-    glVertex2f(x + width, y)
-    glVertex2f(x + width, y + height)
-    glVertex2f(x, y + height)
-    glEnd()
-
+def draw_rect(x, y, width, height, color=(1, 1, 1, 1)):
+    pyglet.graphics.draw(
+        4,
+        GL_LINE_LOOP,
+        ('position3f',
+            (
+                x, y, 0,
+                x + width, y, 0,
+                x + width, y + height, 0,
+                x, y + height, 0,
+            )
+        ),
+        ('colors4f', color * 4)
+    )
 
 class Control(pyglet.event.EventDispatcher):
     x = y = 0
@@ -99,9 +105,9 @@ class Button(Control):
 
     def draw(self):
         if self.charged:
-            glColor3f(1, 0, 0)
-        draw_rect(self.x, self.y, self.width, self.height)
-        glColor3f(1, 1, 1)
+            draw_rect(self.x, self.y, self.width, self.height)
+        else:
+            draw_rect(self.x, self.y, self.width, self.height, color=(1, 0, 0, 1))
         self.draw_label()
 
     def on_mouse_press(self, x, y, button, modifiers):

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -38,7 +38,7 @@ import time
 from collections import deque
 
 import pyglet
-from pyglet.gl import GL_TEXTURE_RECTANGLE
+from pyglet.gl import GL_TEXTURE_2D
 from pyglet.media import buffered_logger as bl
 from pyglet.media.drivers import get_audio_driver
 from pyglet.media.codecs.base import Source, SourceGroup
@@ -393,7 +393,7 @@ class Player(pyglet.event.EventDispatcher):
 
     def _create_texture(self):
         video_format = self.source.video_format
-        self._texture = pyglet.image.Texture.create(video_format.width, video_format.height, GL_TEXTURE_RECTANGLE)
+        self._texture = pyglet.image.Texture.create(video_format.width, video_format.height, GL_TEXTURE_2D)
         self._texture = self._texture.get_transform(flip_y=True)
         # After flipping the texture along the y axis, the anchor_y is set
         # to the top of the image. We want to keep it at the bottom.


### PR DESCRIPTION
* The media player was still using `GL_TEXTURE_RECTANGLE`, something the default shaders are not set up to read from. They only read `GL_TEXTURE_2D`. Also texture rectangles do not work on MacOS and other core only drivers.
* Updated the media player example to draw the simple UI with `pyglet.graphics.draw` instead of deprecated immediate mode functions.

This solves 2 problems: 
1) The video is now visible (shader can reder the texture)
2) The media player example now runs

![bilde](https://user-images.githubusercontent.com/5418180/144948034-3f0991d7-67c8-46a2-993b-af6f385c1039.png)

There are more things to clean up before merge