### PR TITLE
Remove left-over print statement

### DIFF
--- a/pyglet/font/freetype.py
+++ b/pyglet/font/freetype.py
@@ -215,7 +215,6 @@ class FreeTypeFont(base.Font):
         if not match:
             raise base.FontException(f"Could not match font '{self._name}'")
         self.filename = match.file
-        print(match)
         self.face = FreeTypeFace.from_fontconfig(match)
 
     @classmethod


### PR DESCRIPTION
There was a `print()` statement that seems to have been left-over from development work in loading freetype fonts. This causes some unwanted output for end users.