### PR TITLE
fix broken packs/unpacks in ttf/png

### DIFF
--- a/pyglet/extlibs/png.py
+++ b/pyglet/extlibs/png.py
@@ -991,7 +991,7 @@ def unpack_rows(rows):
     to being a sequence of bytes.
     """
     for row in rows:
-        fmt = f'!{len(row)}'
+        fmt = f'!{len(row)}H'
         yield bytearray(struct.pack(fmt, *row))
 
 
@@ -1722,7 +1722,7 @@ class Reader:
                         "PLTE chunk is required before bKGD chunk.")
                 self.background = struct.unpack('B', data)
             else:
-                self.background = struct.unpack(f"!{self.color_planes}",
+                self.background = struct.unpack(f"!{self.color_planes}H",
                                                 data)
         except struct.error:
             raise FormatError("bKGD chunk has incorrect length.")
@@ -1744,7 +1744,7 @@ class Reader:
                     f"tRNS chunk is not valid with colour type {self.color_type}.")
             try:
                 self.transparent = \
-                    struct.unpack(f"!{self.color_planes}", data)
+                    struct.unpack(f"!{self.color_planes}H", data)
             except struct.error:
                 raise FormatError("tRNS chunk has incorrect length.")
 
@@ -1977,7 +1977,7 @@ class Reader:
             pixels = itertrns(pixels)
         targetbitdepth = None
         if self.sbit:
-            sbit = struct.unpack(f'{len(self.sbit)}', self.sbit)
+            sbit = struct.unpack(f'{len(self.sbit)}B', self.sbit)
             targetbitdepth = max(sbit)
             if targetbitdepth > info['bitdepth']:
                 raise Error(f'sBIT chunk {sbit!r} exceeds bitdepth {self.bitdepth}')

--- a/pyglet/font/ttf.py
+++ b/pyglet/font/ttf.py
@@ -367,16 +367,16 @@ class TruetypeInfo:
         # a fuckwit. 
         header = _read_cmap_format4Header(self._data, offset)
         seg_count = header.seg_count_x2 // 2
-        array_size = struct.calcsize(f'>{seg_count}')
-        end_count = self._read_array(f'>{seg_count}',
+        array_size = struct.calcsize(f'>{seg_count}H')
+        end_count = self._read_array(f'>{seg_count}H',
                                      offset + header.size)
-        start_count = self._read_array(f'>{seg_count}',
+        start_count = self._read_array(f'>{seg_count}H',
                                        offset + header.size + array_size + 2)
-        id_delta = self._read_array(f'>{seg_count}',
+        id_delta = self._read_array(f'>{seg_count}H',
                                     offset + header.size + array_size + 2 + array_size)
         id_range_offset_address = \
             offset + header.size + array_size + 2 + array_size + array_size
-        id_range_offset = self._read_array(f'>{seg_count}',
+        id_range_offset = self._read_array(f'>{seg_count}H',
                                            id_range_offset_address)
         character_map = {}
         for i in range(0, seg_count):


### PR DESCRIPTION
I notices, that the loading of tiled maps was not working, when the image was using a color map. The exception was an unpack error.
After some digging, I noticed that the format had the wrong syntax. This was introduced in [this](https://github.com/pyglet/pyglet/commit/561069c110a14e9b388d69d2cf23274252e86933) commit.

I looked through the commit and fixed the same issue in the ttf parser.