### PR TITLE
macOS alternate event loop

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -131,6 +131,7 @@ options = {
     'dw_legacy_naming': False,
     'win32_disable_xinput': False,
     'com_mta': False,
+    'osx_alt_loop': False
 }
 
 _option_types = {
@@ -162,7 +163,8 @@ _option_types = {
     'win32_disable_shaping': bool,
     'dw_legacy_naming': bool,
     'win32_disable_xinput': bool,
-    'com_mta': bool
+    'com_mta': bool,
+    'osx_alt_loop': bool,
 }
 
 

--- a/pyglet/app/__init__.py
+++ b/pyglet/app/__init__.py
@@ -29,21 +29,24 @@ default policy is to wait until all windows are closed)::
 .. versionadded:: 1.1
 """
 
+import platform
 import sys
 import weakref
 
-from pyglet.app.base import EventLoop
+import pyglet
 from pyglet import compat_platform
+from pyglet.app.base import EventLoop
 
 _is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
-
 
 if _is_pyglet_doc_run:
     from pyglet.app.base import PlatformEventLoop
 else:
     if compat_platform == 'darwin':
         from pyglet.app.cocoa import CocoaPlatformEventLoop as PlatformEventLoop
-        from pyglet.app.cocoa import CocoaEventLoop as EventLoop
+
+        if platform.machine() == 'arm64' or pyglet.options["osx_alt_loop"]:
+            from pyglet.app.cocoa import CocoaAlternateEventLoop as EventLoop
     elif compat_platform in ('win32', 'cygwin'):
         from pyglet.app.win32 import Win32EventLoop as PlatformEventLoop
     else:
@@ -62,7 +65,7 @@ the set when they are no longer referenced or are closed explicitly.
 """
 
 
-def run(interval=1/60):
+def run(interval=1 / 60):
     """Begin processing events, scheduled functions and window updates.
 
     This is a convenience function, equivalent to::

--- a/pyglet/app/__init__.py
+++ b/pyglet/app/__init__.py
@@ -42,7 +42,8 @@ if _is_pyglet_doc_run:
     from pyglet.app.base import PlatformEventLoop
 else:
     if compat_platform == 'darwin':
-        from pyglet.app.cocoa import CocoaEventLoop as PlatformEventLoop
+        from pyglet.app.cocoa import CocoaPlatformEventLoop as PlatformEventLoop
+        from pyglet.app.cocoa import CocoaEventLoop as EventLoop
     elif compat_platform in ('win32', 'cygwin'):
         from pyglet.app.win32 import Win32EventLoop as PlatformEventLoop
     else:

--- a/pyglet/app/cocoa.py
+++ b/pyglet/app/cocoa.py
@@ -1,5 +1,7 @@
-from pyglet.app.base import PlatformEventLoop
-from pyglet.libs.darwin import cocoapy, AutoReleasePool
+from pyglet import app
+from pyglet.app.base import PlatformEventLoop, EventLoop
+from pyglet.libs.darwin import cocoapy, AutoReleasePool, ObjCSubclass, PyObjectEncoding, ObjCInstance, send_super, \
+    ObjCClass, get_selector
 
 NSApplication = cocoapy.ObjCClass('NSApplication')
 NSMenu = cocoapy.ObjCClass('NSMenu')
@@ -7,7 +9,7 @@ NSMenuItem = cocoapy.ObjCClass('NSMenuItem')
 NSDate = cocoapy.ObjCClass('NSDate')
 NSEvent = cocoapy.ObjCClass('NSEvent')
 NSUserDefaults = cocoapy.ObjCClass('NSUserDefaults')
-
+NSTimer = cocoapy.ObjCClass('NSTimer')
 
 
 
@@ -46,10 +48,88 @@ def create_menu():
         appMenuItem.release()
 
 
-class CocoaEventLoop(PlatformEventLoop):
+class _AppDelegate_Implementation:
+    _AppDelegate = ObjCSubclass('NSObject', '_AppDelegate')
+
+    @_AppDelegate.method(b'@' + PyObjectEncoding)
+    def init(self, pyglet_loop):
+        objc = ObjCInstance(send_super(self, 'init'))
+        self._pyglet_loop = pyglet_loop
+        return objc  # objc is self
+
+    @_AppDelegate.method('v')
+    def updatePyglet_(self):
+        self._pyglet_loop.arm64_step()
+
+    @_AppDelegate.method('v@')
+    def applicationWillTerminate_(self, aNotification):
+        print("ALL WILL TERMINATE")
+
+    @_AppDelegate.method('v@')
+    def applicationDidFinishLaunching_(self, aNotification):
+        print("APP STARTED")
+
+_AppDelegate = ObjCClass('_AppDelegate')  # the actual class
+
+class CocoaEventLoop(EventLoop):
+    def run(self, interval=1/60):
+        """Begin processing events, scheduled functions and window updates.
+
+        This method returns when :py:attr:`has_exit` is set to True.
+
+        Developers are discouraged from overriding this method, as the
+        implementation is platform-specific.
+        """
+        self.interval = interval
+
+        if not interval:
+            self.clock.schedule(self._redraw_windows)
+        else:
+            self.clock.schedule_interval(self._redraw_windows, interval)
+
+        self.has_exit = False
+
+        from pyglet.window import Window
+        Window._enable_event_queue = False
+
+        # Dispatch pending events
+        for window in app.windows:
+            window.switch_to()
+            window.dispatch_pending_events()
+
+        platform_event_loop = app.platform_event_loop
+        #platform_event_loop.start()
+
+        self.dispatch_event('on_enter')
+        self.is_running = True
+        platform_event_loop.arm64_start(interval)
+
+
+        #while not self.has_exit:
+        #    timeout = self.idle()
+        #    platform_event_loop.step(timeout)
+
+
+
+    def exit(self):
+        """Safely exit the event loop at the end of the current iteration.
+
+        This method is a thread-safe equivalent for setting
+        :py:attr:`has_exit` to ``True``.  All waiting threads will be
+        interrupted (see :py:meth:`sleep`).
+        """
+        self.has_exit = True
+        app.platform_event_loop.notify()
+
+        self.is_running = False
+        self.dispatch_event('on_exit')
+        platform_event_loop = app.platform_event_loop
+        platform_event_loop.arm64_stop()
+
+class CocoaPlatformEventLoop(PlatformEventLoop):
 
     def __init__(self):
-        super(CocoaEventLoop, self).__init__()
+        super(CocoaPlatformEventLoop, self).__init__()
         with AutoReleasePool():
             # Prepare the default application.
             self.NSApp = NSApplication.sharedApplication()
@@ -73,6 +153,9 @@ class CocoaEventLoop(PlatformEventLoop):
 
             self._finished_launching = False
 
+        from pyglet.app import event_loop
+        self._event_loop = event_loop
+
     def start(self):
         with AutoReleasePool():
             if not self.NSApp.isRunning() and not self._finished_launching:
@@ -81,6 +164,28 @@ class CocoaEventLoop(PlatformEventLoop):
                 self.NSApp.finishLaunching()
                 self.NSApp.activateIgnoringOtherApps_(True)
                 self._finished_launching = True
+
+    def arm64_start(self, interval):
+        self._finished_launching = True
+
+        self.appdelegate = _AppDelegate.alloc().init(self)
+        self.NSApp.setDelegate_(self.appdelegate)
+
+        NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+             interval,
+             self.appdelegate,
+             get_selector('updatePyglet:'),
+             False,
+             True
+         )
+        self.NSApp.run()
+
+    def arm64_step(self):
+        self._event_loop.idle()
+        self.dispatch_posted_events()
+
+    def arm64_stop(self):
+        self.NSApp.terminate_(None)
 
     def step(self, timeout=None):
         with AutoReleasePool():
@@ -119,12 +224,12 @@ class CocoaEventLoop(PlatformEventLoop):
                     # replacements ensure that we see all the raw key presses & releases.
                     # We also filter out key-down repeats since pyglet only sends one
                     # on_key_press event per key press.
-                    if event_type == cocoapy.NSKeyDown and not event.isARepeat():
-                        self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyDown:"), None, event)
-                    elif event_type == cocoapy.NSKeyUp:
-                        self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyUp:"), None, event)
-                    elif event_type == cocoapy.NSFlagsChanged:
-                        self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletFlagsChanged:"), None, event)
+                    # if event_type == cocoapy.NSKeyDown and not event.isARepeat():
+                    #     self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyDown:"), None, event)
+                    # elif event_type == cocoapy.NSKeyUp:
+                    #     self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyUp:"), None, event)
+                    # elif event_type == cocoapy.NSFlagsChanged:
+                    #     self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletFlagsChanged:"), None, event)
 
                 self.NSApp.updateWindows()
                 did_time_out = False

--- a/pyglet/app/cocoa.py
+++ b/pyglet/app/cocoa.py
@@ -1,3 +1,4 @@
+import signal
 from pyglet import app
 from pyglet.app.base import PlatformEventLoop, EventLoop
 from pyglet.libs.darwin import cocoapy, AutoReleasePool, ObjCSubclass, PyObjectEncoding, ObjCInstance, send_super, \
@@ -59,29 +60,26 @@ class _AppDelegate_Implementation:
 
     @_AppDelegate.method('v')
     def updatePyglet_(self):
-        self._pyglet_loop.arm64_step()
+        self._pyglet_loop.nsapp_step()
 
     @_AppDelegate.method('v@')
-    def applicationWillTerminate_(self, aNotification):
-        print("ALL WILL TERMINATE")
+    def applicationWillTerminate_(self, notification):
+        self._pyglet_loop.is_running = False
+        self._pyglet_loop.has_exit = True
 
     @_AppDelegate.method('v@')
-    def applicationDidFinishLaunching_(self, aNotification):
-        print("APP STARTED")
+    def applicationDidFinishLaunching_(self, notification):
+        self._pyglet_loop._finished_launching = True
 
 _AppDelegate = ObjCClass('_AppDelegate')  # the actual class
 
-class CocoaEventLoop(EventLoop):
+class CocoaAlternateEventLoop(EventLoop):
+    """This is an alternate loop developed mainly for ARM64 variants of macOS.
+    nextEventMatchingMask_untilDate_inMode_dequeue_ is very broken with ctypes calls. Events eventually stop
+    working properly after X returns. This event loop differs in that it uses the built-in NSApplication event
+    loop. We tie our schedule into it via timer.
+    """
     def run(self, interval=1/60):
-        """Begin processing events, scheduled functions and window updates.
-
-        This method returns when :py:attr:`has_exit` is set to True.
-
-        Developers are discouraged from overriding this method, as the
-        implementation is platform-specific.
-        """
-        self.interval = interval
-
         if not interval:
             self.clock.schedule(self._redraw_windows)
         else:
@@ -97,19 +95,11 @@ class CocoaEventLoop(EventLoop):
             window.switch_to()
             window.dispatch_pending_events()
 
-        platform_event_loop = app.platform_event_loop
-        #platform_event_loop.start()
+        self.platform_event_loop = app.platform_event_loop
 
         self.dispatch_event('on_enter')
         self.is_running = True
-        platform_event_loop.arm64_start(interval)
-
-
-        #while not self.has_exit:
-        #    timeout = self.idle()
-        #    platform_event_loop.step(timeout)
-
-
+        self.platform_event_loop.nsapp_start(interval)
 
     def exit(self):
         """Safely exit the event loop at the end of the current iteration.
@@ -119,12 +109,12 @@ class CocoaEventLoop(EventLoop):
         interrupted (see :py:meth:`sleep`).
         """
         self.has_exit = True
-        app.platform_event_loop.notify()
+        self.platform_event_loop.notify()
 
         self.is_running = False
         self.dispatch_event('on_exit')
-        platform_event_loop = app.platform_event_loop
-        platform_event_loop.arm64_stop()
+
+        self.platform_event_loop.nsapp_stop()
 
 class CocoaPlatformEventLoop(PlatformEventLoop):
 
@@ -153,9 +143,6 @@ class CocoaPlatformEventLoop(PlatformEventLoop):
 
             self._finished_launching = False
 
-        from pyglet.app import event_loop
-        self._event_loop = event_loop
-
     def start(self):
         with AutoReleasePool():
             if not self.NSApp.isRunning() and not self._finished_launching:
@@ -165,26 +152,42 @@ class CocoaPlatformEventLoop(PlatformEventLoop):
                 self.NSApp.activateIgnoringOtherApps_(True)
                 self._finished_launching = True
 
-    def arm64_start(self, interval):
-        self._finished_launching = True
+    def nsapp_start(self, interval):
+        """Used only for CocoaAlternateEventLoop"""
+        from pyglet.app import event_loop
+        self._event_loop = event_loop
+
+        def term_received(*args):
+            if self.timer:
+                self.timer.invalidate()
+                self.timer = None
+
+            self.nsapp_stop()
+
+        # Force NSApp to close if Python receives sig events.
+        signal.signal(signal.SIGINT, term_received)
+        signal.signal(signal.SIGTERM, term_received)
 
         self.appdelegate = _AppDelegate.alloc().init(self)
         self.NSApp.setDelegate_(self.appdelegate)
 
-        NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-             interval,
+        self.timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+             interval,  # Clamped internally to 0.0001 (including 0)
              self.appdelegate,
              get_selector('updatePyglet:'),
              False,
              True
          )
+
         self.NSApp.run()
 
-    def arm64_step(self):
+    def nsapp_step(self):
+        """Used only for CocoaAlternateEventLoop"""
         self._event_loop.idle()
         self.dispatch_posted_events()
 
-    def arm64_stop(self):
+    def nsapp_stop(self):
+        """Used only for CocoaAlternateEventLoop"""
         self.NSApp.terminate_(None)
 
     def step(self, timeout=None):
@@ -212,24 +215,7 @@ class CocoaPlatformEventLoop(PlatformEventLoop):
             if event is not None:
                 event_type = event.type()
                 if event_type != cocoapy.NSApplicationDefined:
-                    # Send out event as normal.  Responders will still receive
-                    # keyUp:, keyDown:, and flagsChanged: events.
                     self.NSApp.sendEvent_(event)
-
-                    # Resend key events as special pyglet-specific messages
-                    # which supplant the keyDown:, keyUp:, and flagsChanged: messages
-                    # because NSApplication translates multiple key presses into key
-                    # equivalents before sending them on, which means that some keyUp:
-                    # messages are never sent for individual keys.   Our pyglet-specific
-                    # replacements ensure that we see all the raw key presses & releases.
-                    # We also filter out key-down repeats since pyglet only sends one
-                    # on_key_press event per key press.
-                    # if event_type == cocoapy.NSKeyDown and not event.isARepeat():
-                    #     self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyDown:"), None, event)
-                    # elif event_type == cocoapy.NSKeyUp:
-                    #     self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletKeyUp:"), None, event)
-                    # elif event_type == cocoapy.NSFlagsChanged:
-                    #     self.NSApp.sendAction_to_from_(cocoapy.get_selector("pygletFlagsChanged:"), None, event)
 
                 self.NSApp.updateWindows()
                 did_time_out = False

--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -215,6 +215,7 @@ NSDefaultRunLoopMode = c_void_p.in_dll(appkit, 'NSDefaultRunLoopMode')
 NSEventTrackingRunLoopMode = c_void_p.in_dll(appkit, 'NSEventTrackingRunLoopMode')
 NSApplicationDidHideNotification = c_void_p.in_dll(appkit, 'NSApplicationDidHideNotification')
 NSApplicationDidUnhideNotification = c_void_p.in_dll(appkit, 'NSApplicationDidUnhideNotification')
+NSApplicationDidUpdateNotification = c_void_p.in_dll(appkit, 'NSApplicationDidUpdateNotification')
 NSPasteboardURLReadingFileURLsOnlyKey = c_void_p.in_dll(appkit, 'NSPasteboardURLReadingFileURLsOnlyKey')
 NSPasteboardTypeURL = c_void_p.in_dll(appkit, 'NSPasteboardTypeURL')
 NSDragOperationGeneric = 4

--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -228,6 +228,17 @@ NSKeyUp              = 11
 NSFlagsChanged       = 12
 NSApplicationDefined = 15
 
+# Undocumented left/right modifier masks found by experimentation:
+NSLeftShiftKeyMask = 1 << 1
+NSRightShiftKeyMask = 1 << 2
+NSLeftControlKeyMask = 1 << 0
+NSRightControlKeyMask = 1 << 13
+NSLeftAlternateKeyMask = 1 << 5
+NSRightAlternateKeyMask = 1 << 6
+NSLeftCommandKeyMask = 1 << 3
+NSRightCommandKeyMask = 1 << 4
+
+
 NSAlphaShiftKeyMask         = 1 << 16
 NSShiftKeyMask              = 1 << 17
 NSControlKeyMask            = 1 << 18

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -1,7 +1,9 @@
 from pyglet.window import key, mouse
 from pyglet.libs.darwin.quartzkey import keymap, charmap
 
-from pyglet.libs.darwin import cocoapy, NSPasteboardURLReadingFileURLsOnlyKey
+from pyglet.libs.darwin import cocoapy, NSPasteboardURLReadingFileURLsOnlyKey, NSLeftShiftKeyMask, NSRightShiftKeyMask, \
+    NSLeftControlKeyMask, NSRightControlKeyMask, NSLeftAlternateKeyMask, NSRightAlternateKeyMask, NSLeftCommandKeyMask, \
+    NSRightCommandKeyMask, NSFunctionKeyMask, NSAlphaShiftKeyMask
 from .pyglet_textview import PygletTextView
 
 
@@ -10,6 +12,20 @@ NSURL = cocoapy.ObjCClass('NSURL')
 NSArray = cocoapy.ObjCClass('NSArray')
 NSDictionary = cocoapy.ObjCClass('NSDictionary')
 NSNumber = cocoapy.ObjCClass('NSNumber')
+
+# Key to mask mapping.
+maskForKey = {
+    key.LSHIFT: NSLeftShiftKeyMask,
+    key.RSHIFT: NSRightShiftKeyMask,
+    key.LCTRL: NSLeftControlKeyMask,
+    key.RCTRL: NSRightControlKeyMask,
+    key.LOPTION: NSLeftAlternateKeyMask,
+    key.ROPTION: NSRightAlternateKeyMask,
+    key.LCOMMAND: NSLeftCommandKeyMask,
+    key.RCOMMAND: NSRightCommandKeyMask,
+    key.CAPSLOCK: NSAlphaShiftKeyMask,
+    key.FUNCTION: NSFunctionKeyMask
+}
 
 # Event data helper functions.
 
@@ -185,29 +201,6 @@ class PygletView_Implementation:
         # Handles on_key_press and on_key_release events for modifier keys.
         # Note that capslock is handled differently than other keys; it acts
         # as a toggle, so on_key_release is only sent when it's turned off.
-
-        # TODO: Move these constants somewhere else.
-        # Undocumented left/right modifier masks found by experimentation:
-        NSLeftShiftKeyMask      = 1 << 1
-        NSRightShiftKeyMask     = 1 << 2
-        NSLeftControlKeyMask    = 1 << 0
-        NSRightControlKeyMask   = 1 << 13
-        NSLeftAlternateKeyMask  = 1 << 5
-        NSRightAlternateKeyMask = 1 << 6
-        NSLeftCommandKeyMask    = 1 << 3
-        NSRightCommandKeyMask   = 1 << 4
-
-        maskForKey = {key.LSHIFT: NSLeftShiftKeyMask,
-                      key.RSHIFT: NSRightShiftKeyMask,
-                      key.LCTRL: NSLeftControlKeyMask,
-                      key.RCTRL: NSRightControlKeyMask,
-                      key.LOPTION: NSLeftAlternateKeyMask,
-                      key.ROPTION: NSRightAlternateKeyMask,
-                      key.LCOMMAND: NSLeftCommandKeyMask,
-                      key.RCOMMAND: NSRightCommandKeyMask,
-                      key.CAPSLOCK: cocoapy.NSAlphaShiftKeyMask,
-                      key.FUNCTION: cocoapy.NSFunctionKeyMask}
-
         symbol = keymap.get(nsevent.keyCode(), None)
 
         # Ignore this event if symbol is not a modifier key.  We must check this

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -124,6 +124,10 @@ class PygletView_Implementation:
         self.addTrackingArea_(self._tracking_area)
 
     @PygletView.method('B')
+    def acceptsFirstResponder (self):
+        return True
+
+    @PygletView.method('B')
     def canBecomeKeyView(self):
         return True
 
@@ -164,19 +168,20 @@ class PygletView_Implementation:
                 app.event_loop.idle()
 
     @PygletView.method('v@')
-    def pygletKeyDown_(self, nsevent):
-        symbol = getSymbol(nsevent)
-        modifiers = getModifiers(nsevent)
-        self._window.dispatch_event('on_key_press', symbol, modifiers)
+    def keyDown_(self, nsevent):
+        if not nsevent.isARepeat():
+            symbol = getSymbol(nsevent)
+            modifiers = getModifiers(nsevent)
+            self._window.dispatch_event('on_key_press', symbol, modifiers)
 
     @PygletView.method('v@')
-    def pygletKeyUp_(self, nsevent):
+    def keyUp_(self, nsevent):
         symbol = getSymbol(nsevent)
         modifiers = getModifiers(nsevent)
         self._window.dispatch_event('on_key_release', symbol, modifiers)
 
     @PygletView.method('v@')
-    def pygletFlagsChanged_(self, nsevent):
+    def flagsChanged_(self, nsevent):
         # Handles on_key_press and on_key_release events for modifier keys.
         # Note that capslock is handled differently than other keys; it acts
         # as a toggle, so on_key_release is only sent when it's turned off.


### PR DESCRIPTION
With the breakdown of `nextEventMatchingMask_untilDate_inMode_dequeue_` through ctypes on ARM64, I have implemented an alternative method. (This issue may be a macOS, Python, or ctypes issue, it is currently unknown.) This work around uses the built in event loop through NSApplication, which does not have the issue, and we schedule our idle and event checks through it. 

Maximum timer resolution with this method is 0.0001 (via `pyglet.app.run()`.

Pyglet option `osx_alt_loop` also forces to this event loop type. Used for testing, or if you experience funny behavior with the the default event loop on macOS, try using this option. This is defaulted for arm64 on macOS.

Removes `pygletKeyDown_`, `pygletKeyDown_`, `pygletFlagsChanged_` in exchange for the default events. I haven't been able to find any negative effects from this. 