### PR TITLE
BUG: Fix bug with dropping frames

### DIFF
--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -962,6 +962,7 @@ class FFmpegSource(StreamingSource):
                     self._decode_video_packet(video_packet)
                 if video_packet.image is not None:
                     ts = video_packet.timestamp
+                    self.videoq.appendleft(video_packet)  # put it back
                     break
                 self._get_video_packet()
         else:

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -478,6 +478,11 @@ class Player(pyglet.event.EventDispatcher):
 
             pyglet.clock.schedule_once(self._video_finished, 0)
             return
+        elif ts > time:
+            # update_texture called too early (probably manually!)
+            pyglet.clock.schedule_once(self.update_texture, ts - time)
+            return
+
 
         image = source.get_next_video_frame()
         if image is not None:


### PR DESCRIPTION
When querying `get_next_video_timestamp()`, it should not (effectively) discard the given frame. The current code seems to do this unintentionally because it pops from the video queue, but does not put the valid frame back in the queue.

For example, this code with this video:

https://user-images.githubusercontent.com/2365790/148837466-8c8c9d51-b720-4077-9554-51c312b6fff2.mp4


```
import numpy as np
import pyglet
from pyglet import gl
window = pyglet.window.Window()
player = pyglet.media.Player()
source = pyglet.media.StreamingSource()
media = pyglet.media.load('example-video.mp4')
player.queue(media)
player.play()


@window.event
def on_draw():
    window.clear()
    if player.source and player.source.video_format:
        tex = player.get_texture()
        for _ in range(10):
            print(player.source.get_next_video_timestamp())
        tex.blit(0, 0)
    else:
        pyglet.app.exit()


pyglet.app.run()
```
Should produce a smooth video with no interruptions, and we should get blocks of the same timestamp printed 10 times in a row. On `pyglet-1.5-maintenance` we get very choppy video with the following increasing time outputs (wrong!):


https://user-images.githubusercontent.com/2365790/148837732-0158421b-198b-42e7-a772-4e49ac312138.mp4



```
0.133333
0.166667
0.233333
0.266667
0.3
0.333333
0.366667
0.4
0.433333
0.466667
```
On this branch, we get correctly-printed blocks of 10 frame numbers and smooth video:


https://user-images.githubusercontent.com/2365790/148838028-fb5fd2af-b505-49e7-ac99-2fb88a7d19f9.mp4



```
0.066667
0.066667
0.066667
0.066667
0.066667
0.066667
0.066667
0.066667
0.066667
0.066667
0.1
0.1
0.1
0.1
0.1
0.1
0.1
0.1
0.1
0.1
```