### PR TITLE
Allow TextLayout ancestors (labels) to be refcount-collected

### DIFF
--- a/pyglet/text/layout.py
+++ b/pyglet/text/layout.py
@@ -928,16 +928,20 @@ class TextLayout:
 
         self._width = width
         self._height = height
-        self._multiline = multiline
-
-        # Alias the correct flow method:
-        self._flow_glyphs = self._flow_glyphs_wrap if multiline else self._flow_glyphs_single_line
+        self._multiline = multiline       
 
         self._wrap_lines_flag = wrap_lines
         self._wrap_lines_invariant()
 
         self._dpi = dpi or 96
         self.document = document
+        
+    @property
+    def _flow_glyphs(self):
+        if self._multiline:
+            return self._flow_glyphs_wrap
+        else:
+            return self._flow_glyphs_single_line
 
     def _initialize_groups(self):
         decoration_shader = get_default_decoration_shader()


### PR DESCRIPTION
The line
`self._flow_glyphs = self._flow_glyphs_wrap if multiline else self._flow_glyphs_single_line`
creates a back-reference to the TextLayout instance. Making `_flow_glyphs` a property removes the back-reference.

The snippet below draws two labels before the change, and one after.
```py
import pyglet

class MainWindow(pyglet.window.Window):
    def on_draw(self):
        self.clear()
        batch.draw()

window = MainWindow(width=600, height=600)

batch = pyglet.graphics.Batch()
label = pyglet.text.Label("Label 1", width=50, multiline=True, x=0, y=0, batch=batch)
del label
label = pyglet.text.Label("Label 2", width=50, multiline=True, x=0, y=30, batch=batch)

pyglet.app.run()
```
