### PR TITLE
Fix game asteroid

### DIFF
--- a/examples/game/version1/game/load.py
+++ b/examples/game/version1/game/load.py
@@ -13,8 +13,8 @@ def asteroids(num_asteroids, player_position):
     """Generate asteroid objects with random positions and velocities, 
     not close to the player"""
     asteroids = []
-    for i in range(num_asteroids):
-        asteroid_x, asteroid_y, _ = player_position
+    for _ in range(num_asteroids):
+        asteroid_x, asteroid_y = player_position
         while distance((asteroid_x, asteroid_y), player_position) < 100:
             asteroid_x = random.randint(0, 800)
             asteroid_y = random.randint(0, 600)

--- a/examples/game/version2/game/load.py
+++ b/examples/game/version2/game/load.py
@@ -22,8 +22,8 @@ def player_lives(num_icons, batch=None):
 def asteroids(num_asteroids, player_position, batch=None):
     """Generate asteroid objects with random positions and velocities, not close to the player"""
     asteroids = []
-    for i in range(num_asteroids):
-        asteroid_x, asteroid_y, _ = player_position
+    for _ in range(num_asteroids):
+        asteroid_x, asteroid_y = player_position
         while distance((asteroid_x, asteroid_y), player_position) < 100:
             asteroid_x = random.randint(0, 800)
             asteroid_y = random.randint(0, 600)

--- a/examples/game/version3/game/load.py
+++ b/examples/game/version3/game/load.py
@@ -18,8 +18,8 @@ def player_lives(num_icons, batch=None):
 def asteroids(num_asteroids, player_position, batch=None):
     """Generate asteroid objects with random positions and velocities, not close to the player"""
     asteroids = []
-    for i in range(num_asteroids):
-        asteroid_x, asteroid_y, _ = player_position
+    for _ in range(num_asteroids):
+        asteroid_x, asteroid_y = player_position
         while util.distance((asteroid_x, asteroid_y), player_position) < 100:
             asteroid_x = random.randint(0, 800)
             asteroid_y = random.randint(0, 600)

--- a/examples/game/version4/game/load.py
+++ b/examples/game/version4/game/load.py
@@ -18,8 +18,8 @@ def player_lives(num_icons, batch=None):
 def asteroids(num_asteroids, player_position, batch=None):
     """Generate asteroid objects with random positions and velocities, not close to the player"""
     asteroids = []
-    for i in range(num_asteroids):
-        asteroid_x, asteroid_y, _ = player_position
+    for _ in range(num_asteroids):
+        asteroid_x, asteroid_y = player_position
         while util.distance((asteroid_x, asteroid_y), player_position) < 100:
             asteroid_x = random.randint(0, 800)
             asteroid_y = random.randint(0, 600)

--- a/examples/game/version5/asteroid.py
+++ b/examples/game/version5/asteroid.py
@@ -119,6 +119,7 @@ def update(dt):
     # Get rid of dead objects
     for to_remove in [obj for obj in game_objects if obj.dead]:
         if to_remove == player_ship:
+            player_ship.dead = True
             player_dead = True
         # If the dying object spawned any new objects, add those to the 
         # game_objects list later

--- a/examples/game/version5/game/load.py
+++ b/examples/game/version5/game/load.py
@@ -18,8 +18,8 @@ def player_lives(num_icons, batch=None):
 def asteroids(num_asteroids, player_position, batch=None):
     """Generate asteroid objects with random positions and velocities, not close to the player"""
     asteroids = []
-    for i in range(num_asteroids):
-        asteroid_x, asteroid_y, _ = player_position
+    for _ in range(num_asteroids):
+        asteroid_x, asteroid_y = player_position
         while util.distance((asteroid_x, asteroid_y), player_position) < 100:
             asteroid_x = random.randint(0, 800)
             asteroid_y = random.randint(0, 600)

--- a/examples/game/version5/game/player.py
+++ b/examples/game/version5/game/player.py
@@ -6,6 +6,8 @@ from . import bullet, physicalobject, resources
 class Player(physicalobject.PhysicalObject):
     """Physical object that responds to user input"""
 
+    dead = False
+
     def __init__(self, *args, **kwargs):
         super(Player, self).__init__(img=resources.player_image, *args, **kwargs)
 
@@ -52,6 +54,10 @@ class Player(physicalobject.PhysicalObject):
             self.engine_sprite.visible = False
 
     def on_key_press(self, symbol, modifiers):
+        # Stop listening any event if dead
+        if self.dead:
+            return
+        
         if symbol == key.SPACE:
             self.fire()
 


### PR DESCRIPTION
Fixed 2 crashes at the example game "asteroid".

First was present in all the versions, at "load.py". Game crashed on start by trying to assign 2 values to 3 variables.
Second was present on version 5, at "player.py". Game crashed on trying to shoot with the player dead. The reason is the "on_key_pressed" function at "player.py", it was listening to key events after the player death, causing the game to crash on calling the "fire()" function.

This is a basic fix, but i hope it's enough :).