### PR TITLE
Create buffers with 0 byte data by default

### DIFF
--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -188,7 +188,8 @@ class BufferObject(AbstractBuffer):
         self.id = buffer_id.value
 
         glBindBuffer(target, self.id)
-        glBufferData(target, self.size, None, self.usage)
+        data = (GLubyte * self.size)()
+        glBufferData(target, self.size, data, self.usage)
 
     def invalidate(self):
         glBufferData(self.target, self.size, None, self.usage)


### PR DESCRIPTION
There is no guarantee a buffer will contain 0 byte values on creation if no data is supplied. it really depends on the drivers.

Changing this fixes the text issue because the translation buffer data is not always set and translation values will contain random data depending on drivers. AMD and Intel drivers are more likely to have random data on creation. It might be that we want to fix the original issue as well. When the text vertex data is split into a different domain the translation values are probably not copied to the new buffer, so that probably create other issues!

Still, creating 0 byte value buffers is probably a good idea, or it can be optional on creation (init parameter)
