### PR TITLE
Various fixes for DirectInput event handling

### DIFF
--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -818,10 +818,15 @@ class ImageData(AbstractImage):
 
         # Unset GL_UNPACK_ROW_LENGTH:
         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0)
+        self._default_region_unpack()
+
         # Flush image upload before data get GC'd:
         glFlush()
 
     def _apply_region_unpack(self):
+        pass
+
+    def _default_region_unpack(self):
         pass
 
     def _convert(self, fmt, pitch):
@@ -996,6 +1001,10 @@ class ImageDataRegion(ImageData):
     def _apply_region_unpack(self):
         glPixelStorei(GL_UNPACK_SKIP_PIXELS, self.x)
         glPixelStorei(GL_UNPACK_SKIP_ROWS, self.y)
+
+    def _default_region_unpack(self):
+        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0)
+        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0)
 
     def get_region(self, x, y, width, height):
         x += self.x
@@ -1302,7 +1311,7 @@ class Texture(AbstractImage):
             glPixelStorei(GL_PACK_ALIGNMENT, 1)
             glCheckFramebufferStatus(GL_FRAMEBUFFER)
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, self.id, self.level)
-            glReadPixels(0, 0, self.width, self.height, gl_format, GL_UNSIGNED_BYTE, buf) 
+            glReadPixels(0, 0, self.width, self.height, gl_format, GL_UNSIGNED_BYTE, buf)
             glBindFramebuffer(GL_FRAMEBUFFER, 0)
             glDeleteFramebuffers(1, fbo)
         else:

--- a/pyglet/input/win32/__init__.py
+++ b/pyglet/input/win32/__init__.py
@@ -57,8 +57,7 @@ class Win32ControllerManager(base.ControllerManager):
             def on_disconnect(xdevice):
                 self.dispatch_event('on_disconnect', self._xinput_controllers[xdevice])
 
-        for device in _di_device_manager.devices:
-            self._add_di_controller(device)
+        self._set_initial_didevices()
 
         @_di_device_manager.event
         def on_connect(di_device):
@@ -72,6 +71,14 @@ class Win32ControllerManager(base.ControllerManager):
                 _controller = self._di_controllers[di_device]
                 del self._di_controllers[di_device]
                 pyglet.app.platform_event_loop.post_event(self, 'on_disconnect', _controller)
+
+    def _set_initial_didevices(self):
+        if not _di_device_manager.registered:
+            _di_device_manager.register_device_events()
+            _di_device_manager.set_current_devices()
+
+        for device in _di_device_manager.devices:
+            self._add_di_controller(device)
 
     def _add_di_controller(self, device: DirectInputDevice) -> Optional[base.Controller]:
         controller = _create_controller(device)

--- a/pyglet/libs/win32/__init__.py
+++ b/pyglet/libs/win32/__init__.py
@@ -207,8 +207,11 @@ _user32.GetRawInputData.restype = UINT
 _user32.GetRawInputData.argtypes = [HRAWINPUT, UINT, LPVOID, PUINT, UINT]
 _user32.ChangeWindowMessageFilterEx.restype = BOOL
 _user32.ChangeWindowMessageFilterEx.argtypes = [HWND, UINT, DWORD, c_void_p]
-_user32.RegisterDeviceNotificationW.restype = LPVOID
+_user32.RegisterDeviceNotificationW.restype = HANDLE
 _user32.RegisterDeviceNotificationW.argtypes = [HANDLE, LPVOID, DWORD]
+_user32.UnregisterDeviceNotification.restype = BOOL
+_user32.UnregisterDeviceNotification.argtypes = [HANDLE]
+
 
 # dwmapi
 _dwmapi.DwmIsCompositionEnabled.restype = c_int


### PR DESCRIPTION
Fixes various issues including fallback behavior in certain input scenarios:

1. If you were to disable the shadow window, and import `pyglet.input` before you created a normal Window this would cause errors.

Now behavior is:
Attempt to find a Window to register events to. If no window found, skip.
When attempting to iterate `_di_manager` devices. Such as (`get_joysticks`, `get_controllers`, or `get_controllers` on `ControllerManager`), and Window event is not registered:
   a) Look for Window and attempt to register the event again.
   b) If failure, produce a warning.
   c) Refresh current list of devices in the DI Device Manager.

2. This also fixes issue with Connection Manager not having a list of prepopulated devices if above scenario played out.

3. Added missing `UnregisterDeviceNotification` so we can register events to a new window if needed.
 
4. Also now adds itself as a window handler to determine if the window it's attached to is closed. In a multi-window scenario it will attempt to register itself to another open window if found. (May need a better way to do this, since `on_close` even can be completely overridden)

5. Now that COM thread mode is STA by default, we cannot run xinput's COM checks inside the handled event without an error. Created a dummy dispatch event so we can run in the main thread outside of the send event to fix this.