### PR TITLE
Adds WIC encoder

### DIFF
--- a/pyglet/image/codecs/wic.py
+++ b/pyglet/image/codecs/wic.py
@@ -48,14 +48,20 @@ WICBitmapDitherTypeErrorDiffusion = 0x8
 WICBITMAPDITHERTYPE_FORCE_DWORD = 0x7fffffff
 WICBITMAPTRANSFORMOPTIONS_FORCE_DWORD = 0x7fffffff
 
-
 WICDecodeOptions = UINT
 WICDecodeMetadataCacheOnDemand = 0
 WICDecodeMetadataCacheOnLoad = 0x1
 WICMETADATACACHEOPTION_FORCE_DWORD = 0x7fffffff
 
+WICBitmapEncoderCacheOption = UINT
+WICBitmapEncoderCacheInMemory = 0x0
+WICBitmapEncoderCacheTempFile = 0x1
+WICBitmapEncoderNoCache = 0x2
+WICBITMAPENCODERCACHEOPTION_FORCE_DWORD = 0x7fffffff
+
 # Different pixel formats.
 REFWICPixelFormatGUID = com.GUID
+GUID_WICPixelFormatDontCare = com.GUID(0x6fddc324,0x4e03,0x4bfe,0xb1,0x85,0x3d,0x77,0x76,0x8d,0xc9,0x00)
 GUID_WICPixelFormat1bppIndexed = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x01)
 GUID_WICPixelFormat2bppIndexed = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x02)
 GUID_WICPixelFormat4bppIndexed = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x03)
@@ -74,11 +80,154 @@ GUID_WICPixelFormat24bppRGB = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0
 GUID_WICPixelFormat32bppBGR = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x0e)
 GUID_WICPixelFormat32bppBGRA = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x0f)
 GUID_WICPixelFormat32bppPBGRA = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x10)
-GUID_WICPixelFormat32bppRGB = com.GUID(0xd98c6b95, 0x3efe, 0x47d6, 0xbb, 0x25, 0xeb, 0x17, 0x48, 0xab, 0x0c, 0xf1)  # 7 platform update?
+GUID_WICPixelFormat32bppRGB = com.GUID(0xd98c6b95, 0x3efe, 0x47d6, 0xbb, 0x25, 0xeb, 0x17, 0x48, 0xab, 0x0c,  0xf1)  # 7 platform update?
 GUID_WICPixelFormat32bppRGBA = com.GUID(0xf5c7ad2d, 0x6a8d, 0x43dd, 0xa7, 0xa8, 0xa2, 0x99, 0x35, 0x26, 0x1a, 0xe9)
 GUID_WICPixelFormat32bppPRGBA = com.GUID(0x3cc4a650, 0xa527, 0x4d37, 0xa9, 0x16, 0x31, 0x42, 0xc7, 0xeb, 0xed, 0xba)
 GUID_WICPixelFormat48bppRGB = com.GUID(0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x15)
 GUID_WICPixelFormat48bppBGR = com.GUID(0xe605a384, 0xb468, 0x46ce, 0xbb, 0x2e, 0x36, 0xf1, 0x80, 0xe6, 0x43, 0x13)
+
+GUID_ContainerFormatBmp = com.GUID(0x0af1d87e, 0xfcfe, 0x4188, 0xbd, 0xeb, 0xa7, 0x90, 0x64, 0x71, 0xcb, 0xe3)
+GUID_ContainerFormatPng = com.GUID(0x1b7cfaf4, 0x713f, 0x473c, 0xbb, 0xcd, 0x61, 0x37, 0x42, 0x5f, 0xae, 0xaf)
+GUID_ContainerFormatIco = com.GUID(0xa3a860c4, 0x338f, 0x4c17, 0x91, 0x9a, 0xfb, 0xa4, 0xb5, 0x62, 0x8f, 0x21)
+GUID_ContainerFormatJpeg = com.GUID(0x19e4a5aa, 0x5662, 0x4fc5, 0xa0, 0xc0, 0x17, 0x58, 0x02, 0x8e, 0x10, 0x57)
+GUID_ContainerFormatTiff = com.GUID(0x163bcc30, 0xe2e9, 0x4f0b, 0x96, 0x1d, 0xa3, 0xe9, 0xfd, 0xb7, 0x88, 0xa3)
+GUID_ContainerFormatGif = com.GUID(0x1f8a5601, 0x7d4d, 0x4cbd, 0x9c, 0x82, 0x1b, 0xc8, 0xd4, 0xee, 0xb9, 0xa5)
+GUID_ContainerFormatWmp = com.GUID(0x57a37caa, 0x367a, 0x4540, 0x91, 0x6b, 0xf1, 0x83, 0xc5, 0x09, 0x3a, 0x4b)
+
+
+class IPropertyBag2(com.pIUnknown):
+    _methods_ = [
+        ('Read',
+         com.STDMETHOD()),
+        ('Write',
+         com.STDMETHOD()),
+        ('CountProperties',
+         com.STDMETHOD()),
+        ('GetPropertyInfo',
+         com.STDMETHOD()),
+        ('LoadObject',
+         com.STDMETHOD())
+    ]
+
+
+# class PROPBAG2(Structure):
+#     _fields_ = [
+#         ('dwType', DWORD),
+#         ('vt', VARTYPE),
+#         ('cfType', CLIPFORMAT),
+#         ('dwHint', DWORD),
+#         ('pstrName', LPOLESTR),
+#         ('clsid', CLSID)
+#     ]
+
+class IWICPalette(com.pIUnknown):
+    _methods_ = [
+        ('InitializePredefined',
+         com.STDMETHOD()),
+        ('InitializeCustom',
+         com.STDMETHOD()),
+        ('InitializeFromBitmap',
+         com.STDMETHOD()),
+        ('InitializeFromPalette',
+         com.STDMETHOD()),
+        ('GetType',
+         com.STDMETHOD()),
+        ('GetColorCount',
+         com.STDMETHOD()),
+        ('GetColors',
+         com.STDMETHOD()),
+        ('IsBlackWhite',
+         com.STDMETHOD()),
+        ('IsGrayscale',
+         com.STDMETHOD()),
+        ('HasAlpha',
+         com.STDMETHOD()),
+    ]
+class IWICStream(com.pIUnknown):
+    _methods_ = [
+        ('Read',
+         com.STDMETHOD()),
+        ('Write',
+         com.STDMETHOD()),
+        ('Seek',
+         com.STDMETHOD()),
+        ('SetSize',
+         com.STDMETHOD()),
+        ('CopyTo',
+         com.STDMETHOD()),
+        ('Commit',
+         com.STDMETHOD()),
+        ('Revert',
+         com.STDMETHOD()),
+        ('LockRegion',
+         com.STDMETHOD()),
+        ('UnlockRegion',
+         com.STDMETHOD()),
+        ('Stat',
+         com.STDMETHOD()),
+        ('Clone',
+         com.STDMETHOD()),
+        ('InitializeFromIStream',
+         com.STDMETHOD()),
+        ('InitializeFromFilename',
+         com.STDMETHOD(LPCWSTR, DWORD)),
+        ('InitializeFromMemory',
+         com.STDMETHOD()),
+        ('InitializeFromIStreamRegion',
+         com.STDMETHOD()),
+    ]
+
+
+class IWICBitmapFrameEncode(com.pIUnknown):
+    _methods_ = [
+        ('Initialize',
+         com.STDMETHOD(IPropertyBag2)),
+        ('SetSize',
+         com.STDMETHOD(UINT, UINT)),
+        ('SetResolution',
+         com.STDMETHOD()),
+        ('SetPixelFormat',
+         com.STDMETHOD(REFWICPixelFormatGUID)),
+        ('SetColorContexts',
+         com.STDMETHOD()),
+        ('SetPalette',
+         com.STDMETHOD(IWICPalette)),
+        ('SetThumbnail',
+         com.STDMETHOD()),
+        ('WritePixels',
+         com.STDMETHOD(UINT, UINT, UINT, POINTER(BYTE))),
+        ('WriteSource',
+         com.STDMETHOD()),
+        ('Commit',
+         com.STDMETHOD()),
+        ('GetMetadataQueryWriter',
+         com.STDMETHOD())
+    ]
+
+
+class IWICBitmapEncoder(com.pIUnknown):
+    _methods_ = [
+        ('Initialize',
+         com.STDMETHOD(IWICStream, WICBitmapEncoderCacheOption)),
+        ('GetContainerFormat',
+         com.STDMETHOD()),
+        ('GetEncoderInfo',
+         com.STDMETHOD()),
+        ('SetColorContexts',
+         com.STDMETHOD()),
+        ('SetPalette',
+         com.STDMETHOD()),
+        ('SetThumbnail',
+         com.STDMETHOD()),
+        ('SetPreview',
+         com.STDMETHOD()),
+        ('CreateNewFrame',
+         com.STDMETHOD(POINTER(IWICBitmapFrameEncode), POINTER(IPropertyBag2))),
+        ('Commit',
+         com.STDMETHOD()),
+        ('GetMetadataQueryWriter',
+         com.STDMETHOD())
+    ]
 
 
 class IWICComponentInfo(com.pIUnknown):
@@ -135,7 +284,8 @@ class IWICBitmapSource(com.pIUnknown):
 class IWICFormatConverter(IWICBitmapSource, com.pIUnknown):
     _methods_ = [
         ('Initialize',
-         com.STDMETHOD(IWICBitmapSource, POINTER(REFWICPixelFormatGUID), WICBitmapDitherType, c_void_p, DOUBLE, WICBitmapPaletteType)),
+         com.STDMETHOD(IWICBitmapSource, POINTER(REFWICPixelFormatGUID), WICBitmapDitherType, c_void_p, DOUBLE,
+                       WICBitmapPaletteType)),
         ('CanConvert',
          com.STDMETHOD(POINTER(REFWICPixelFormatGUID), POINTER(REFWICPixelFormatGUID), POINTER(BOOL))),
     ]
@@ -234,9 +384,9 @@ class IWICImagingFactory(com.pIUnknown):
         ('CreateDecoder',
          com.STDMETHOD()),
         ('CreateEncoder',
-         com.STDMETHOD()),
+         com.STDMETHOD(com.GUID, POINTER(com.GUID), POINTER(IWICBitmapEncoder))),
         ('CreatePalette',
-         com.STDMETHOD()),
+         com.STDMETHOD(POINTER(IWICPalette))),
         ('CreateFormatConverter',
          com.STDMETHOD(POINTER(IWICFormatConverter))),
         ('CreateBitmapScaler',
@@ -246,7 +396,7 @@ class IWICImagingFactory(com.pIUnknown):
         ('CreateBitmapFlipRotator',
          com.STDMETHOD(POINTER(IWICBitmapFlipRotator))),
         ('CreateStream',
-         com.STDMETHOD()),
+         com.STDMETHOD(POINTER(IWICStream))),
         ('CreateColorContext',
          com.STDMETHOD()),
         ('CreateColorTransformer',
@@ -258,7 +408,7 @@ class IWICImagingFactory(com.pIUnknown):
         ('CreateBitmapFromSourceRect',
          com.STDMETHOD()),
         ('CreateBitmapFromMemory',
-         com.STDMETHOD()),
+         com.STDMETHOD(UINT, UINT, REFWICPixelFormatGUID, UINT, UINT, POINTER(BYTE), POINTER(IWICBitmap))),
         ('CreateBitmapFromHBITMAP',
          com.STDMETHOD()),
         ('CreateBitmapFromHICON',
@@ -276,23 +426,27 @@ class IWICImagingFactory(com.pIUnknown):
     ]
 
 
+_factory = IWICImagingFactory()
+
+try:
+    ole32.CoInitializeEx(None, COINIT_MULTITHREADED)
+except OSError as err:
+    warnings.warn(str(err))
+
+ole32.CoCreateInstance(CLSID_WICImagingFactory,
+                       None,
+                       CLSCTX_INPROC_SERVER,
+                       IID_IWICImagingFactory,
+                       byref(_factory))
+
+
 class WICDecoder(ImageDecoder):
     """Windows Imaging Component.
     This decoder is a replacement for GDI and GDI+ starting with Windows 7 with more features up to Windows 10."""
+
     def __init__(self):
         super(ImageDecoder, self).__init__()
-        self._factory = IWICImagingFactory()
-
-        try:
-            ole32.CoInitializeEx(None, COINIT_MULTITHREADED)
-        except OSError as err:
-            warnings.warn(str(err))
-
-        ole32.CoCreateInstance(CLSID_WICImagingFactory,
-                               None,
-                               CLSCTX_INPROC_SERVER,
-                               IID_IWICImagingFactory,
-                               byref(self._factory))
+        self._factory = _factory
 
     def get_file_extensions(self):
         return ['.bmp', '.jpg', '.jpeg', '.png', '.tif', '.tiff', '.ico', '.jxr', '.hdp', '.wdp']
@@ -411,5 +565,83 @@ def get_decoders():
     return [WICDecoder()]
 
 
+extension_to_container = {
+    '.bmp': GUID_ContainerFormatBmp,
+    '.jpg': GUID_ContainerFormatJpeg,
+    '.jpeg': GUID_ContainerFormatJpeg,
+    '.tif': GUID_ContainerFormatTiff,
+    '.tiff': GUID_ContainerFormatTiff,
+    '.wmp': GUID_ContainerFormatWmp,
+    '.jxr': GUID_ContainerFormatWmp,
+    '.wdp': GUID_ContainerFormatWmp,
+    '.png': GUID_ContainerFormatPng,
+}
+
+
+class WICEncoder(ImageEncoder):
+    def get_file_extensions(self):
+        return [ext for ext in extension_to_container]
+
+    def encode(self, image, file, filename):
+        # Close default file handler.file.close()
+        stream = IWICStream()
+        encoder = IWICBitmapEncoder()
+        frame = IWICBitmapFrameEncode()
+        property_bag = IPropertyBag2()
+
+        _factory.CreateStream(byref(stream))
+
+        stream.InitializeFromFilename(filename, GENERIC_WRITE)
+        name, ext = os.path.splitext(filename)
+
+        # Choose container based on extension. Default to PNG.
+        container = extension_to_container.get(ext, GUID_ContainerFormatPng)
+
+        _factory.CreateEncoder(container, None, byref(encoder))
+
+        encoder.Initialize(stream, WICBitmapEncoderNoCache)
+
+        encoder.CreateNewFrame(byref(frame), byref(property_bag))
+
+        frame.Initialize(property_bag)
+
+        frame.SetSize(image.width, image.height)
+
+        # https://docs.microsoft.com/en-us/windows/win32/wic/-wic-codec-native-pixel-formats#native-image-formats
+        if container == GUID_ContainerFormatJpeg:
+            # Expects BGR, no transparency available. Hard coded.
+            fmt = 'BGR'
+            default_format = GUID_WICPixelFormat24bppBGR
+        else:
+            # Windows encodes in BGRA.
+            if len(image.format) == 3:
+                fmt = 'BGR'
+                default_format = GUID_WICPixelFormat24bppBGR
+            else:
+                fmt = 'BGRA'
+                default_format = GUID_WICPixelFormat32bppBGRA
+
+        frame.SetPixelFormat(default_format)
+
+        pitch = image.width * len(fmt)
+        actual_pitch = -pitch
+
+        image_data = image.get_data(fmt, actual_pitch)
+
+        size = len(image_data)
+
+        data = (c_byte * size).from_buffer(bytearray(image_data))
+
+        frame.WritePixels(image.height, pitch, size, data)
+
+        frame.Commit()
+
+        encoder.Commit()
+
+        encoder.Release()
+        frame.Release()
+        property_bag.Release()
+        stream.Release()
+
 def get_encoders():
-    return []
+    return [WICEncoder()]


### PR DESCRIPTION
By default other platforms use a default of RGB/A when loading images such as PNG. However, Windows uses BGR/A as the default image format when loading. This can cause slowdowns because the default encoders such as PIL or PNG force RGB/A when encoding images, so it has to go through regex restructuring of the image data to the desired format. 

Here are some example of the speed differences between encoding different sized images:
```
WIC:
480x480 time: 0.04906469999999996s
2048x2048 time: 0.49710109999999985s

PIL:
480x480 time: 1.1027328s
2048x2048 time: 14.9952449s
In many cases running the 2048x2048 conversion would result in a MemoryError exception.
```

This new encoder supports bmp, jpg, tif, wmp, and png (default). It does not require any dependency such as PIL, pypng, or anything else. It will also convert the data to the BGR/A format if it is not correct. Other encoding options could be added in the future to control quality options if enough people request it.

Some other thoughts:
Not sure if other encoders can support BGR/A (Such as PIL), but if they do, perhaps they should be enhanced to support the other pixel formats?