### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/internal/testing.rst
+++ b/doc/internal/testing.rst
@@ -36,7 +36,7 @@ There are currently 3 types of interactive test cases:
   These tests are decorated with
   :func:`~tests.interactive.interactive_test_base.requires_user_action`.
 - Tests that can run without user interaction, but that cannot validate
-  whether they should pass or fail. These tests are docorated with
+  whether they should pass or fail. These tests are decorated with
   :func:`~tests.interactive.interactive_test_base.requires_user_validation`.
 - Tests that can run without user interaction and that can compare results
   to screenshots from a previous run to determine whether they pass or

--- a/doc/programming_guide/time.rst
+++ b/doc/programming_guide/time.rst
@@ -39,7 +39,7 @@ To have a function called periodically, for example, once every 0.1 seconds::
 The `dt`, or `delta time` parameter gives the number of "wall clock" seconds
 elapsed since the last call of this function, (or the time the function was
 scheduled, if it's the first period). Due to latency, load and timer
-inprecision, this might be slightly more or less than the requested interval.
+imprecision, this might be slightly more or less than the requested interval.
 Please note that the `dt` parameter is always passed to scheduled functions,
 so be sure to expect it when writing functions even if you don't need to
 use it.


### PR DESCRIPTION
There are small typos in:
- doc/internal/testing.rst
- doc/programming_guide/time.rst

Fixes:
- Should read `imprecision` rather than `inprecision`.
- Should read `decorated` rather than `docorated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md