### PR TITLE
XInput Device Filtering

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -159,6 +159,7 @@ options = {
     'headless': False,
     'headless_device': 0,
     'win32_disable_shaping': False,
+    'xinput_controllers': True,
 }
 
 _option_types = {
@@ -186,7 +187,8 @@ _option_types = {
     'win32_gdi_font': bool,
     'headless': bool,
     'headless_device': int,
-    'win32_disable_shaping': bool
+    'win32_disable_shaping': bool,
+    'xinput_controllers': bool
 }
 
 

--- a/pyglet/input/directinput.py
+++ b/pyglet/input/directinput.py
@@ -226,8 +226,21 @@ def _init_directinput():
 def get_devices(display=None):
     _init_directinput()
     _devices = []
+    _xinput_devices = []
+    if pyglet.options["xinput_controllers"]:
+        try:
+            from .xinput import get_xinput_guids
+            _xinput_devices = get_xinput_guids()
+        except ImportError:
+            pass
 
     def _device_enum(device_instance, arg):
+        guid_id = format(device_instance.contents.guidProduct.Data1, "08x")
+        # Only XInput should handle DirectInput devices if enabled. Filter them out.
+        if guid_id in _xinput_devices:
+            # Log somewhere?
+            return dinput.DIENUM_CONTINUE
+
         device = dinput.IDirectInputDevice8()
         _i_dinput.CreateDevice(device_instance.contents.guidInstance, ctypes.byref(device), None)
         _devices.append(DirectInputDevice(display, device, device_instance.contents))

--- a/pyglet/libs/win32/__init__.py
+++ b/pyglet/libs/win32/__init__.py
@@ -91,6 +91,7 @@ _user32 = DebugLibrary(windll.user32)
 _dwmapi = DebugLibrary(windll.dwmapi)
 _shell32 = DebugLibrary(windll.shell32)
 _ole32 = DebugLibrary(windll.ole32)
+_oleaut32 = DebugLibrary(windll.oleaut32)
 
 # _gdi32
 _gdi32.AddFontMemResourceEx.restype = HANDLE
@@ -292,6 +293,8 @@ _shell32.DragQueryPoint.argtypes = [HDROP, LPPOINT]
 
 # ole32
 _ole32.CreateStreamOnHGlobal.argtypes = [HGLOBAL, BOOL, LPSTREAM]
+_ole32.CoInitialize.restype = HRESULT
+_ole32.CoInitialize.argtypes = [LPVOID]
 _ole32.CoInitializeEx.restype = HRESULT
 _ole32.CoInitializeEx.argtypes = [LPVOID, DWORD]
 _ole32.CoUninitialize.restype = HRESULT
@@ -300,3 +303,12 @@ _ole32.PropVariantClear.restype = HRESULT
 _ole32.PropVariantClear.argtypes = [c_void_p]
 _ole32.CoCreateInstance.restype = HRESULT
 _ole32.CoCreateInstance.argtypes = [com.REFIID, c_void_p, DWORD, com.REFIID, c_void_p]
+_ole32.CoSetProxyBlanket.restype = HRESULT
+_ole32.CoSetProxyBlanket.argtypes = (c_void_p, DWORD, DWORD, c_void_p, DWORD, DWORD, c_void_p, DWORD)
+
+
+# oleaut32
+_oleaut32.VariantInit.restype = c_void_p
+_oleaut32.VariantInit.argtypes = [c_void_p]
+_oleaut32.VariantClear.restype = HRESULT
+_oleaut32.VariantClear.argtypes = [c_void_p]

--- a/pyglet/libs/win32/types.py
+++ b/pyglet/libs/win32/types.py
@@ -509,6 +509,23 @@ class PROPVARIANT(ctypes.Structure):
         ('union', _VarTable)
     ]
 
+class _VarTableVariant(ctypes.Union):
+    """Must be in an anonymous union or values will not work across various VT's."""
+    _fields_ = [
+        ('bstrVal', LPCWSTR)
+    ]
+
+
+class VARIANT(ctypes.Structure):
+    _anonymous_ = ['union']
+
+    _fields_ = [
+        ('vt', ctypes.c_ushort),
+        ('wReserved1', WORD),
+        ('wReserved2', WORD),
+        ('wReserved3', WORD),
+        ('union', _VarTableVariant)
+    ]
 
 class DWM_BLURBEHIND(ctypes.Structure):
     _fields_ = [


### PR DESCRIPTION
Allow filtering out of XInput devices in DirectInput, as a device should only be managed by one API to prevent overlapping issues.

Add option of disabling XInput if you wish to work purely with DirectInput.