### PR TITLE
Fix blitting with regions

### DIFF
--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1228,7 +1228,7 @@ class Texture(AbstractImage):
         glBindImageTexture(unit, self.id, level, layered, layer, access, fmt)
 
     @classmethod
-    def create(cls, width, height, target=GL_TEXTURE_2D, internalformat=GL_RGBA8, min_filter=None, mag_filter=None, fmt=GL_RGBA):
+    def create(cls, width, height, target=GL_TEXTURE_2D, internalformat=GL_RGBA8, min_filter=None, mag_filter=None, fmt=GL_RGBA, blank_data=True):
         """Create a Texture
 
         Create a Texture with the specified dimentions, target and format.
@@ -1253,6 +1253,9 @@ class Texture(AbstractImage):
                 GL constant giving format of texture; for example, ``GL_RGBA``.
                 The format specifies what format the pixel data we're expecting to write
                 to the texture and should ideally be the same as for internal format.
+            `blank_data` : bool
+                Setting to True will initialize the texture data with all zeros. Setting False, will initialize Texture
+                with no data.
 
         :rtype: :py:class:`~pyglet.image.Texture`
         """
@@ -1266,7 +1269,7 @@ class Texture(AbstractImage):
         glTexParameteri(target, GL_TEXTURE_MAG_FILTER, mag_filter)
 
         if internalformat is not None:
-            blank = (GLubyte * (width * height * 4))()
+            blank = (GLubyte * (width * height * 4))() if blank_data else None
             glTexImage2D(target, 0,
                          internalformat,
                          width, height,
@@ -1478,7 +1481,7 @@ class Texture3D(Texture, UniformTextureSequence):
     items = ()
 
     @classmethod
-    def create_for_images(cls, images, internalformat=GL_RGBA):
+    def create_for_images(cls, images, internalformat=GL_RGBA, blank_data=True):
         item_width = images[0].width
         item_height = images[0].height
         for image in images:
@@ -1494,12 +1497,13 @@ class Texture3D(Texture, UniformTextureSequence):
 
         texture.images = depth
 
+        blank = (GLubyte * (texture.width * texture.height * texture.images))() if blank_data else None
         glBindTexture(texture.target, texture.id)
         glTexImage3D(texture.target, texture.level,
                      internalformat,
                      texture.width, texture.height, texture.images, 0,
                      GL_ALPHA, GL_UNSIGNED_BYTE,
-                     None)
+                     blank)
 
         items = []
         for i, image in enumerate(images):

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -818,10 +818,15 @@ class ImageData(AbstractImage):
 
         # Unset GL_UNPACK_ROW_LENGTH:
         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0)
+        self._default_region_unpack()
+
         # Flush image upload before data get GC'd:
         glFlush()
 
     def _apply_region_unpack(self):
+        pass
+
+    def _default_region_unpack(self):
         pass
 
     def _convert(self, fmt, pitch):
@@ -996,6 +1001,10 @@ class ImageDataRegion(ImageData):
     def _apply_region_unpack(self):
         glPixelStorei(GL_UNPACK_SKIP_PIXELS, self.x)
         glPixelStorei(GL_UNPACK_SKIP_ROWS, self.y)
+
+    def _default_region_unpack(self):
+        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0)
+        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0)
 
     def get_region(self, x, y, width, height):
         x += self.x
@@ -1302,7 +1311,7 @@ class Texture(AbstractImage):
             glPixelStorei(GL_PACK_ALIGNMENT, 1)
             glCheckFramebufferStatus(GL_FRAMEBUFFER)
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, self.id, self.level)
-            glReadPixels(0, 0, self.width, self.height, gl_format, GL_UNSIGNED_BYTE, buf) 
+            glReadPixels(0, 0, self.width, self.height, gl_format, GL_UNSIGNED_BYTE, buf)
             glBindFramebuffer(GL_FRAMEBUFFER, 0)
             glDeleteFramebuffers(1, fbo)
         else:

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1266,13 +1266,14 @@ class Texture(AbstractImage):
         glTexParameteri(target, GL_TEXTURE_MAG_FILTER, mag_filter)
 
         if internalformat is not None:
+            blank = (GLubyte * (width * height * 4))()
             glTexImage2D(target, 0,
                          internalformat,
                          width, height,
                          0,
                          fmt,
                          GL_UNSIGNED_BYTE,
-                         None)
+                         blank)
             glFlush()
 
         texture = cls(width, height, target, tex_id.value)


### PR DESCRIPTION
Set skip pixels back to 0 to prevent state issues. Without this, after the first image, it will cause state issues with other textures causing corruption like this and can sometimes segfault as well: 
![image](https://user-images.githubusercontent.com/17804711/221441337-6a508c63-1082-447e-b0a6-c38649122cfb.png)


I would also like to discuss to reverse PR https://github.com/pyglet/pyglet/commit/faf081d5fad2cf3ec50d8f9a0c7f78e283e0622b 

This broke image creation in Windows as it causes the newly created image to have random garbage pixels upon creation. Whereas previous behavior would give you a completely blank transparent texture.  If you plan to blit a region to a new texture, you will have undesired pixels in the newly created texture. For instance, this affects texture atlases. We should restore it for previous behavior and possibly add an argument to create it with no data if for some reason people need that option.

EDIT: After looking at why this was done, it was to fix an issue with example here: https://github.com/CiotatSoft/pyglet_test/ but this fix properly fixes that issue. I am adding back the blank data to this PR.