### PR TITLE
Shape enhancement and consolidate shader name

### DIFF
--- a/pyglet/model/__init__.py
+++ b/pyglet/model/__init__.py
@@ -215,7 +215,7 @@ class BaseMaterialGroup(graphics.Group):
 
 class TexturedMaterialGroup(BaseMaterialGroup):
     default_vert_src = """#version 330 core
-    in vec3 vertices;
+    in vec3 position;
     in vec3 normals;
     in vec2 tex_coords;
     in vec4 colors;
@@ -235,7 +235,7 @@ class TexturedMaterialGroup(BaseMaterialGroup):
 
     void main()
     {
-        vec4 pos = window.view * model * vec4(vertices, 1.0);
+        vec4 pos = window.view * model * vec4(position, 1.0);
         gl_Position = window.projection * pos;
         mat3 normal_matrix = transpose(inverse(mat3(model)));
 
@@ -286,7 +286,7 @@ class TexturedMaterialGroup(BaseMaterialGroup):
 
 class MaterialGroup(BaseMaterialGroup):
     default_vert_src = """#version 330 core
-    in vec3 vertices;
+    in vec3 position;
     in vec3 normals;
     in vec4 colors;
 
@@ -304,7 +304,7 @@ class MaterialGroup(BaseMaterialGroup):
 
     void main()
     {
-        vec4 pos = window.view * model * vec4(vertices, 1.0);
+        vec4 pos = window.view * model * vec4(position, 1.0);
         gl_Position = window.projection * pos;
         mat3 normal_matrix = transpose(inverse(mat3(model)));
 

--- a/pyglet/model/codecs/obj.py
+++ b/pyglet/model/codecs/obj.py
@@ -214,7 +214,7 @@ class OBJModelDecoder(ModelDecoder):
                 texture = pyglet.resource.texture(material.texture_name)
                 matgroup = TexturedMaterialGroup(material, program, texture, parent=group)
                 vertex_lists.append(program.vertex_list(count, GL_TRIANGLES, batch, matgroup,
-                                                        vertices=('f', mesh.vertices),
+                                                        position=('f', mesh.vertices),
                                                         normals=('f', mesh.normals),
                                                         tex_coords=('f', mesh.tex_coords),
                                                         colors=('f', material.diffuse * count)))
@@ -222,7 +222,7 @@ class OBJModelDecoder(ModelDecoder):
                 program = pyglet.model.get_default_shader()
                 matgroup = MaterialGroup(material, program, parent=group)
                 vertex_lists.append(program.vertex_list(count, GL_TRIANGLES, batch, matgroup,
-                                                        vertices=('f', mesh.vertices),
+                                                        position=('f', mesh.vertices),
                                                         normals=('f', mesh.normals),
                                                         colors=('f', material.diffuse * count)))
             groups.append(matgroup)

--- a/tests/interactive/text/test_inline_elements.py
+++ b/tests/interactive/text/test_inline_elements.py
@@ -80,7 +80,7 @@ class TestElement(document.InlineElement):
         y += self.descent
         w = self.advance
         h = self.ascent - self.descent
-        self.vertex_list.vertices[:] = (x, y, 
+        self.vertex_list.position[:] = (x, y,
                                         x + w, y,
                                         x + w, y + h,
                                         x, y + h)

--- a/tests/interactive/text/test_inline_elements_style_change.py
+++ b/tests/interactive/text/test_inline_elements_style_change.py
@@ -55,7 +55,7 @@ class TestElement(document.InlineElement):
         y += self.descent
         w = self.advance
         h = self.ascent - self.descent
-        self.vertex_list.vertices[:] = (x, y, 
+        self.vertex_list.position[:] = (x, y,
                                         x + w, y,
                                         x + w, y + h,
                                         x, y + h)


### PR DESCRIPTION
Add `group_class` class variable to Shapes to make it easier to subclass it.
Update shapes shader to use 'position' instead of 'vertices' to match Sprite
Update model shader to use 'position' instead of 'vertices' to match Sprite

Resolves request: https://github.com/pyglet/pyglet/issues/709