### PR TITLE
Fix #673: restore allowing 0 values in Sprite.update & add tests

### DIFF
--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -651,24 +651,41 @@ class Sprite(event.EventDispatcher):
             `scale_y` : float
                 Vertical scaling factor.
         """
-        if x:
+
+        translations_outdated = False
+
+        # only bother updating if the translation actually changed
+        if x is not None and x != self._x:
             self._x = x
-        if y:
+            translations_outdated = True
+        if y is not None and y != self._y:
             self._y = y
-        if z:
+            translations_outdated = True
+        if z is not None and z != self._z:
             self._z = z
-        if x or y or z:
+            translations_outdated = True
+
+        if translations_outdated:
             self._vertex_list.translate[:] = (self._x, self._y, self._z) * 4
-        if rotation:
+
+        if rotation is not None and rotation != self._rotation:
             self._rotation = rotation
             self._vertex_list.rotation[:] = (rotation,) * 4
-        if scale:
+
+        scales_outdated = False
+
+        # only bother updating if the scale actually changed
+        if scale is not None and scale != self._scale:
             self._scale = scale
-        if scale_x:
+            scales_outdated = True
+        if scale_x is not None and scale_x != self._scale_x:
             self._scale_x = scale_x
-        if scale_y:
+            scales_outdated = True
+        if scale_y is not None and scale_x != self._scale_y:
             self._scale_y = scale_y
-        if scale or scale_x or scale_y:
+            scales_outdated = True
+
+        if scales_outdated:
             self._vertex_list.scale[:] = (self._scale * self._scale_x, self._scale * self._scale_y) * 4
 
     @property

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -655,13 +655,13 @@ class Sprite(event.EventDispatcher):
         translations_outdated = False
 
         # only bother updating if the translation actually changed
-        if x is not None and x != self._x:
+        if x is not None:
             self._x = x
             translations_outdated = True
-        if y is not None and y != self._y:
+        if y is not None:
             self._y = y
             translations_outdated = True
-        if z is not None and z != self._z:
+        if z is not None:
             self._z = z
             translations_outdated = True
 
@@ -675,13 +675,13 @@ class Sprite(event.EventDispatcher):
         scales_outdated = False
 
         # only bother updating if the scale actually changed
-        if scale is not None and scale != self._scale:
+        if scale is not None:
             self._scale = scale
             scales_outdated = True
-        if scale_x is not None and scale_x != self._scale_x:
+        if scale_x is not None:
             self._scale_x = scale_x
             scales_outdated = True
-        if scale_y is not None and scale_x != self._scale_y:
+        if scale_y is not None:
             self._scale_y = scale_y
             scales_outdated = True
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -14,7 +14,7 @@ def get_fake_shader_program(*args, **kwargs):
 
     This will often be a `get_default_shader` method found at the top of
     a module. When testing a module, you can turn off GL context creation
-    near the top of the file as follows:
+    near the top of the file as follows::
 
         # At the end of the imports section. You may need to change the
         # relative import to account for nesting of test folders.

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,5 +1,28 @@
 from unittest import mock
 
 
-def get_fake_shader_program():
+def get_fake_shader_program(*args, **kwargs):
+    """
+    Return a mock instead of creating a real shader & GL context.
+
+    By default, batchable objects create or re-use a default shader
+    program. Creating this also creates a GL context, which risks unit
+    tests failing due to requiring an outside resource.
+
+    To keep unit tests pure, this function should be used to monkeypatch
+    methods that return a shader program during unit tests.
+
+    This will often be a `get_default_shader` method found at the top of
+    a module. When testing a module, you can turn off GL context creation
+    near the top of the file as follows:
+
+        # At the end of the imports section. You may need to change the
+        # relative import to account for nesting of test folders.
+        from . import get_fake_shader_program
+
+        pyglet.shapes.get_default_shader = get_fake_shader_program
+
+
+    :return: A mock shader that doesn't do anything
+    """
     return mock.MagicMock()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,5 @@
+from unittest import mock
+
+
+def get_fake_shader_program():
+    return mock.MagicMock()

--- a/tests/unit/shapes/__init__.py
+++ b/tests/unit/shapes/__init__.py
@@ -1,4 +1,3 @@
-from unittest import mock
 from pytest import fixture
 
 
@@ -17,8 +16,4 @@ def new_rgb_or_rgba_color(request):
     return request.param
 
 
-def get_fake_shader_program():
-    return mock.MagicMock()
-
-
-__all__ = ['new_rgb_color', 'new_rgba_color', 'new_rgb_or_rgba_color', 'get_fake_shader_program']
+__all__ = ['new_rgb_color', 'new_rgba_color', 'new_rgb_or_rgba_color']

--- a/tests/unit/shapes/test_bordered_rectangle.py
+++ b/tests/unit/shapes/test_bordered_rectangle.py
@@ -9,6 +9,7 @@ import pytest
 import pyglet
 from pyglet.shapes import BorderedRectangle
 from . import *
+from .. import get_fake_shader_program
 
 pyglet.shapes.get_default_shader = get_fake_shader_program
 

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -4,6 +4,7 @@ from functools import partial
 import pyglet
 from pyglet.shapes import *
 from . import *
+from .. import get_fake_shader_program
 
 
 # A real OpenGL context is not needed for these tests

--- a/tests/unit/test_sprite.py
+++ b/tests/unit/test_sprite.py
@@ -24,42 +24,93 @@ def _new_val_or_none(dimension_index: int = 0) -> Tuple[float, None]:
 
 
 @pytest.fixture(params=_new_val_or_none())
-def x_update_value(request):
+def x(request):
     return request.param
 
 
 @pytest.fixture(params=_new_val_or_none(1))
-def y_update_value(request):
+def y(request):
     return request.param
 
 
 @pytest.fixture(params=_new_val_or_none(2))
-def z_update_value(request):
+def z(request):
     return request.param
 
 
-def test_update_sets_passed_positions(dummy_sprite, x_update_value, y_update_value, z_update_value):
-
-    dummy_sprite.update(x=x_update_value, y=y_update_value, z=z_update_value)
-
-    if x_update_value is not None:
-        assert dummy_sprite.x == x_update_value
-
-    if y_update_value is not None:
-        assert dummy_sprite.y == y_update_value
-
-    if z_update_value is not None:
-        assert dummy_sprite.z == z_update_value
+@pytest.fixture(params=_new_val_or_none(3))
+def scale(request):
+    return request.param
 
 
-def test_update_leaves_unpassed_attributes_alone(dummy_sprite, x_update_value, y_update_value, z_update_value):
-    dummy_sprite.update(x=x_update_value, y=y_update_value, z=z_update_value)
+@pytest.fixture(params=_new_val_or_none(4))
+def scale_x(request):
+    return request.param
 
-    if x_update_value is None:
+
+@pytest.fixture(params=_new_val_or_none(5))
+def scale_y(request):
+    return request.param
+
+
+def test_update_sets_passed_positions(dummy_sprite, x, y, z):
+
+    dummy_sprite.update(x=x, y=y, z=z)
+
+    if x is not None:
+        assert dummy_sprite.x == x
+
+    if y is not None:
+        assert dummy_sprite.y == y
+
+    if z is not None:
+        assert dummy_sprite.z == z
+
+
+def test_update_leaves_unpassed_translations_alone(dummy_sprite, x, y, z):
+    dummy_sprite.update(x=x, y=y, z=z)
+
+    if x is None:
         assert dummy_sprite.x == 0
 
-    if y_update_value is None:
+    if y is None:
         assert dummy_sprite.y == 0
 
-    if z_update_value is None:
+    if z is None:
         assert dummy_sprite.z == 0
+
+
+def test_update_sets_passed_scales(dummy_sprite, scale, scale_x, scale_y):
+    dummy_sprite.update(scale=scale, scale_x=scale_x, scale_y=scale_y)
+
+    if scale is not None:
+        assert dummy_sprite.scale == scale
+
+    if scale_x is not None:
+        assert dummy_sprite.scale_x == scale_x
+
+    if scale_y is not None:
+        assert dummy_sprite.scale_y == scale_y
+
+
+def test_update_leaves_unpassed_scales_alone(dummy_sprite, x, y, z):
+    dummy_sprite.update(x=x, y=y, z=z)
+
+    if x is None:
+        assert dummy_sprite.x == 0
+
+    if y is None:
+        assert dummy_sprite.y == 0
+
+    if z is None:
+        assert dummy_sprite.z == 0
+
+
+def test_update_sets_rotation_when_passed(dummy_sprite):
+    dummy_sprite.update(rotation=3.0)
+    assert dummy_sprite.rotation == 3.0
+
+
+def test_update_leaves_rotation_alone_when_none(dummy_sprite):
+    dummy_sprite.update()
+    assert dummy_sprite.rotation == 0

--- a/tests/unit/test_sprite.py
+++ b/tests/unit/test_sprite.py
@@ -1,0 +1,65 @@
+from typing import Tuple
+from unittest.mock import MagicMock
+import pytest
+import pyglet
+from . import get_fake_shader_program
+
+
+# We don't need a real GL context for unit tests
+pyglet.sprite.get_default_shader = get_fake_shader_program
+
+
+@pytest.fixture
+def dummy_sprite():
+    """A sprite at 0, 0 with no image data.
+
+    The fact that there's no image data doesn't matter because these
+    tests never touch a real GL context which would check for it.
+    """
+    return pyglet.sprite.Sprite(MagicMock())
+
+
+def _new_val_or_none(dimension_index: int = 0) -> Tuple[float, None]:
+    return float(dimension_index + 1), None
+
+
+@pytest.fixture(params=_new_val_or_none())
+def x_update_value(request):
+    return request.param
+
+
+@pytest.fixture(params=_new_val_or_none(1))
+def y_update_value(request):
+    return request.param
+
+
+@pytest.fixture(params=_new_val_or_none(2))
+def z_update_value(request):
+    return request.param
+
+
+def test_update_sets_passed_positions(dummy_sprite, x_update_value, y_update_value, z_update_value):
+
+    dummy_sprite.update(x=x_update_value, y=y_update_value, z=z_update_value)
+
+    if x_update_value is not None:
+        assert dummy_sprite.x == x_update_value
+
+    if y_update_value is not None:
+        assert dummy_sprite.y == y_update_value
+
+    if z_update_value is not None:
+        assert dummy_sprite.z == z_update_value
+
+
+def test_update_leaves_unpassed_attributes_alone(dummy_sprite, x_update_value, y_update_value, z_update_value):
+    dummy_sprite.update(x=x_update_value, y=y_update_value, z=z_update_value)
+
+    if x_update_value is None:
+        assert dummy_sprite.x == 0
+
+    if y_update_value is None:
+        assert dummy_sprite.y == 0
+
+    if z_update_value is None:
+        assert dummy_sprite.z == 0

--- a/tests/unit/test_sprite.py
+++ b/tests/unit/test_sprite.py
@@ -10,107 +10,119 @@ pyglet.sprite.get_default_shader = get_fake_shader_program
 
 
 @pytest.fixture
-def dummy_sprite():
-    """A sprite at 0, 0 with no image data.
+def sprite():
+    """A sprite with no image data.
 
-    The fact that there's no image data doesn't matter because these
-    tests never touch a real GL context which would check for it.
+    It is created at a non-zero position so that the update method can
+    be verified as working when passed zero positions (Issue #673).
+    Scale values do not need to be set to 0 in the fixture as they are
+    all 1.0 by default.
+
+    The lack of image data doesn't matter because these tests never touch
+    a real GL context which would require it.
     """
-    return pyglet.sprite.Sprite(MagicMock())
+    sprite = pyglet.sprite.Sprite(MagicMock(), x=1, y=2, z=3)
+    sprite.rotation = 90
+
+    return sprite
 
 
-def _new_val_or_none(dimension_index: int = 0) -> Tuple[float, None]:
-    return float(dimension_index + 1), None
+def _new_or_none(new_value: float = 0.0) -> Tuple[float, None]:
+    return new_value, None
 
 
-@pytest.fixture(params=_new_val_or_none())
+@pytest.fixture(params=_new_or_none())
 def x(request):
     return request.param
 
 
-@pytest.fixture(params=_new_val_or_none(1))
+@pytest.fixture(params=_new_or_none())
 def y(request):
     return request.param
 
 
-@pytest.fixture(params=_new_val_or_none(2))
+@pytest.fixture(params=_new_or_none())
 def z(request):
     return request.param
 
 
-@pytest.fixture(params=_new_val_or_none(3))
+@pytest.fixture(params=_new_or_none())
 def scale(request):
     return request.param
 
 
-@pytest.fixture(params=_new_val_or_none(4))
+@pytest.fixture(params=_new_or_none())
 def scale_x(request):
     return request.param
 
 
-@pytest.fixture(params=_new_val_or_none(5))
+@pytest.fixture(params=_new_or_none())
 def scale_y(request):
     return request.param
 
 
-def test_update_sets_passed_positions(dummy_sprite, x, y, z):
+def test_update_sets_passed_positions(sprite, x, y, z):
 
-    dummy_sprite.update(x=x, y=y, z=z)
+    sprite.update(x=x, y=y, z=z)
 
     if x is not None:
-        assert dummy_sprite.x == x
+        assert sprite.x == x
 
     if y is not None:
-        assert dummy_sprite.y == y
+        assert sprite.y == y
 
     if z is not None:
-        assert dummy_sprite.z == z
+        assert sprite.z == z
 
 
-def test_update_leaves_unpassed_translations_alone(dummy_sprite, x, y, z):
-    dummy_sprite.update(x=x, y=y, z=z)
+def test_update_leaves_none_translations_alone(sprite, x, y, z):
+    o_x, o_y, o_z = sprite.x, sprite.y, sprite.z
+
+    sprite.update(x=x, y=y, z=z)
 
     if x is None:
-        assert dummy_sprite.x == 0
+        assert sprite.x == o_x
 
     if y is None:
-        assert dummy_sprite.y == 0
+        assert sprite.y == o_y
 
     if z is None:
-        assert dummy_sprite.z == 0
+        assert sprite.z == o_z
 
 
-def test_update_sets_passed_scales(dummy_sprite, scale, scale_x, scale_y):
-    dummy_sprite.update(scale=scale, scale_x=scale_x, scale_y=scale_y)
+def test_update_sets_passed_scales(sprite, scale, scale_x, scale_y):
+    sprite.update(scale=scale, scale_x=scale_x, scale_y=scale_y)
 
     if scale is not None:
-        assert dummy_sprite.scale == scale
+        assert sprite.scale == scale
 
     if scale_x is not None:
-        assert dummy_sprite.scale_x == scale_x
+        assert sprite.scale_x == scale_x
 
     if scale_y is not None:
-        assert dummy_sprite.scale_y == scale_y
+        assert sprite.scale_y == scale_y
 
 
-def test_update_leaves_unpassed_scales_alone(dummy_sprite, x, y, z):
-    dummy_sprite.update(x=x, y=y, z=z)
+def test_update_leaves_none_scales_alone(sprite, scale, scale_x, scale_y):
+    o_scale, o_scale_x, o_scale_y = sprite.scale, sprite.scale_x, sprite.scale_y
 
-    if x is None:
-        assert dummy_sprite.x == 0
+    sprite.update(x=x, y=y, z=z)
 
-    if y is None:
-        assert dummy_sprite.y == 0
+    if scale is None:
+        assert sprite.scale == o_scale
 
-    if z is None:
-        assert dummy_sprite.z == 0
+    if scale_x is None:
+        assert sprite.scale_x == o_scale_x
 
-
-def test_update_sets_rotation_when_passed(dummy_sprite):
-    dummy_sprite.update(rotation=3.0)
-    assert dummy_sprite.rotation == 3.0
+    if scale_y is None:
+        assert sprite.scale_y == o_scale_y
 
 
-def test_update_leaves_rotation_alone_when_none(dummy_sprite):
-    dummy_sprite.update()
-    assert dummy_sprite.rotation == 0
+def test_update_sets_rotation_when_passed(sprite):
+    sprite.update(rotation=0.0)
+    assert sprite.rotation == 0.0
+
+
+def test_update_leaves_rotation_alone_when_none(sprite):
+    sprite.update()
+    assert sprite.rotation == 90


### PR DESCRIPTION
Closes #673 

My understanding was that function calls and sending data to the GPU are expensive. However, I can see it making sense to not check for equivalences since `Sprite.update` can be understood as an explicit command to update. Let me know if I should scale back or remove the equivalence checks.