### PR TITLE
Fix "sticky buttons"

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -129,6 +129,7 @@ import warnings
 
 import pyglet
 import pyglet.window.key
+import pyglet.window.mouse
 import pyglet.window.event
 
 from pyglet import gl

--- a/pyglet/window/key.py
+++ b/pyglet/window/key.py
@@ -67,6 +67,8 @@ from pyglet import compat_platform
 class KeyStateHandler(dict):
     """Simple handler that tracks the state of keys on the keyboard. If a
     key is pressed then this handler holds a True value for it.
+    If the window loses focus, all keys will be reset to False to avoid a
+    "sticky" key state.
 
     For example::
 
@@ -82,11 +84,15 @@ class KeyStateHandler(dict):
         False
 
     """
+
     def on_key_press(self, symbol, modifiers):
         self[symbol] = True
 
     def on_key_release(self, symbol, modifiers):
         self[symbol] = False
+    
+    def on_deactivate(self):
+        self.clear()
 
     def __getitem__(self, key):
         return self.get(key, False)

--- a/pyglet/window/mouse.py
+++ b/pyglet/window/mouse.py
@@ -40,6 +40,8 @@
 class MouseStateHandler(dict):
     """Simple handler that tracks the state of buttons from the mouse. If a
     button is pressed then this handler holds a True value for it.
+    If the window loses focus, all buttons will be reset to False to avoid a
+    "sticky" button state.
 
     For example::
 
@@ -55,12 +57,16 @@ class MouseStateHandler(dict):
         False
 
     """
+
     def on_mouse_press(self, x, y, button, modifiers):
         self[button] = True
         
     def on_mouse_release(self, x, y, button, modifiers):
         self[button] = False
         
+    def on_deactivate(self):
+        self.clear()
+
     def __getitem__(self, key):
         return self.get(key, False)
 


### PR DESCRIPTION
This PR makes 2 changes:

- Adds the `on_deactivate` event to the mouse and key state handlers, meaning that when the window loses focus it will treat it like all keys and mouse buttons had just been released. This prevents issues with "sticky buttons" such as when alt+tabbing when holding a key down.
- Imports the `pyglet.window.mouse` module by default.

Resolves #681 