### PR TITLE
Fix for DC leak

### DIFF
--- a/pyglet/canvas/win32.py
+++ b/pyglet/canvas/win32.py
@@ -65,11 +65,13 @@ class Win32Screen(Screen):
         self._handle = handle
 
     def get_matching_configs(self, template):
-        canvas = Win32Canvas(self.display, 0, _user32.GetDC(0))
+        hdc = _user32.GetDC(0)
+        canvas = Win32Canvas(self.display, 0, hdc)
         configs = template.match(canvas)
         # XXX deprecate config's being screen-specific
         for config in configs:
             config.screen = self
+        _user32.ReleaseDC(0, hdc)
         return configs
 
     def get_device_name(self):

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -323,6 +323,7 @@ class Win32Window(BaseWindow):
             return
 
         _user32.DestroyWindow(self._hwnd)
+        _user32.UnregisterClassW(self._view_window_class.lpszClassName, 0)
         _user32.UnregisterClassW(self._window_class.lpszClassName, 0)
 
         self._window_class = None


### PR DESCRIPTION
Free DC when configs are checked. Seems after DC is used when checking pixel information, it's no longer used and another DC is created when the context is actually created. (Correct me if I'm wrong)

Unregister view window during window close to match behavior. Seems to resolve issue with a float zero issue.

Resolves https://github.com/pyglet/pyglet/issues/655

Can be merged into 1.5 as well.