### PR TITLE
TextEntry on_mouse_press (minor change)

### DIFF
--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -494,6 +494,8 @@ class TextEntry(WidgetBase):
         if self._check_hit(x, y):
             self._set_focus(True)
             self._caret.on_mouse_press(x, y, buttons, modifiers)
+        else:
+            self._set_focus(False)
 
     def on_text(self, text):
         if not self.enabled:


### PR DESCRIPTION
Made it so when you click elsewhere on the window it deactivates the TextEntry. This prevents the weird effect of two TextEntry  being active at the same time _(for instance: clicking a TextEntry while another is active allowing you to write in both at the same time)_.