### PR TITLE
Bind index buffers safely

### DIFF
--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -271,8 +271,9 @@ def draw_indexed(size, mode, indices, **data):
     # With GL 3.3 vertex arrays indices needs to be in a buffer
     # bound to the ELEMENT_ARRAY slot
     index_array = (index_c_type * len(indices))(*indices)
-    index_buffer = BufferObject(ctypes.sizeof(index_array), GL_ELEMENT_ARRAY_BUFFER)
+    index_buffer = BufferObject(ctypes.sizeof(index_array))
     index_buffer.set_data(index_array)
+    index_buffer.bind_to_index_buffer()
 
     glDrawElements(mode, len(indices), index_type, 0)
     glFlush()

--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -177,7 +177,7 @@ class BufferObject(AbstractBuffer):
     that does implement :py:meth:`~AbstractMappable.get_region`.
     """
 
-    def __init__(self, size, target, usage=GL_DYNAMIC_DRAW):
+    def __init__(self, size, target=GL_ARRAY_BUFFER, usage=GL_DYNAMIC_DRAW):
         self.size = size
         self.target = target
         self.usage = usage
@@ -199,6 +199,10 @@ class BufferObject(AbstractBuffer):
 
     def unbind(self):
         glBindBuffer(self.target, 0)
+
+    def bind_to_index_buffer(self):
+        """Binds this buffer as an index buffer on the active vertex array."""
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, self.id)
 
     def set_data(self, data):
         glBindBuffer(self.target, self.id)

--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -194,8 +194,8 @@ class BufferObject(AbstractBuffer):
     def invalidate(self):
         glBufferData(self.target, self.size, None, self.usage)
 
-    def bind(self):
-        glBindBuffer(self.target, self.id)
+    def bind(self, target=None):
+        glBindBuffer(target or self.target, self.id)
 
     def unbind(self):
         glBindBuffer(self.target, 0)

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -370,8 +370,7 @@ class IndexedVertexDomain(VertexDomain):
         self.index_gl_type = index_gl_type
         self.index_c_type = vertexattribute._c_types[index_gl_type]
         self.index_element_size = ctypes.sizeof(self.index_c_type)
-        self.index_buffer = BufferObject(
-            self.index_allocator.capacity * self.index_element_size, GL_ELEMENT_ARRAY_BUFFER)
+        self.index_buffer = BufferObject(self.index_allocator.capacity * self.index_element_size)
 
     def safe_index_alloc(self, count):
         """Allocate indices, resizing the buffers if necessary."""
@@ -454,7 +453,7 @@ class IndexedVertexDomain(VertexDomain):
             for attribute in attributes:
                 attribute.enable()
                 attribute.set_pointer(attribute.buffer.ptr)
-        self.index_buffer.bind()
+        self.index_buffer.bind_to_index_buffer()
 
         starts, sizes = self.index_allocator.get_allocated_regions()
         primcount = len(starts)
@@ -494,7 +493,7 @@ class IndexedVertexDomain(VertexDomain):
             for attribute in attributes:
                 attribute.enable()
                 attribute.set_pointer(attribute.buffer.ptr)
-        self.index_buffer.bind()
+        self.index_buffer.bind_to_index_buffer()
 
         glDrawElements(mode, vertex_list.index_count, self.index_gl_type,
                        self.index_buffer.ptr +


### PR DESCRIPTION
Buffers should ideally just stay as `GL_ARRAY_BUFFER` by default since this target doesn't affect anything. Binding to any other target has an important meaning in OpenGL and should not be used just to write data into the buffer.

This PR fixes an issue were an index buffer in pyglet suddely binds itself to any random vertex array that is active. In this case it was a vertex array in arcade.
