### PR TITLE
BUG: Fix video alpha on Windows

### DIFF
--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -616,7 +616,7 @@ class WMFSource(Source):
 
         imfmedia.Release()
 
-        uncompressed_mt.SetGUID(MF_MT_SUBTYPE, MFVideoFormat_RGB32)
+        uncompressed_mt.SetGUID(MF_MT_SUBTYPE, MFVideoFormat_ARGB32)
         uncompressed_mt.SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive)
         uncompressed_mt.SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, 1)
 


### PR DESCRIPTION
Closes #531.

One possible fix -- actually request the alpha channel in the data. It seems to fix the issue. Another option would be just to set explicitly the alpha channel to 1 (or 255?) in `ImageData` after creation, but this solution should be faster since it relies on Microsoft's C code to do it for us.