### PR TITLE
Add context manager wrapping GDI acquisition & release

### DIFF
--- a/pyglet/canvas/win32.py
+++ b/pyglet/canvas/win32.py
@@ -3,7 +3,7 @@ from .base import Display, Screen, ScreenMode, Canvas
 from pyglet.libs.win32 import _user32
 from pyglet.libs.win32.constants import *
 from pyglet.libs.win32.types import *
-from ..libs.win32.context_managers import device_context
+from pyglet.libs.win32.context_managers import device_context
 
 
 class Win32Display(Display):

--- a/pyglet/canvas/win32.py
+++ b/pyglet/canvas/win32.py
@@ -3,6 +3,7 @@ from .base import Display, Screen, ScreenMode, Canvas
 from pyglet.libs.win32 import _user32
 from pyglet.libs.win32.constants import *
 from pyglet.libs.win32.types import *
+from ..libs.win32.context_managers import device_context
 
 
 class Win32Display(Display):
@@ -30,13 +31,13 @@ class Win32Screen(Screen):
         self._handle = handle
 
     def get_matching_configs(self, template):
-        hdc = _user32.GetDC(0)
-        canvas = Win32Canvas(self.display, 0, hdc)
-        configs = template.match(canvas)
-        # XXX deprecate config's being screen-specific
-        for config in configs:
-            config.screen = self
-        _user32.ReleaseDC(0, hdc)
+        with device_context(0) as hdc:
+            canvas = Win32Canvas(self.display, 0, hdc)
+            configs = template.match(canvas)
+            # XXX deprecate config's being screen-specific
+            for config in configs:
+                config.screen = self
+
         return configs
 
     def get_device_name(self):

--- a/pyglet/canvas/win32.py
+++ b/pyglet/canvas/win32.py
@@ -31,7 +31,7 @@ class Win32Screen(Screen):
         self._handle = handle
 
     def get_matching_configs(self, template):
-        with device_context(0) as hdc:
+        with device_context(None) as hdc:
             canvas = Win32Canvas(self.display, 0, hdc)
             configs = template.match(canvas)
             # XXX deprecate config's being screen-specific

--- a/pyglet/font/win32.py
+++ b/pyglet/font/win32.py
@@ -196,7 +196,7 @@ class Win32Font(base.Font):
         self.hfont = gdi32.CreateFontIndirectW(byref(self.logfont))
 
         # Create a dummy DC for coordinate mapping
-        with device_context(0) as dc:
+        with device_context(None) as dc:
             metrics = TEXTMETRIC()
             gdi32.SelectObject(dc, self.hfont)
             gdi32.GetTextMetricsA(dc, byref(metrics))
@@ -210,7 +210,7 @@ class Win32Font(base.Font):
     @staticmethod
     def get_logfont(name, size, bold, italic, dpi):
         # Create a dummy DC for coordinate mapping
-        with device_context(0) as dc:
+        with device_context(None) as dc:
             if dpi is None:
                 dpi = 96
             logpixelsy = dpi

--- a/pyglet/font/win32.py
+++ b/pyglet/font/win32.py
@@ -210,22 +210,22 @@ class Win32Font(base.Font):
     @staticmethod
     def get_logfont(name, size, bold, italic, dpi):
         # Create a dummy DC for coordinate mapping
-        dc = user32.GetDC(0)
-        if dpi is None:
-            dpi = 96
-        logpixelsy = dpi
+        with device_context(0) as dc:
+            if dpi is None:
+                dpi = 96
+            logpixelsy = dpi
 
-        logfont = LOGFONTW()
-        # Conversion of point size to device pixels
-        logfont.lfHeight = int(-size * logpixelsy // 72)
-        if bold:
-            logfont.lfWeight = FW_BOLD
-        else:
-            logfont.lfWeight = FW_NORMAL
-        logfont.lfItalic = italic
-        logfont.lfFaceName = name
-        logfont.lfQuality = ANTIALIASED_QUALITY
-        user32.ReleaseDC(0, dc)
+            logfont = LOGFONTW()
+            # Conversion of point size to device pixels
+            logfont.lfHeight = int(-size * logpixelsy // 72)
+            if bold:
+                logfont.lfWeight = FW_BOLD
+            else:
+                logfont.lfWeight = FW_NORMAL
+            logfont.lfItalic = italic
+            logfont.lfFaceName = name
+            logfont.lfQuality = ANTIALIASED_QUALITY
+
         return logfont
 
     @classmethod

--- a/pyglet/font/win32.py
+++ b/pyglet/font/win32.py
@@ -9,6 +9,7 @@ from pyglet.font import base
 from pyglet.font import win32query
 import pyglet.image
 from pyglet.libs.win32.constants import *
+from pyglet.libs.win32.context_managers import device_context
 from pyglet.libs.win32.types import *
 from pyglet.libs.win32 import _gdi32 as gdi32, _user32 as user32
 from pyglet.libs.win32 import _kernel32 as kernel32
@@ -195,14 +196,13 @@ class Win32Font(base.Font):
         self.hfont = gdi32.CreateFontIndirectW(byref(self.logfont))
 
         # Create a dummy DC for coordinate mapping
-        dc = user32.GetDC(0)
-        metrics = TEXTMETRIC()
-        gdi32.SelectObject(dc, self.hfont)
-        gdi32.GetTextMetricsA(dc, byref(metrics))
-        self.ascent = metrics.tmAscent
-        self.descent = -metrics.tmDescent
-        self.max_glyph_width = metrics.tmMaxCharWidth
-        user32.ReleaseDC(0, dc)
+        with device_context(0) as dc:
+            metrics = TEXTMETRIC()
+            gdi32.SelectObject(dc, self.hfont)
+            gdi32.GetTextMetricsA(dc, byref(metrics))
+            self.ascent = metrics.tmAscent
+            self.descent = -metrics.tmDescent
+            self.max_glyph_width = metrics.tmMaxCharWidth
 
     def __del__(self):
         gdi32.DeleteObject(self.hfont)

--- a/pyglet/font/win32query.py
+++ b/pyglet/font/win32query.py
@@ -71,6 +71,7 @@ appropriate typeface name and create the font using CreateFont or
 CreateFontIndirect.
 
 """
+from pyglet.libs.win32.context_managers import device_context
 
 DEBUG = False
 
@@ -385,36 +386,33 @@ def query(charset=DEFAULT_CHARSET):
     global FONTDB
 
     # 1. Get device context of the entire screen
-    hdc = user32.GetDC(None)
+    with device_context(0) as hdc:
 
-    # 2. Call EnumFontFamiliesExA (ANSI version)
+        # 2. Call EnumFontFamiliesExA (ANSI version)
 
-    # 2a. Call with empty font name to query all available fonts
-    #     (or fonts for the specified charset)
-    #
-    # NOTES:
-    #
-    #  * there are fonts that don't support ANSI charset
-    #  * for DEFAULT_CHARSET font is passed to callback function as
-    #    many times as charsets it supports
+        # 2a. Call with empty font name to query all available fonts
+        #     (or fonts for the specified charset)
+        #
+        # NOTES:
+        #
+        #  * there are fonts that don't support ANSI charset
+        #  * for DEFAULT_CHARSET font is passed to callback function as
+        #    many times as charsets it supports
 
-    # [ ] font name should be less than 32 symbols with terminating \0
-    # [ ] check double purpose - enumerate all available font names
-    #      - enumerate all available charsets for a single font
-    #      - other params?
+        # [ ] font name should be less than 32 symbols with terminating \0
+        # [ ] check double purpose - enumerate all available font names
+        #      - enumerate all available charsets for a single font
+        #      - other params?
 
-    logfont = LOGFONTW(0, 0, 0, 0, 0, 0, 0, 0, charset, 0, 0, 0, 0, '')
-    FONTDB = []  # clear cached FONTDB for enum_font_names callback
-    res = gdi32.EnumFontFamiliesExW(
-        hdc,  # handle to device context
-        ctypes.byref(logfont),
-        enum_font_names,  # pointer to callback function
-        0,  # lParam  - application-supplied data
-        0)  # dwFlags - reserved = 0
-    # res here is the last value returned by callback function
-
-    # 3. Release DC
-    user32.ReleaseDC(None, hdc)
+        logfont = LOGFONTW(0, 0, 0, 0, 0, 0, 0, 0, charset, 0, 0, 0, 0, '')
+        FONTDB = []  # clear cached FONTDB for enum_font_names callback
+        res = gdi32.EnumFontFamiliesExW(
+            hdc,  # handle to device context
+            ctypes.byref(logfont),
+            enum_font_names,  # pointer to callback function
+            0,  # lParam  - application-supplied data
+            0)  # dwFlags - reserved = 0
+        # res here is the last value returned by callback function
 
     return FONTDB
 

--- a/pyglet/font/win32query.py
+++ b/pyglet/font/win32query.py
@@ -386,7 +386,7 @@ def query(charset=DEFAULT_CHARSET):
     global FONTDB
 
     # 1. Get device context of the entire screen
-    with device_context(0) as hdc:
+    with device_context(None) as hdc:
 
         # 2. Call EnumFontFamiliesExA (ANSI version)
 

--- a/pyglet/libs/win32/context_managers.py
+++ b/pyglet/libs/win32/context_managers.py
@@ -48,8 +48,9 @@ def device_context(window_handle: Optional[int] = None) -> Generator[HANDLE, Non
         HANDLE: the managed drawing context handle to auto-close.
 
     """
-    if _dc := user32.GetDC(window_handle) is None:
+    if not (_dc := user32.GetDC(window_handle)):
         raise WinError()
+
     try:
         yield _dc
     finally:

--- a/pyglet/libs/win32/context_managers.py
+++ b/pyglet/libs/win32/context_managers.py
@@ -2,12 +2,13 @@
 Win32 resources as handy context managers.
 
 These are intended to help keep loader code clean & stable at the price
-of a tiny bit of execution speed.
+of a tiny bit of execution speed. Performance-critical code should avoid
+using these helpers in favor of direct win32 API calls.
 
 Before::
 
     def loader_function(arg):
-        context_handle = user32.GetResource(0)
+        context_handle = user32.GetResource(None)
 
         result = calculation(arg)
 
@@ -20,13 +21,11 @@ After::
 
     def loader_function(arg):
 
-        with ResourceContext(0) as context_handle:
+        with resource_context() as context_handle:
             result = calculation(arg)
 
         return result
 
-Performance-critical code should avoid using these classes in favor of
-direct win32 API calls.
 """
 from contextlib import contextmanager
 from typing import Optional, Generator

--- a/pyglet/libs/win32/context_managers.py
+++ b/pyglet/libs/win32/context_managers.py
@@ -28,26 +28,14 @@ After::
 Performance-critical code should avoid using these classes in favor of
 direct win32 API calls.
 """
-import contextlib
-
-import pyglet
+from contextlib import contextmanager
 from typing import Optional, Generator
-
-if pyglet.compat_platform in ('win32', 'cygwin'):
-    from ctypes.wintypes import HANDLE
-    from ctypes import WinError
-    from pyglet.libs.win32 import _user32 as user32
-
-else:  # Nasty local imports for testing on non-Win32 systems
-    from ctypes import c_void_p as HANDLE
-    from unittest.mock import Mock
-
-    user32 = Mock()
-    user32.GetDC = lambda a: HANDLE()
-    user32.attach_callable_mock('ReleaseDC', Mock())
+from ctypes.wintypes import HANDLE
+from ctypes import WinError
+from pyglet.libs.win32 import _user32 as user32
 
 
-@contextlib.contextmanager
+@contextmanager
 def device_context(window_handle: Optional[int] = None) -> Generator[HANDLE, None, None]:
     """
     A Windows device context wrapped as a context manager.

--- a/pyglet/libs/win32/context_managers.py
+++ b/pyglet/libs/win32/context_managers.py
@@ -1,0 +1,87 @@
+"""
+Win32 resources as handy context managers.
+
+These are intended to help keep loader code clean & stable at the price
+of a tiny bit of execution speed.
+
+Before::
+
+    def loader_function(arg):
+        context_handle = user32.GetResource(0)
+
+        result = calculation(arg)
+
+        # Easily forgotten!
+        user32.ReleaseResource(context_handle)
+
+        return result
+
+After::
+
+    def loader_function(arg):
+
+        with ResourceContext(0) as context_handle:
+            result = calculation(arg)
+
+        return result
+
+Performance-critical code should avoid using these classes in favor of
+direct win32 API calls.
+"""
+import pyglet
+from typing import Optional
+
+
+if pyglet.compat_platform in ('win32', 'cygwin'):
+    from ctypes.wintypes import HANDLE
+    from ctypes import WinError
+    from pyglet.libs.win32 import _user32 as user32
+    from pyglet.libs.win32 import _kernel32 as kernel32
+
+else:  # Nasty local imports for testing on non-Win32 systems
+    from ctypes import c_void_p as HANDLE
+    from unittest.mock import Mock
+
+    user32 = Mock()
+    user32.GetDC = lambda a: HANDLE()
+    user32.attach_callable_mock('ReleaseDC', Mock())
+
+
+class DeviceContext(HANDLE):
+    """
+    A Win32 device context as a Python Context manager.
+
+    This class sacrifices a tiny bit of speed to gain durability
+    and readability. Performance-critical code should directly acquire
+    & release win32 resources the old-fashioned way.
+    """
+
+    def __init__(self, handle: Optional[int] = None):
+        super().__init__()
+        self._is_ctx_manager: bool = False
+
+        # Nasty trick: copy the handle value to this one
+        self.value = self._acquire_handle(handle)
+
+    def _acquire_handle(self, window_handle: Optional[int] = None) -> HANDLE:
+
+        handle_dc = user32.GetDC(window_handle)
+        if not handle_dc:
+            raise WinError()
+
+        return handle_dc
+
+    def _close_handle(self) -> None:
+        user32.ReleaseDC(self)
+
+    def __enter__(self) -> HANDLE:
+        self._is_ctx_manager = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._close_handle()
+
+    def close(self) -> None:
+        if self._is_ctx_manager:
+            raise AttributeError(
+                "Manual closing not allowed inside context manager")

--- a/tests/integration/platform/test_win_context_managers.py
+++ b/tests/integration/platform/test_win_context_managers.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import Mock
+
+# Skip this entire test module if on a non-win32 platform.
+# Although it's ugly, it's easier than refactoring platform restriction
+# code to allow exceptions to enable mock-backed testing.
+try:
+    from pyglet.libs.win32 import context_managers
+    from ctypes.wintypes import HANDLE
+except ImportError:
+    context_managers = None
+
+pytestmark = pytest.mark.skipif(
+    context_managers is None,
+    reason='Win32 context managers only available on Windows...')
+
+
+# = Fixtures & Constants = #
+
+GET_DC_SUCCESS = 1
+GET_DC_FAILURE = None
+RELEASE_DC_SUCCESS = 1
+RELEASE_DC_FAILURE = 0
+USER32_MODPATH = 'pyglet.libs.win32.context_managers.user32'
+
+
+# === Fixtures === #
+
+# Indirectly parametrize via pytest.mark.parametrize
+# https://docs.pytest.org/en/stable/example/parametrize.html#indirect-parametrization
+@pytest.fixture
+def dc_handle(request) -> "HANDLE":
+    return HANDLE(request.param)
+
+
+@pytest.fixture
+def release_result(request) -> int:
+    return request.param
+
+
+@pytest.fixture
+def patched_get_dc(monkeypatch, dc_handle):
+    mock = Mock(return_value=dc_handle)
+    monkeypatch.setattr(USER32_MODPATH, 'GetDC', mock)
+    return mock
+
+
+@pytest.fixture
+def patched_release_dc(monkeypatch, release_result):
+    mock = Mock(return_value=release_result)
+    monkeypatch.setattr(USER32_MODPATH, 'ReleaseDC', mock)
+    return mock
+
+
+# Kludge to avoid IDE typing issues or ugly cast / type: ignore
+@pytest.fixture
+def patched_win_error_type(monkeypatch):
+    monkeypatch.setattr('pyglet.libs.win32.context_managers', 'WinError', OSError)
+    return OSError
+
+
+# = Tests = #
+
+
+@pytest.mark.parametrize('dc_handle', [GET_DC_SUCCESS], indirect=True)
+@pytest.mark.parametrize('release_result', [RELEASE_DC_SUCCESS], indirect=True)
+def test_device_context_yields_correct_value_when_get_dc_succeeds(
+        patched_get_dc, patched_release_dc, dc_handle
+):
+    with context_managers.device_context() as dc:
+        assert dc is dc_handle
+
+
+@pytest.mark.parametrize('dc_handle', [GET_DC_FAILURE], indirect=True)
+@pytest.mark.parametrize('release_result', [RELEASE_DC_SUCCESS], indirect=True)
+def test_device_context_raises_winerror_when_get_dc_fails(
+        patched_win_error_type, patched_get_dc, patched_release_dc
+):
+    with pytest.raises(patched_win_error_type):
+        with context_managers.device_context() as dc:
+            pass
+
+
+@pytest.mark.parametrize('dc_handle', [GET_DC_SUCCESS], indirect=True)
+@pytest.mark.parametrize('release_result', [RELEASE_DC_FAILURE], indirect=True)
+def test_device_context_raises_winerror_when_cleanup_fails(
+        patched_win_error_type,
+        patched_get_dc, patched_release_dc
+):
+    with pytest.raises(patched_win_error_type):
+        with context_managers.device_context() as dc:
+            pass
+
+
+# Nasty whitebox tests
+@pytest.mark.parametrize('dc_handle', [GET_DC_SUCCESS, GET_DC_FAILURE], indirect=True)
+@pytest.mark.parametrize('release_result', [RELEASE_DC_SUCCESS], indirect=True)
+def test_device_context_calls_get_dc(
+        patched_get_dc,
+        dc_handle,
+        patched_release_dc
+):
+    try:
+        with context_managers.device_context() as dc:
+            pass
+    finally:
+        patched_get_dc.assert_called_with(dc_handle.value)
+
+
+@pytest.mark.parametrize('dc_handle', [GET_DC_SUCCESS], indirect=True)
+@pytest.mark.parametrize('release_result',
+                         [RELEASE_DC_FAILURE, RELEASE_DC_SUCCESS], indirect=True)
+def test_device_context_calls_release_dc(
+        patched_get_dc,
+        dc_handle,
+        patched_release_dc
+):
+    try:
+        with context_managers.device_context() as dc:
+            pass
+    finally:
+        patched_release_dc.assert_called_with(dc_handle)


### PR DESCRIPTION
tl;dr trial run for context managers to help cleanup font loader code as discussed on discord

This PR adds a context manager which does the following to altered code:
1. Increase durability due to no longer needing to manually close the resource
2. Increase readability by adding structure to code

This is a trial step for cleaning up font loading rather than optimizing pyglet performance. Performance-critical code is not intended to use context managers unless benchmarking deems their overhead acceptable.