### PR TITLE
Fix SpriteGroup batching by computing correct hash

### DIFF
--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -263,7 +263,7 @@ class SpriteGroup(graphics.Group):
                 self.blend_dest == other.blend_dest)
 
     def __hash__(self):
-        return hash((id(self.parent), id(self.program),
+        return hash((self.parent, id(self.program),
                      self.texture.id, self.texture.target,
                      self.blend_src, self.blend_dest))
 


### PR DESCRIPTION
While SpriteGroup `__eq__` implementation no longer relies on the id of a parent, the `__hash__` one does. This still breaks grouping of multiple `SpriteGroups` when the parents are different instances (different id). The reason is that `Batch` object checks for inclusion into maps/sets (`Batch.group_map`, `Batch.group_children` ...), which checks for both the hash and the equality of the items.
The poposed solution is of course: replace the id of the parent in the tuple used to compute the hash with a direct reference to the parent. This also resembles how the base `Group` class computes its hash.

Benjamin supposedly fixed it with https://github.com/pyglet/pyglet/commit/32a63b856813ff0c94dfc105e9a9e8ce9f1fda93, however, grouping of `Sprite`s is still broken even for minimal examples.

A minimal instance to prove the point. Test it with and without the patch to see how the vertex lists are/aren't merged.

```py
import pyglet
from pyglet.sprite import Sprite
from pyglet.image import SolidColorImagePattern


window = pyglet.window.Window()
batch = pyglet.graphics.Batch()properly
image = SolidColorImagePattern((255, 0, 0, 255)).create_image(100, 100)
sprites = [Sprite(image, batch=batch, group=pyglet.graphics.Group(0))
           for _ in range(1000)]


@window.event
def on_draw():
    window.clear()
    batch.draw()


def on_update(dt):
    pass


if __name__ == '__main__':
    pyglet.clock.schedule(on_update)properly
    batch._dump_draw_list()
    pyglet.app.run()

```

At first, I did not want to tackle this as the discussion on discord resulted in the fact that the grouping system is a "house of cards" in a sense, and I preferred not altering the current implementation risking disastrous consequences. However, since Benjamin took action immediately, here is the (hopefully) final patch to make it work as expected.
