### PR TITLE
Better version detection for ffmpeg

### DIFF
--- a/pyglet/media/codecs/__init__.py
+++ b/pyglet/media/codecs/__init__.py
@@ -122,7 +122,7 @@ def have_ffmpeg():
     try:
         from . import ffmpeg_lib
         if _debug:
-            print('FFmpeg available, using to load media files.')
+            print('FFmpeg available, using to load media files. Versions: {}'.format(ffmpeg_lib.compat.versions))
         return True
 
     except (ImportError, FileNotFoundError, AttributeError):

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -36,24 +36,19 @@
 """Use ffmpeg to decode audio and video media.
 """
 
-import tempfile
-from ctypes import (c_int, c_uint16, c_int32, c_int64, c_uint32, c_uint64,
-                    c_uint8, c_uint, c_double, c_float, c_ubyte, c_size_t, c_char, c_char_p,
-                    c_void_p, addressof, byref, cast, POINTER, CFUNCTYPE, Structure, Union,
-                    create_string_buffer, memmove, pointer)
 from collections import deque
+from ctypes import (c_int, c_int32, c_uint8, c_char_p,
+                    addressof, byref, cast, POINTER, Structure, create_string_buffer, memmove)
 
 import pyglet
 import pyglet.lib
-
 from pyglet import image
 from pyglet.util import asbytes, asbytes_filename, asstr
-from ..events import MediaEvent
-from ..exceptions import MediaFormatException
-from .base import StreamingSource, VideoFormat, AudioFormat
+from . import MediaDecoder
 from .base import AudioData, SourceInfo, StaticSource
+from .base import StreamingSource, VideoFormat, AudioFormat
 from .ffmpeg_lib import *
-from . import MediaEncoder, MediaDecoder
+from ..exceptions import MediaFormatException
 
 
 class FileInfo:

--- a/pyglet/media/codecs/ffmpeg_lib/compat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/compat.py
@@ -34,9 +34,6 @@
 # ----------------------------------------------------------------------------
 
 from collections import namedtuple
-from pyglet.util import debug_print
-
-_debug = debug_print('debug_media')
 
 CustomField = namedtuple("CustomField", "fields removals")
 
@@ -60,7 +57,7 @@ _version_changes = {
     'avcodec': {},
     'avformat': {},
     'avutil': {},
-    'swresample':{},
+    'swresample': {},
     'swscale': {}
 }
 
@@ -75,8 +72,8 @@ def add_version_changes(library, version, structure, fields, removals):
 
     if structure in _version_changes[library][version]:
         raise Exception("Structure: {} from: {} has already been added for version {}.".format(structure,
-                                                                                            library,
-                                                                                            version)
+                                                                                               library,
+                                                                                               version)
                         )
 
     _version_changes[library][version][structure] = CustomField(fields, removals)
@@ -87,9 +84,6 @@ def apply_version_changes():
        Field data can vary from version to version, however assigning _fields_ automatically assigns memory.
        _fields_ can also not be re-assigned. Use a temporary list that can be manipulated before setting the
        _fields_ of the Structure."""
-
-    if _debug:
-        print("FFmpeg Loaded Versions:", versions)
 
     for library, data in _version_changes.items():
         for version in data:
@@ -102,5 +96,3 @@ def apply_version_changes():
                                     cf_data.fields.remove(field)
 
                     structure._fields_ = cf_data.fields
-
-

--- a/pyglet/media/codecs/ffmpeg_lib/libavcodec.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavcodec.py
@@ -47,25 +47,16 @@ from . import libavutil
 
 _debug = debug_print('debug_media')
 
-try:
-    avcodec = pyglet.lib.load_library(
-        'avcodec',
-        win32='avcodec-59',
-        darwin='avcodec.59'
-    )
-    version = 59
-except ImportError:
-    if _debug:
-        print("Failed to load: avcodec-59. Trying older version.")
+avcodec = pyglet.lib.load_library(
+    'avcodec',
+    win32=('avcodec-59', 'avcodec-58'),
+    darwin=('avcodec.59', 'avcodec.58')
+)
 
-    avcodec = pyglet.lib.load_library(
-        'avcodec',
-        win32='avcodec-58',
-        darwin='avcodec.58'
-    )
-    version = 58
+avcodec.avcodec_version.restype = c_int
 
-compat.set_version('avcodec', version)
+compat.set_version('avcodec', avcodec.avcodec_version() >> 16)
+
 
 FF_INPUT_BUFFER_PADDING_SIZE = 32
 

--- a/pyglet/media/codecs/ffmpeg_lib/libavformat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavformat.py
@@ -36,7 +36,7 @@
 """
 from ctypes import c_int, c_int64
 from ctypes import c_uint8, c_uint, c_double, c_ubyte, c_size_t, c_char, c_char_p
-from ctypes import c_void_p, POINTER, CFUNCTYPE, Structure, sizeof
+from ctypes import c_void_p, POINTER, CFUNCTYPE, Structure
 
 import pyglet.lib
 from pyglet.util import debug_print
@@ -46,25 +46,15 @@ from . import libavutil
 
 _debug = debug_print('debug_media')
 
-try:
-    avformat = pyglet.lib.load_library(
-        'avformat',
-        win32='avformat-59',
-        darwin='avformat.59'
-    )
-    version = 59
-except ImportError:
-    if _debug:
-        print("Failed to load: avformat-59. Trying older version.")
+avformat = pyglet.lib.load_library(
+    'avformat',
+    win32=('avformat-59', 'avformat-58'),
+    darwin=('avformat.59', 'avformat.58')
+)
 
-    avformat = pyglet.lib.load_library(
-        'avformat',
-        win32='avformat-58',
-        darwin='avformat.58'
-    )
-    version = 58
+avformat.avformat_version.restype = c_int
 
-compat.set_version('avformat', version)
+compat.set_version('avformat', avformat.avformat_version() >> 16)
 
 AVSEEK_FLAG_BACKWARD = 1  # ///< seek backward
 AVSEEK_FLAG_BYTE = 2  # ///< seeking based on position in bytes

--- a/pyglet/media/codecs/ffmpeg_lib/libavutil.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavutil.py
@@ -44,25 +44,14 @@ from . import compat
 
 _debug = debug_print('debug_media')
 
-try:
-    avutil = pyglet.lib.load_library(
-        'avutil',
-        win32='avutil-57',
-        darwin='avutil.57'
-    )
-    version = 57
-except ImportError:
-    if _debug:
-        print("Failed to load: avutil-57. Trying older version.")
+avutil = pyglet.lib.load_library(
+    'avutil',
+    win32=('avutil-57', 'avutil-56'),
+    darwin=('avutil.57', 'avutil-56')
+)
 
-    avutil = pyglet.lib.load_library(
-        'avutil',
-        win32='avutil-56',
-        darwin='avutil.56'
-    )
-    version = 56
-
-compat.set_version('avutil', version)
+avutil.avutil_version.restype = c_int
+compat.set_version('avutil', avutil.avutil_version() >> 16)
 
 AVMEDIA_TYPE_UNKNOWN = -1
 AVMEDIA_TYPE_VIDEO = 0
@@ -137,6 +126,9 @@ class AVRational(Structure):
         ('num', c_int),
         ('den', c_int)
     ]
+
+    def __repr__(self):
+        return f"AVRational({self.num}/{self.den})"
 
 
 class AVFrameSideData(Structure):

--- a/pyglet/media/codecs/ffmpeg_lib/libswresample.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libswresample.py
@@ -44,27 +44,16 @@ from . import compat
 
 _debug = debug_print('debug_media')
 
+swresample = pyglet.lib.load_library(
+    'swresample',
+    win32=('swresample-4', 'swresample-3'),
+    darwin=('swresample.4', 'swresample.3')
+)
 
-try:
-    swresample = pyglet.lib.load_library(
-        'swresample',
-        win32='swresample-4',
-        darwin='swresample.4'
-    )
-    version = 4
+swresample.swresample_version.restype = c_int
 
-except ImportError:
-    if _debug:
-        print("Failed to load: swresample-4. Trying older version.")
+compat.set_version('swresample', swresample.swresample_version() >> 16)
 
-    swresample = pyglet.lib.load_library(
-        'swresample',
-        win32='swresample-3',
-        darwin='swresample.3'
-    )
-    version = 3
-
-compat.set_version('swresample', version)
 
 SWR_CH_MAX = 32
 

--- a/pyglet/media/codecs/ffmpeg_lib/libswscale.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libswscale.py
@@ -44,25 +44,17 @@ from . import compat
 
 _debug = debug_print('debug_media')
 
-try:
-    swscale = pyglet.lib.load_library(
-        'swscale',
-        win32='swscale-6',
-        darwin='swscale.6'
-    )
-    version = 6
-except ImportError:
-    if _debug:
-        print("Failed to load: swscale-6. Trying older version.")
 
-    swscale = pyglet.lib.load_library(
-        'swscale',
-        win32='swscale-5',
-        darwin='swscale.5'
-    )
-    version = 5
+swscale = pyglet.lib.load_library(
+    'swscale',
+    win32=('swscale-6', 'swscale-5'),
+    darwin=('swscale.6', 'swscale.5')
+)
 
-compat.set_version('swscale', version)
+swscale.swscale_version.restype = c_int
+
+compat.set_version('swscale', swscale.swscale_version() >> 16)
+
 
 SWS_FAST_BILINEAR = 1
 


### PR DESCRIPTION
Version detection is now done on the library files themselves, rather than trying to determine from the filename. This should fix compatibility issues with Linux as there are no version names in the filename.

Version information moved into the FFmpeg loaded debug message.