### PR TITLE
Use RGBA default caret_color in TextEntry.__init__

### DIFF
--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -370,7 +370,7 @@ class TextEntry(WidgetBase):
     """
 
     def __init__(self, text, x, y, width,
-                 color=(255, 255, 255, 255), text_color=(0, 0, 0, 255), caret_color=(0, 0, 0),
+                 color=(255, 255, 255, 255), text_color=(0, 0, 0, 255), caret_color=(0, 0, 0, 255),
                  batch=None, group=None):
         """Create a text entry widget.
 
@@ -387,8 +387,9 @@ class TextEntry(WidgetBase):
                 The color of the outline box in RGBA format.
             `text_color` : (int, int, int, int)
                 The color of the text in RGBA format.
-            `caret_color` : (int, int, int)
-                The color of the caret in RGB format.
+            `caret_color` : (int, int, int, int)
+                The color of the caret when it is visible in RGBA or RGB
+                format.
             `batch` : `~pyglet.graphics.Batch`
                 Optional batch to add the text entry widget to.
             `group` : `~pyglet.graphics.Group`


### PR DESCRIPTION
### Changes

tl;dr style consistency follow-up to #805 brought to light by #823.

* Set default `caret_color` value in `TextEntry`'s `__init__` arguments to an RGBA tuple.
* Update docstring with RGBA & additional caret behavior clarity

### How to Test

Run the unit tests & the widgets demo.