### PR TITLE
Fix for TextEntry

### DIFF
--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -438,6 +438,7 @@ class TextEntry(WidgetBase):
     def _set_focus(self, value):
         self._focus = value
         self._caret.visible = value
+        self._caret.layout = self._layout
 
     def update_groups(self, order):
         self._outline.group = Group(order=order + 1, parent=self._user_group)

--- a/pyglet/text/layout.py
+++ b/pyglet/text/layout.py
@@ -958,6 +958,7 @@ class TextLayout:
     def group(self, group):
         self._user_group = group
         self._initialize_groups()
+        self.group_cache.clear()
         self._update()
 
     @property


### PR DESCRIPTION
Fix for Rectangle appearing over the IncrementalTextLayout.

Group cache needs to be cleared upon group change for TextLayouts.

Caret also needs to be able to update layout in-case the group changes, otherwise it cannot appear on the same group level as the foreground after a change.