### PR TITLE
Include fragment shader in default program

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -455,7 +455,13 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
             gl_Position = window.projection * window.view * position;
         }
     """
+    _default_fragment_source = """#version 150 core
+    out vec4 fragColor;
 
+    void main() {
+        fragColor = vec4(1.0);
+    }
+    """
     def __init__(self,
                  width=None,
                  height=None,
@@ -611,7 +617,10 @@ class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
             self.activate()
 
     def _create_projection(self):
-        self._default_program = shader.ShaderProgram(shader.Shader(self._default_vertex_source, 'vertex'))
+        self._default_program = shader.ShaderProgram(
+            shader.Shader(self._default_vertex_source, 'vertex'),
+            shader.Shader(self._default_fragment_source, 'fragment'),
+        )
         self.ubo = self._default_program.uniform_blocks['WindowBlock'].create_ubo()
 
         self._viewport = 0, 0, *self.get_framebuffer_size()


### PR DESCRIPTION
Some drivers can be more aggressive than others  when it comes to purging program members that don't have any effect on a program as a whole during the linking stage. In theory the default program  could be reduced to an empty `main()` because there is no shader picking up the data emitted by the vertex  shader.

The only way to be 100% sure a pure vertex shader would not be stripped of members is with a transform vertex shaders with an  `out vec4 out_position`  instead of `gl_Position` and this out varying was  configured with `glTransformFeedbackVaryings` before the program is linked.
