### PR TITLE
fix args when calling super class

### DIFF
--- a/examples/sprite/multi_texture_sprite.py
+++ b/examples/sprite/multi_texture_sprite.py
@@ -63,7 +63,7 @@ class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
     """A sprite group that uses multiple active textures.
     """
 
-    def __init__(self, textures, blend_src, blend_dest, program=None, order=0, parent=None):
+    def __init__(self, textures, blend_src, blend_dest, program=None, parent=None):
         """Create a sprite group for multiple textures and samplers.
            All textures must share the same target type.
 
@@ -82,7 +82,7 @@ class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
         self.textures = textures
         texture = list(self.textures.values())[0]
         self.target = texture.target
-        super().__init__(texture, blend_src, blend_dest, program, order, parent)
+        super().__init__(texture, blend_src, blend_dest, program, parent)
 
     def set_state(self):
         self.program.use()
@@ -145,7 +145,7 @@ class MultiTextureSprite(pyglet.sprite.AdvancedSprite):
         self._texture = list(textures.values())[0]
 
         self._batch = batch or graphics.get_default_batch()
-        self._group = self.group_class(textures, blend_src, blend_dest, self._program, 0, group)
+        self._group = self.group_class(textures, blend_src, blend_dest, self._program, group)
         self._subpixel = subpixel
         self._create_vertex_list()
 

--- a/pyglet/input/linux/x11_xinput.py
+++ b/pyglet/input/linux/x11_xinput.py
@@ -107,20 +107,16 @@ class XInputDevice(DeviceResponder, Device):
         super(XInputDevice, self).open(window, exclusive)
 
         if window is None:
-            self.is_open = False
             raise DeviceOpenException('XInput devices require a window')
 
         if window.display._display != self.display._display:
-            self.is_open = False
             raise DeviceOpenException('Window and device displays differ')
 
         if exclusive:
-            self.is_open = False
             raise DeviceOpenException('Cannot open XInput device exclusive')
 
         self._device = xi.XOpenDevice(self.display._display, self._device_id)
         if not self._device:
-            self.is_open = False
             raise DeviceOpenException('Cannot open device')
 
         self._install_events(window)

--- a/pyglet/input/linux/x11_xinput.py
+++ b/pyglet/input/linux/x11_xinput.py
@@ -107,16 +107,20 @@ class XInputDevice(DeviceResponder, Device):
         super(XInputDevice, self).open(window, exclusive)
 
         if window is None:
+            self.is_open = False
             raise DeviceOpenException('XInput devices require a window')
 
         if window.display._display != self.display._display:
+            self.is_open = False
             raise DeviceOpenException('Window and device displays differ')
 
         if exclusive:
+            self.is_open = False
             raise DeviceOpenException('Cannot open XInput device exclusive')
 
         self._device = xi.XOpenDevice(self.display._display, self._device_id)
         if not self._device:
+            self.is_open = False
             raise DeviceOpenException('Cannot open device')
 
         self._install_events(window)


### PR DESCRIPTION
[`SpriteGroup`](https://github.com/pyglet/pyglet/blob/e374e81c7b2128b24da52707e4f233b19749c40e/pyglet/sprite.py#L177)

SpriteGroup class constructor only has 5 parameters in its definition. The call to the super class constructor provides 6 arguments.  Removing that argument makes the up-stream arguments superfluous, thus removed them as well.


