### PR TITLE
Make OpenGL the default API

### DIFF
--- a/pyglet/gl/base.py
+++ b/pyglet/gl/base.py
@@ -120,7 +120,7 @@ class Config:
     major_version = None
     minor_version = None
     forward_compatible = None
-    opengl_api = None
+    opengl_api = "gl"
     debug = None
 
     def __init__(self, **kwargs):
@@ -220,7 +220,7 @@ class CanvasConfig(Config):
         self.major_version = base_config.major_version
         self.minor_version = base_config.minor_version
         self.forward_compatible = base_config.forward_compatible
-        self.opengl_api = base_config.opengl_api
+        self.opengl_api = base_config.opengl_api or self.opengl_api
         self.debug = base_config.debug
 
     def compatible(self, canvas):

--- a/pyglet/gl/headless.py
+++ b/pyglet/gl/headless.py
@@ -73,6 +73,8 @@ class HeadlessConfig(Config):
             attrs.extend([EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT])
         elif self.opengl_api == "gles":
             attrs.extend([EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT])
+        else:
+            raise ValueError(f"Unknown OpenGL API: {self.opengl_api}")
         attrs.extend([EGL_NONE])
         attrs_list = (egl.EGLint * len(attrs))(*attrs)
 

--- a/pyglet/gl/xlib.py
+++ b/pyglet/gl/xlib.py
@@ -395,6 +395,8 @@ class XlibContextARB(XlibContext13):
             attribs.extend([glxext_arb.GLX_CONTEXT_PROFILE_MASK_ARB, glxext_arb.GLX_CONTEXT_CORE_PROFILE_BIT_ARB])
         elif self.config.opengl_api == "gles":
             attribs.extend([glxext_arb.GLX_CONTEXT_PROFILE_MASK_ARB, glxext_arb.GLX_CONTEXT_ES2_PROFILE_BIT_EXT])
+        else:
+            raise ValueError(f"Unknown OpenGL API: {self.opengl_api}")
 
         flags = 0
         if self.config.forward_compatible:


### PR DESCRIPTION
The current change will do the following:

* Ensure the EGL backend works without explicitly passing `opengl_api="gl"` in the config.
* Report back to user when the selected opengl api is not supported (or misconfigured)

Things broke when we added GLES. In some instances the context would be created even if `opengl_api` is `None` since opengl is assumed to be default by some backends. This is not always the case. Making sure the opengl api is explicitly set means less trouble.