### PR TITLE
Removed unnecessary __init__ that only calls super().__init__()

### DIFF
--- a/pyglet/window/headless/__init__.py
+++ b/pyglet/window/headless/__init__.py
@@ -56,9 +56,6 @@ class HeadlessWindow(BaseWindow):
     _egl_display_connection = None
     _egl_surface = None
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _recreate(self, changes):
         pass
 


### PR DESCRIPTION
In [this](https://github.com/pyglet/pyglet/blob/master/pyglet/window/headless/__init__.py#L59) file on line 55-60 there is this code:
```py
class HeadlessWindow(BaseWindow):
    _egl_display_connection = None
    _egl_surface = None

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
```

the `HeadlessWindow.__init__(self, *args, **kwargs)` overwrites `BaseWindow`'s `__init__` only to just call the `BaseWindow`'s init with `super().__init__(*args, **kwargs)` its unneeded because BaseWindow has an `__init__`, and code editors will only show `(*args, **kwargs)` in the parameters preview.