### PR TITLE
[Win32] Stop setting `HWND_TOPMOST` for fullscreen

### DIFF
--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -267,18 +267,13 @@ class Win32Window(BaseWindow):
                                    GWL_EXSTYLE,
                                    self._ex_ws_style)
 
-        if self._fullscreen:
-            hwnd_after = HWND_TOPMOST
-        else:
-            hwnd_after = HWND_NOTOPMOST
-
         # Position and size window
         if self._fullscreen:
-            _user32.SetWindowPos(self._hwnd, hwnd_after,
+            _user32.SetWindowPos(self._hwnd, HWND_NOTOPMOST,
                                  self._screen.x, self._screen.y, width, height, SWP_FRAMECHANGED)
         elif False:  # TODO location not in pyglet API
             x, y = self._client_to_window_pos(*factory.get_location())
-            _user32.SetWindowPos(self._hwnd, hwnd_after,
+            _user32.SetWindowPos(self._hwnd, HWND_NOTOPMOST,
                                  x, y, width, height, SWP_FRAMECHANGED)
         elif self.style == 'transparent' or self.style == "overlay":
             _user32.SetLayeredWindowAttributes(self._hwnd, 0, 254, LWA_ALPHA)
@@ -286,7 +281,7 @@ class Win32Window(BaseWindow):
                 _user32.SetWindowPos(self._hwnd, HWND_TOPMOST, 0,
                                      0, width, height, SWP_NOMOVE | SWP_NOSIZE)
         else:
-            _user32.SetWindowPos(self._hwnd, hwnd_after,
+            _user32.SetWindowPos(self._hwnd, HWND_NOTOPMOST,
                                  0, 0, width, height, SWP_NOMOVE | SWP_FRAMECHANGED)
 
         self._update_view_location(self._width, self._height)
@@ -429,7 +424,7 @@ class Win32Window(BaseWindow):
 
     def set_visible(self, visible=True):
         if visible:
-            insertAfter = HWND_TOPMOST if self._fullscreen else HWND_TOP
+            insertAfter = HWND_TOP
             _user32.SetWindowPos(self._hwnd, insertAfter, 0, 0, 0, 0,
                                  SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW)
             self.dispatch_event('on_resize', self._width, self._height)

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -269,7 +269,8 @@ class Win32Window(BaseWindow):
 
         # Position and size window
         if self._fullscreen:
-            _user32.SetWindowPos(self._hwnd, HWND_NOTOPMOST,
+            hwnd_after = HWND_TOPMOST if self.style == "overlay" else HWND_NOTOPMOST
+            _user32.SetWindowPos(self._hwnd, hwnd_after,
                                  self._screen.x, self._screen.y, width, height, SWP_FRAMECHANGED)
         elif False:  # TODO location not in pyglet API
             x, y = self._client_to_window_pos(*factory.get_location())


### PR DESCRIPTION
This patch removes the code that sets the `HWND_TOPMOST` flag when the window is in fullscreen mode.
If the `overlay` window style is used then the `HWND_TOPMOST` flag will still be used, so the original effect can still be achieved if intended.

This resolves #566 