### PR TITLE
Fix for get_default_screen() 

### DIFF
--- a/pyglet/canvas/base.py
+++ b/pyglet/canvas/base.py
@@ -98,12 +98,18 @@ class Display:
         raise NotImplementedError('abstract')
 
     def get_default_screen(self):
-        """Get the default screen as specified by the user's operating system
+        """Get the default (primary) screen as specified by the user's operating system
         preferences.
 
         :rtype: :class:`Screen`
         """
-        return self.get_screens()[0]
+        screens = self.get_screens()
+        for screen in screens:
+            if screen.x == 0 and screen.y == 0:
+                return screen
+
+        # No Primary screen found?
+        return screens[0]
 
     def get_windows(self):
         """Get the windows currently attached to this display.


### PR DESCRIPTION
`display.get_default_screen()` doesn't get the primary monitor. It just gets the first monitor in the list, which is not guaranteed to be the primary.

From what I have found in testing, the display at position 0, 0 is considered the primary in almost all cases.

I have tested in a 3 monitor setup and my primary is on "Display 2", but my default prior to the fix was always considered Display 1.  After testing, (on Windows) now, even if I switch to Display 3 being primary, Display 3 becomes 0, 0 and is properly recognized.

If the primary is not found for whatever reason, it will fallback to default behavior of choosing first in the list. 

This just needs confirmation on Linux and Mac that the behavior is the same.

This can be backported to 1.5