### PR TITLE
fix is_open in x11_input

### DIFF
--- a/pyglet/input/linux/x11_xinput.py
+++ b/pyglet/input/linux/x11_xinput.py
@@ -107,20 +107,20 @@ class XInputDevice(DeviceResponder, Device):
         super(XInputDevice, self).open(window, exclusive)
 
         if window is None:
-            self.is_open = False
+            self._is_open = False
             raise DeviceOpenException('XInput devices require a window')
 
         if window.display._display != self.display._display:
-            self.is_open = False
+            self._is_open = False
             raise DeviceOpenException('Window and device displays differ')
 
         if exclusive:
-            self.is_open = False
+            self._is_open = False
             raise DeviceOpenException('Cannot open XInput device exclusive')
 
         self._device = xi.XOpenDevice(self.display._display, self._device_id)
         if not self._device:
-            self.is_open = False
+            self._is_open = False
             raise DeviceOpenException('Cannot open device')
 
         self._install_events(window)


### PR DESCRIPTION
[`Device`](https://github.com/pyglet/pyglet/blob/e374e81c7b2128b24da52707e4f233b19749c40e/pyglet/input/base.py#L43)

`XInputDevice` is a sub-class of `Device`.  The property (**is_open**) is inherited, however the parent class defines this property as **_is_open**. These changes correct this difference.