### PR TITLE
Fix ShaderProgram.vertex_list

### DIFF
--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -580,7 +580,7 @@ class ShaderProgram:
                 raise ShaderException(f"\nThe attribute `{name}` doesn't exist. Valid names: \n{list(attributes)}")
 
         batch = batch or pyglet.graphics.get_default_batch()
-        domain = batch.get_domain(False, mode, group, self._id, attributes)
+        domain = batch.get_domain(False, mode, group, self, attributes)
 
         # Create vertex list and initialize
         vlist = domain.create(count)
@@ -624,7 +624,7 @@ class ShaderProgram:
                 raise ShaderException(f"\nThe attribute `{name}` doesn't exist. Valid names: \n{list(attributes)}")
 
         batch = batch or pyglet.graphics.get_default_batch()
-        domain = batch.get_domain(True, mode, group, self._id, attributes)
+        domain = batch.get_domain(True, mode, group, self, attributes)
 
         # Create vertex list and initialize
         vlist = domain.create(count, len(indices))


### PR DESCRIPTION
`ShaderProgram.vertex_list` passes `self._id` as `program` argument instead of `self` to batch.get_domain.
This leads to `ShaderGroup` being created with `int` type argument instead of `ShaderProgram` when no `group` argument is passed to `vertex_list`.
The following snippet results in `self.program.use()... AttributeError: 'int' object has no attribute 'use'` before the change.
```py
import pyglet

program = pyglet.graphics.get_default_shader()

window = pyglet.window.Window(300, 300)
batch = pyglet.graphics.Batch()
vlist = program.vertex_list(1, pyglet.gl.GL_POINTS, batch, group=None, position=('f', [100, 100]), colors=('B', [255, 255, 255,255]))
@window.event
def on_draw():
    window.clear()
    batch.draw()

pyglet.app.run()
```