### PR TITLE
Buffer: Remove target in initializer + target cleanup

### DIFF
--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -202,7 +202,7 @@ def draw(size, mode, **data):
         attribute = vertexattribute.VertexAttribute(name, location, count, gl_type, normalize)
         assert size == len(array) // attribute.count, 'Data for %s is incorrect length' % fmt
 
-        buffer = BufferObject(size * attribute.stride, GL_ARRAY_BUFFER)
+        buffer = BufferObject(size * attribute.stride)
         attribute.set_region(buffer, 0, size, array)
         attribute.enable()
         attribute.set_pointer(buffer.ptr)
@@ -252,7 +252,7 @@ def draw_indexed(size, mode, indices, **data):
         attribute = vertexattribute.VertexAttribute(name, location, count, gl_type, normalize)
         assert size == len(array) // attribute.count, 'Data for %s is incorrect length' % fmt
 
-        buffer = BufferObject(size * attribute.stride, GL_ARRAY_BUFFER)
+        buffer = BufferObject(size * attribute.stride)
         attribute.set_region(buffer, 0, size, array)
         attribute.enable()
         attribute.set_pointer(buffer.ptr)

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -729,7 +729,7 @@ class UniformBufferObject:
     __slots__ = 'buffer', 'view', '_view_ptr', 'index'
 
     def __init__(self, view_class, buffer_size, index):
-        self.buffer = BufferObject(buffer_size, GL_UNIFORM_BUFFER)
+        self.buffer = BufferObject(buffer_size)
         self.view = view_class()
         self._view_ptr = pointer(self.view)
         self.index = index
@@ -743,10 +743,10 @@ class UniformBufferObject:
 
     def read(self):
         """Read the byte contents of the buffer"""
-        glBindBuffer(GL_UNIFORM_BUFFER, self.buffer.id)
-        ptr = glMapBufferRange(GL_UNIFORM_BUFFER, 0, self.buffer.size, GL_MAP_READ_BIT)
+        glBindBuffer(GL_ARRAY_BUFFER, self.buffer.id)
+        ptr = glMapBufferRange(GL_ARRAY_BUFFER, 0, self.buffer.size, GL_MAP_READ_BIT)
         data = string_at(ptr, size=self.buffer.size)
-        glUnmapBuffer(GL_UNIFORM_BUFFER)
+        glUnmapBuffer(GL_ARRAY_BUFFER)
         return data
 
     def __enter__(self):

--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -59,8 +59,6 @@ class AbstractBuffer:
         `ptr` : int
             Memory offset of the buffer, as used by the ``glVertexPointer``
             family of functions
-        `target` : int
-            OpenGL buffer target, for example ``GL_ARRAY_BUFFER``
         `usage` : int
             OpenGL buffer usage, for example ``GL_DYNAMIC_DRAW``
 
@@ -69,8 +67,8 @@ class AbstractBuffer:
     ptr = 0
     size = 0
 
-    def bind(self):
-        """Bind this buffer to its OpenGL target."""
+    def bind(self, target=GL_ARRAY_BUFFER):
+        """Bind this buffer to an OpenGL target."""
         raise NotImplementedError('abstract')
 
     def unbind(self):
@@ -170,6 +168,9 @@ class BufferObject(AbstractBuffer):
     The data in the buffer is not replicated in any system memory (unless it
     is done so by the video driver).  While this can improve memory usage and
     possibly performance, updates to the buffer are relatively slow.
+    The target of the buffer is ``GL_ARRAY_BUFFER`` internally to avoid
+    accidentally overriding other states when altering the buffer contents.
+    The intended target can be set when binding the buffer.
 
     This class does not implement :py:class:`AbstractMappable`, and so has no
     :py:meth:`~AbstractMappable.get_region` method.  See 
@@ -177,9 +178,8 @@ class BufferObject(AbstractBuffer):
     that does implement :py:meth:`~AbstractMappable.get_region`.
     """
 
-    def __init__(self, size, target=GL_ARRAY_BUFFER, usage=GL_DYNAMIC_DRAW):
+    def __init__(self, size, usage=GL_DYNAMIC_DRAW):
         self.size = size
-        self.target = target
         self.usage = usage
         self._context = pyglet.gl.current_context
 
@@ -187,43 +187,43 @@ class BufferObject(AbstractBuffer):
         glGenBuffers(1, buffer_id)
         self.id = buffer_id.value
 
-        glBindBuffer(target, self.id)
+        glBindBuffer(GL_ARRAY_BUFFER, self.id)
         data = (GLubyte * self.size)()
-        glBufferData(target, self.size, data, self.usage)
+        glBufferData(GL_ARRAY_BUFFER, self.size, data, self.usage)
 
     def invalidate(self):
-        glBufferData(self.target, self.size, None, self.usage)
+        glBufferData(GL_ARRAY_BUFFER, self.size, None, self.usage)
 
-    def bind(self, target=None):
-        glBindBuffer(target or self.target, self.id)
+    def bind(self, target=GL_ARRAY_BUFFER):
+        glBindBuffer(target, self.id)
 
     def unbind(self):
-        glBindBuffer(self.target, 0)
+        glBindBuffer(GL_ARRAY_BUFFER, 0)
 
     def bind_to_index_buffer(self):
         """Binds this buffer as an index buffer on the active vertex array."""
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, self.id)
 
     def set_data(self, data):
-        glBindBuffer(self.target, self.id)
-        glBufferData(self.target, self.size, data, self.usage)
+        glBindBuffer(GL_ARRAY_BUFFER, self.id)
+        glBufferData(GL_ARRAY_BUFFER, self.size, data, self.usage)
 
     def set_data_region(self, data, start, length):
-        glBindBuffer(self.target, self.id)
-        glBufferSubData(self.target, start, length, data)
+        glBindBuffer(GL_ARRAY_BUFFER, self.id)
+        glBufferSubData(GL_ARRAY_BUFFER, start, length, data)
 
     def map(self):
-        glBindBuffer(self.target, self.id)
-        ptr = ctypes.cast(glMapBuffer(self.target, GL_WRITE_ONLY), ctypes.POINTER(ctypes.c_byte * self.size)).contents
+        glBindBuffer(GL_ARRAY_BUFFER, self.id)
+        ptr = ctypes.cast(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY), ctypes.POINTER(ctypes.c_byte * self.size)).contents
         return ptr
 
     def map_range(self, start, size, ptr_type):
-        glBindBuffer(self.target, self.id)
-        ptr = ctypes.cast(glMapBufferRange(self.target, start, size, GL_MAP_WRITE_BIT), ptr_type).contents
+        glBindBuffer(GL_ARRAY_BUFFER, self.id)
+        ptr = ctypes.cast(glMapBufferRange(GL_ARRAY_BUFFER, start, size, GL_MAP_WRITE_BIT), ptr_type).contents
         return ptr
 
     def unmap(self):
-        glUnmapBuffer(self.target)
+        glUnmapBuffer(GL_ARRAY_BUFFER)
 
     def __del__(self):
         try:
@@ -244,13 +244,13 @@ class BufferObject(AbstractBuffer):
         # Map, create a copy, then reinitialize.
         temp = (ctypes.c_byte * size)()
 
-        glBindBuffer(self.target, self.id)
-        data = glMapBufferRange(self.target, 0, self.size, GL_MAP_READ_BIT)
+        glBindBuffer(GL_ARRAY_BUFFER, self.id)
+        data = glMapBufferRange(GL_ARRAY_BUFFER, 0, self.size, GL_MAP_READ_BIT)
         ctypes.memmove(temp, data, min(size, self.size))
-        glUnmapBuffer(self.target)
+        glUnmapBuffer(GL_ARRAY_BUFFER)
 
         self.size = size
-        glBufferData(self.target, self.size, temp, self.usage)
+        glBufferData(GL_ARRAY_BUFFER, self.size, temp, self.usage)
 
     def __repr__(self):
         return f"{self.__class__.__name__}(id={self.id}, size={self.size})"
@@ -267,8 +267,8 @@ class MappableBufferObject(BufferObject, AbstractMappable):
 
     Updates to data via :py:meth:`map` are committed immediately.
     """
-    def __init__(self, size, target, usage=GL_DYNAMIC_DRAW):
-        super(MappableBufferObject, self).__init__(size, target, usage)
+    def __init__(self, size, usage=GL_DYNAMIC_DRAW):
+        super(MappableBufferObject, self).__init__(size, usage)
         self.data = (ctypes.c_byte * size)()
         self.data_ptr = ctypes.addressof(self.data)
         self._dirty_min = sys.maxsize
@@ -280,9 +280,9 @@ class MappableBufferObject(BufferObject, AbstractMappable):
         size = self._dirty_max - self._dirty_min
         if size > 0:
             if size == self.size:
-                glBufferData(self.target, self.size, self.data, self.usage)
+                glBufferData(GL_ARRAY_BUFFER, self.size, self.data, self.usage)
             else:
-                glBufferSubData(self.target, self._dirty_min, size, self.data_ptr + self._dirty_min)
+                glBufferSubData(GL_ARRAY_BUFFER, self._dirty_min, size, self.data_ptr + self._dirty_min)
             self._dirty_min = sys.maxsize
             self._dirty_max = 0
 
@@ -317,8 +317,8 @@ class MappableBufferObject(BufferObject, AbstractMappable):
 
         self.size = size
 
-        glBindBuffer(self.target, self.id)
-        glBufferData(self.target, self.size, self.data, self.usage)
+        glBindBuffer(GL_ARRAY_BUFFER, self.id)
+        glBufferData(GL_ARRAY_BUFFER, self.size, self.data, self.usage)
 
         self._dirty_min = sys.maxsize
         self._dirty_max = 0

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -127,7 +127,7 @@ class VertexDomain:
             attribute = vertexattribute.VertexAttribute(name, location, count, gl_type, normalize)
             self.attributes.append(attribute)
             # Create buffer:
-            attribute.buffer = MappableBufferObject(attribute.stride * self.allocator.capacity, GL_ARRAY_BUFFER)
+            attribute.buffer = MappableBufferObject(attribute.stride * self.allocator.capacity)
             attribute.buffer.element_size = attribute.stride
             attribute.buffer.attributes = (attribute,)
             self.buffer_attributes.append((attribute.buffer, (attribute,)))


### PR DESCRIPTION
* Remove `target` in buffer initializer and use `GL_ARRAY_BUFFER` internally. The user can set the target when binding the buffer.
* Clean up code specifying target
* `UniformBufferObject` should use `GL_ARRAY_BUFFER` internally