### PR TITLE
ENH: Prefer ffmpeg

### DIFF
--- a/pyglet/media/codecs/__init__.py
+++ b/pyglet/media/codecs/__init__.py
@@ -53,7 +53,7 @@ class MediaDecoder(Decoder):
 
     def decode(self, file, filename, streaming):
         """Read the given file object and return an instance of `Source`
-        or `StreamingSource`. 
+        or `StreamingSource`.
         Throws MediaDecodeException if there is an error.  `filename`
         can be a file type hint.
         """
@@ -90,18 +90,18 @@ def add_default_media_codecs():
             pass
 
     try:
+        if have_ffmpeg():
+            from . import ffmpeg
+            add_decoders(ffmpeg)
+    except ImportError:
+        pass
+
+    try:
         if pyglet.compat_platform in ('win32', 'cygwin'):
             from pyglet.libs.win32.constants import WINDOWS_VISTA_OR_GREATER
             if WINDOWS_VISTA_OR_GREATER:  # Supports Vista and above.
                 from . import wmf
                 add_decoders(wmf)
-    except ImportError:
-        pass
-
-    try:
-        if have_ffmpeg():
-            from . import ffmpeg
-            add_decoders(ffmpeg)
     except ImportError:
         pass
 


### PR DESCRIPTION
In https://github.com/pyglet/pyglet/pull/534#issuecomment-1010732272 it was pointed out that WMF is not accelerated, and ffmpeg is preferred for larger videos. However, there is no way for the user to actually make this choice AFAIK, because it's set in the order of `add_decoders`. Assuming it's not *awful* for smaller videos (where performance will be less important anyway), it seems like `ffmpeg` should be the preferred decoder on Windows. So this PR is really a proposal to change the priority order, feel free to close if it doesn't make sense.

An alternative would be to allow users to set an option to set the priority / preference using `pyglet.options` somehow, like there is for audio.

The motivation here is that the playback speed difference between these backends [for large videos is drastic](https://github.com/LABSN/expyfun/pull/439#issuecomment-1013295729).