### PR TITLE
Add Bezier curve

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -659,11 +659,15 @@ class BezierCurve(ShapeBase):
             # Calculate the points of the curve:
             points = [(x + self._make_curve(t / self._segments)[0],
                        y + self._make_curve(t / self._segments)[1]) for t in range(self._segments + 1)]
+            trans_x, trans_y = points[0]
+            trans_x += self._anchor_x
+            trans_y += self._anchor_y
+            coords = [[x - trans_x, y - trans_y] for x, y in points]
 
             # Create a list of doubled-up points from the points:
             vertices = []
-            for i in range(len(points) - 1):
-                line_points = *points[i], *points[i + 1]
+            for i in range(len(coords) - 1):
+                line_points = *coords[i], *coords[i + 1]
                 vertices.extend(line_points)
 
         self._vertex_list.vertices[:] = vertices


### PR DESCRIPTION
I have created a `pyglet.shapes.BezierCurve` class for Bézier curve.

There is an example:
```python
import pyglet
from pyglet import shapes

window = pyglet.window.Window(300, 300)
curve = shapes.BezierCurve((100, 100), (150, 200), (200, 100), segments=10)
line = [
    shapes.Line(100, 100, 150, 200, color=(255, 0, 0)),
    shapes.Line(150, 200, 200, 100, color=(255, 0, 0))
]

@window.event
def on_draw():
    window.clear()
    curve.draw()
    for obj in line:
        obj.draw()

pyglet.app.run()
```

But it still has some problems, as the picture showed:
![problem0](https://user-images.githubusercontent.com/58848782/210488124-640a32a5-8be7-4631-bd60-5cda13e2adba.png)

And the points generated by the curve formula(the `_make_curve` method) seems correct:
```
[(100.0, 100.0), (110.0, 118.0), (120.0, 132.0), (130.0, 142.0), (140.0, 148.0), (150.0, 150.0), (160.0, 148.0), (170.0, 142.0), (180.0, 132.0), (190.0, 118.0), (200.0, 100.0)]
```

Another example:
![problem1](https://user-images.githubusercontent.com/58848782/210488820-ae9039ca-b429-4528-8e59-e96f06f9ef90.png)
