### PR TITLE
Fix resize issue and move event

### DIFF
--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -832,11 +832,6 @@ class Win32Window(BaseWindow):
         else:
             return None
 
-    @Win32EventHandler(WM_WINDOWPOSCHANGED)
-    def _event_window_pos_changed(self, msg, wParam, lParam):
-        if self._exclusive_mouse:
-            self._update_clipped_cursor()
-
     @Win32EventHandler(WM_NCLBUTTONDOWN)
     def _event_ncl_button_down(self, msg, wParam, lParam):
         self._in_title_bar = True
@@ -1097,6 +1092,10 @@ class Win32Window(BaseWindow):
         if not self._fullscreen:
             self._width, self._height = w, h
         self._update_view_location(self._width, self._height)
+
+        if self._exclusive_mouse:
+            self._update_clipped_cursor()
+
         self.switch_to()
         self.dispatch_event('on_resize', self._width, self._height)
         return 0


### PR DESCRIPTION
This should fix two issues: One window was not updating image on resize: 
Example:
![image](https://user-images.githubusercontent.com/17804711/162589906-cb66bd85-e397-4ef5-8c7e-57112b0d42f4.png)

`on_move` event was not being called.

(Notes: WM_WINDOWPOSCHANGED is newer and supposed to be faster, however lParam returns garbage data at the beginning of Window creation making it unreliable. Sizes are also based on total window size, not viewable areas. So not as suitable.)