### PR TITLE
Fix #542

### DIFF
--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -410,6 +410,8 @@ class Win32Window(BaseWindow):
         width, height = self._client_to_window_size(width, height)
         _user32.SetWindowPos(self._hwnd, 0, 0, 0, width, height,
                              (SWP_NOZORDER | SWP_NOMOVE | SWP_NOOWNERZORDER))
+        _user32.ShowWindow(self._hwnd, SW_HIDE)
+        _user32.ShowWindow(self._hwnd, SW_SHOW)
         self.dispatch_event('on_resize', width, height)
 
     def get_size(self):


### PR DESCRIPTION
The actual usable window surface wouldn't get correctly resized.

In order to force an update from the window, after changing the size
with SetWindowPos a rapid toggle of SW_HIDE/SW_SHOW is executed.