### PR TITLE
Fix attempting to load multiple libraries on win32

### DIFF
--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -162,7 +162,8 @@ class LibraryLoader:
                     except OSError:
                         pass
                 elif self.platform == "win32" and o.winerror != 126:
-                    raise ImportError("Unexpected error loading library %s: %s" % (name, str(o)))
+                    if _debug_lib:
+                        print(f"Unexpected error loading library {name}: {str(o)}")
 
         raise ImportError('Library "%s" not found.' % names[0])
 


### PR DESCRIPTION
When trying to load multiple library names on win32 `load_library` will just exit the loop on the first library that fails. Let's instead print some debug info instead.