### PR TITLE
Fix TextureArrayRegion.

### DIFF
--- a/pyglet/image/atlas.py
+++ b/pyglet/image/atlas.py
@@ -275,11 +275,13 @@ class TextureArrayBin:
         :rtype: :py:class:`~pyglet.image.TextureArrayRegion`
         :return: The region of an array containing the newly added image.
         """
-        for array in self.arrays[-1]:
-            try:
-                return array.add(img)
-            except pyglet.image.TextureArrayDepthExceeded:
-                pass
+        try:
+            array = self.arrays[-1]
+            return array.add(img)
+        except pyglet.image.TextureArrayDepthExceeded:
+            pass
+        except IndexError:
+            pass
 
         array = pyglet.image.TextureArray.create(self.texture_width, self.texture_height, max_depth=self.max_depth)
         self.arrays.append(array)

--- a/pyglet/image/atlas.py
+++ b/pyglet/image/atlas.py
@@ -23,8 +23,12 @@ the application's responsibility to keep track of the regions returned by the
 
 .. versionadded:: 1.1
 """
+from typing import TYPE_CHECKING, Tuple
 
 import pyglet
+
+if TYPE_CHECKING:
+    from pyglet.image import AbstractImage, TextureRegion, TextureArrayRegion
 
 
 class AllocatorException(Exception):
@@ -36,13 +40,13 @@ class AllocatorException(Exception):
 class _Strip:
     __slots__ = 'x', 'y', 'max_height', 'y2'
 
-    def __init__(self, y, max_height):
+    def __init__(self, y: int, max_height: int):
         self.x = 0
         self.y = y
         self.max_height = max_height
         self.y2 = y
 
-    def add(self, width, height):
+    def add(self, width: int, height: int):
         assert width > 0 and height > 0
         assert height <= self.max_height
 
@@ -67,7 +71,7 @@ class Allocator:
     """
     __slots__ = 'width', 'height', 'strips', 'used_area'
 
-    def __init__(self, width, height):
+    def __init__(self, width: int, height: int):
         """Create an `Allocator` of the given size.
 
         :Parameters:
@@ -83,7 +87,7 @@ class Allocator:
         self.strips = [_Strip(0, height)]
         self.used_area = 0
 
-    def alloc(self, width, height):
+    def alloc(self, width: int, height: int) -> Tuple[int, int]:
         """Get a free area in the allocator of the given size.
 
         After calling `alloc`, the requested area will no longer be used.
@@ -114,7 +118,7 @@ class Allocator:
 
         raise AllocatorException('No more space in %r for box %dx%d' % (self, width, height))
 
-    def get_usage(self):
+    def get_usage(self) -> float:
         """Get the fraction of area already allocated.
 
         This method is useful for debugging and profiling only.
@@ -123,7 +127,7 @@ class Allocator:
         """
         return self.used_area / float(self.width * self.height)
 
-    def get_fragmentation(self):
+    def get_fragmentation(self) -> float:
         """Get the fraction of area that's unlikely to ever be used, based on
         current allocation behaviour.
 
@@ -141,7 +145,7 @@ class Allocator:
 class TextureAtlas:
     """Collection of images within a texture."""
 
-    def __init__(self, width=2048, height=2048):
+    def __init__(self, width: int = 2048, height: int = 2048):
         """Create a texture atlas of the given size.
 
         :Parameters:
@@ -158,7 +162,7 @@ class TextureAtlas:
         self.texture = pyglet.image.Texture.create(width, height)
         self.allocator = Allocator(width, height)
 
-    def add(self, img, border=0):
+    def add(self, img: 'AbstractImage', border: int = 0) -> 'TextureRegion':
         """Add an image to the atlas.
 
         This method will fail if the given image cannot be transferred
@@ -178,9 +182,9 @@ class TextureAtlas:
         :rtype: :py:class:`~pyglet.image.TextureRegion`
         :return: The region of the atlas containing the newly added image.
         """
-        x, y = self.allocator.alloc(img.width + border*2, img.height + border*2)
-        self.texture.blit_into(img, x+border, y+border, 0)
-        return self.texture.get_region(x+border, y+border, img.width, img.height)
+        x, y = self.allocator.alloc(img.width + border * 2, img.height + border * 2)
+        self.texture.blit_into(img, x + border, y + border, 0)
+        return self.texture.get_region(x + border, y + border, img.width, img.height)
 
 
 class TextureBin:
@@ -190,7 +194,7 @@ class TextureBin:
     ones as necessary to accommodate images added to the bin.
     """
 
-    def __init__(self, texture_width=2048, texture_height=2048):
+    def __init__(self, texture_width: int = 2048, texture_height: int = 2048):
         """Create a texture bin for holding atlases of the given size.
 
         :Parameters:
@@ -208,7 +212,7 @@ class TextureBin:
         self.texture_height = min(texture_height, max_texture_size)
         self.atlases = []
 
-    def add(self, img, border=0):
+    def add(self, img: 'AbstractImage', border: int = 0) -> 'TextureRegion':
         """Add an image into this texture bin.
 
         This method calls `TextureAtlas.add` for the first atlas that has room
@@ -239,3 +243,44 @@ class TextureBin:
         atlas = TextureAtlas(self.texture_width, self.texture_height)
         self.atlases.append(atlas)
         return atlas.add(img, border)
+
+
+class TextureArrayBin:
+    """Collection of texture arrays.
+
+    :py:class:`~pyglet.image.atlas.TextureArrayBin` maintains a collection of texture arrays, and creates new
+    ones as necessary as the depth is exceeded.
+    """
+
+    def __init__(self, texture_width=2048, texture_height=2048, max_depth=None):
+        max_texture_size = pyglet.image.get_max_texture_size()
+        self.max_depth = max_depth or pyglet.image.get_max_array_texture_layers()
+        self.texture_width = min(texture_width, max_texture_size)
+        self.texture_height = min(texture_height, max_texture_size)
+        self.arrays = []
+
+    def add(self, img: 'AbstractImage') -> 'TextureArrayRegion':
+        """Add an image into this texture array bin.
+
+        This method calls `TextureArray.add` for the first array that has room
+        for the image.
+
+        `TextureArraySizeExceeded` is raised if the image exceeds the dimensions of
+        ``texture_width`` and ``texture_height``.
+
+        :Parameters:
+            `img` : `~pyglet.image.AbstractImage`
+                The image to add.
+
+        :rtype: :py:class:`~pyglet.image.TextureArrayRegion`
+        :return: The region of an array containing the newly added image.
+        """
+        for array in self.arrays[-1]:
+            try:
+                return array.add(img)
+            except pyglet.image.TextureArrayDepthExceeded:
+                pass
+
+        array = pyglet.image.TextureArray.create(self.texture_width, self.texture_height, max_depth=self.max_depth)
+        self.arrays.append(array)
+        return array.add(img)


### PR DESCRIPTION
Fix TextureArrayRegion crash.
Add TextureArray.add to add a single image.

Add TextureArrayBin helper class. This functions similarly to a TextureAtlas in that it will allocate textures until  the array is full, then create a new one. Depth can be specified as well, leaving it default will create the maximum size the hardware supports.