### PR TITLE
Fixes for Layouts

### DIFF
--- a/pyglet/text/layout.py
+++ b/pyglet/text/layout.py
@@ -1131,8 +1131,8 @@ class TextLayout:
             dz = z - self._z
             for vertex_list in self._vertex_lists:
                 vertices = vertex_list.position[:]
-                vertices[::2] = [x + dx for x in vertices[::2]]
-                vertices[1::2] = [y + dy for y in vertices[1::2]]
+                vertices[::3] = [x + dx for x in vertices[::3]]
+                vertices[1::3] = [y + dy for y in vertices[1::3]]
                 vertices[2::3] = [z + dz for z in vertices[2::3]]
                 vertex_list.position[:] = vertices
             self._x = x
@@ -2046,8 +2046,6 @@ class IncrementalTextLayout(TextLayout, EventDispatcher):
         self._update_scissor_area()
 
     def _update_scissor_area(self):
-        if not self.document.text:
-            return
         area = self._get_left(), self._get_bottom(self._get_lines()), self._width, self._height
         for group in self.group_cache.values():
             group.scissor_area = area
@@ -2127,6 +2125,7 @@ class IncrementalTextLayout(TextLayout, EventDispatcher):
                                 self.invalid_flow.is_invalid() or
                                 self.invalid_lines.is_invalid())
 
+        len_groups = len(self.group_cache)
         # Special care if there is no text:
         if not self.glyphs:
             for line in self.lines:
@@ -2144,6 +2143,11 @@ class IncrementalTextLayout(TextLayout, EventDispatcher):
         self._update_flow_lines()
         self._update_visible_lines()
         self._update_vertex_lists()
+
+        # Update group cache areas if the count has changed. Usually if it starts with no text.
+        # Group cache is only cleared in a regular TextLayout. May need revisiting if that changes.
+        if len_groups != len(self.group_cache):
+            self._update_scissor_area()
 
         if trigger_update_event:
             self.dispatch_event('on_layout_update')


### PR DESCRIPTION
* Fix for Layout position for expanded vertices.

* Fix for IncrementalTextLayout when it starts with no text.
- The current fix only updates if the count changes, if 1 group_cache is removed and 1 is added, this will not update. I haven't experienced this occurring as the group_cache is not cleared in anyway unlike the regular TextLayout. (It is cleared every update in a TextLayout, but not for other layouts, unsure this needs to be done still). If group_cache needs to be cleared for layouts with scissor areas, the layouts will need to update the scissor area every update call.