### PR TITLE
Added support for FFmpeg 6.0.

### DIFF
--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -125,8 +125,9 @@ class LibraryLoader:
                         if _debug_trace:
                             lib = _TraceLibrary(lib)
                         return lib
-                    except OSError:
-                        pass
+                    except OSError as e:
+                        if _debug_lib:
+                            print(f"Unexpected error loading library {name}: {str(e)}")
                 elif self.platform == "win32" and o.winerror != 126:
                     if _debug_lib:
                         print(f"Unexpected error loading library {name}: {str(o)}")

--- a/pyglet/media/codecs/__init__.py
+++ b/pyglet/media/codecs/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pyglet.util import CodecRegistry, Decoder, Encoder
 from .base import *
 
@@ -94,10 +96,22 @@ def have_ffmpeg():
     try:
         from . import ffmpeg_lib
         if _debug:
-            print('FFmpeg available, using to load media files. Versions: {}'.format(ffmpeg_lib.compat.versions))
+            print('FFmpeg available, using to load media files.')
+
+        found = False
+        for release_versions, build_versions in ffmpeg_lib.release_versions.items():
+            if ffmpeg_lib.compat.versions == build_versions:
+                if _debug:
+                    print(f'FFMpeg Release Version: {release_versions}. Versions Loaded: {ffmpeg_lib.compat.versions}')
+                found = True
+                break
+
+        if not found:
+            warnings.warn(f'FFmpeg release version not found. This may be a new or untested release. Unknown behavior may occur. Versions Loaded: {ffmpeg_lib.compat.versions}')
+
         return True
 
-    except (ImportError, FileNotFoundError, AttributeError):
+    except (ImportError, FileNotFoundError, AttributeError) as err:
         if _debug:
-            print('FFmpeg not available.')
+            print(f'FFmpeg not available: {err}')
         return False

--- a/pyglet/media/codecs/ffmpeg_lib/compat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/compat.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
-CustomField = namedtuple("CustomField", "fields removals")
+CustomField = namedtuple("CustomField", "fields removals repositions")
+Reposition = namedtuple("Reposition", "field after")
 
 # Versions of the loaded libraries
 versions = {
@@ -12,10 +13,11 @@ versions = {
 }
 
 # Group codecs by version they are usually packaged with.
-release_versions = [
-    {'avcodec': 58, 'avformat': 58, 'avutil': 56, 'swresample': 3, 'swscale': 5},
-    {'libavcodec': 59, 'avformat': 59, 'avutil': 57, 'swresample': 4, 'swscale': 6}
-]
+release_versions = {
+    4: {'avcodec': 58, 'avformat': 58, 'avutil': 56, 'swresample': 3, 'swscale': 5},  # 4.x
+    5: {'avcodec': 59, 'avformat': 59, 'avutil': 57, 'swresample': 4, 'swscale': 6},  # 5.x
+    6: {'avcodec': 60, 'avformat': 60, 'avutil': 58, 'swresample': 4, 'swscale': 7},  # 6.x
+}
 
 # Removals done per library and version.
 _version_changes = {
@@ -31,7 +33,7 @@ def set_version(library, version):
     versions[library] = version
 
 
-def add_version_changes(library, version, structure, fields, removals):
+def add_version_changes(library, version, structure, fields, removals, repositions=None):
     if version not in _version_changes[library]:
         _version_changes[library][version] = {}
 
@@ -41,7 +43,7 @@ def add_version_changes(library, version, structure, fields, removals):
                                                                                                version)
                         )
 
-    _version_changes[library][version][structure] = CustomField(fields, removals)
+    _version_changes[library][version][structure] = CustomField(fields, removals, repositions)
 
 
 def apply_version_changes():
@@ -59,5 +61,21 @@ def apply_version_changes():
                             for field in list(cf_data.fields):
                                 if field[0] == remove_field:
                                     cf_data.fields.remove(field)
+
+                    if cf_data.repositions:
+                        for reposition in cf_data.repositions:
+                            data = None
+                            insertId = None
+                            for idx, field in enumerate(list(cf_data.fields)):
+                                if field[0] == reposition.field:
+                                    data = field
+                                elif field[0] == reposition.after:
+                                    insertId = idx
+
+                            if data and insertId:
+                                cf_data.fields.remove(data)
+                                cf_data.fields.insert(insertId+1, data)
+                            else:
+                                print(f"Warning: {reposition} for {library} was not able to be processed.")
 
                     structure._fields_ = cf_data.fields

--- a/pyglet/media/codecs/ffmpeg_lib/libavcodec.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavcodec.py
@@ -14,8 +14,8 @@ _debug = debug_print('debug_media')
 
 avcodec = pyglet.lib.load_library(
     'avcodec',
-    win32=('avcodec-59', 'avcodec-58'),
-    darwin=('avcodec.59', 'avcodec.58')
+    win32=('avcodec-60', 'avcodec-59', 'avcodec-58'),
+    darwin=('avcodec.60', 'avcodec.59', 'avcodec.58')
 )
 
 avcodec.avcodec_version.restype = c_int
@@ -67,6 +67,8 @@ compat.add_version_changes('avcodec', 58, AVPacket, AVPacket_Fields,
 compat.add_version_changes('avcodec', 59, AVPacket, AVPacket_Fields,
                            removals=('convergence_duration',))
 
+compat.add_version_changes('avcodec', 60, AVPacket, AVPacket_Fields,
+                           removals=('convergence_duration',))
 
 class AVCodecParserContext(Structure):
     pass
@@ -376,6 +378,17 @@ compat.add_version_changes('avcodec', 59, AVCodecContext, AVCodecContext_Fields,
                   'rtp_payload_size', 'mv_bits', 'header_bits', 'i_tex_bits', 'p_tex_bits', 'i_count', 'p_count',
                   'skip_count', 'misc_bits', 'frames_bits', 'coded_frame', 'vbv_delay', 'side_data_only_packets')
 )
+
+compat.add_version_changes('avcodec', 60, AVCodecContext, AVCodecContext_Fields,
+    removals=('b_frame_strategy', 'mpeg_quant', 'prediction_method', 'pre_me', 'scenechange_threshold',
+                  'noise_reduction', 'me_penalty_compensation', 'brd_scale', 'chromaoffset', 'b_sensitivity',
+                  'refcounted_frames', 'coder_type', 'context_model', 'coder_type', 'context_model',
+                  'frame_skip_threshold', 'frame_skip_factor', 'frame_skip_exp', 'frame_skip_cmp',
+                  'min_prediction_order', 'max_prediction_order', 'timecode_frame_start', 'rtp_callback',
+                  'rtp_payload_size', 'mv_bits', 'header_bits', 'i_tex_bits', 'p_tex_bits', 'i_count', 'p_count',
+                  'skip_count', 'misc_bits', 'frames_bits', 'coded_frame', 'vbv_delay', 'side_data_only_packets')
+)
+
 
 AV_CODEC_ID_VP8 = 139
 AV_CODEC_ID_VP9 = 167

--- a/pyglet/media/codecs/ffmpeg_lib/libavformat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavformat.py
@@ -14,8 +14,8 @@ _debug = debug_print('debug_media')
 
 avformat = pyglet.lib.load_library(
     'avformat',
-    win32=('avformat-59', 'avformat-58'),
-    darwin=('avformat.59', 'avformat.58')
+    win32=('avformat-60', 'avformat-59', 'avformat-58'),
+    darwin=('avformat.60', 'avformat.59', 'avformat.58')
 )
 
 avformat.avformat_version.restype = c_int
@@ -115,6 +115,7 @@ class AVStream(Structure):
     pass
 
 AVStream_Fields = [
+        ('av_class', POINTER(AVClass)),
         ('index', c_int),
         ('id', c_int),
         ('codec', POINTER(AVCodecContext)),  # Deprecated. Removed in 59.
@@ -139,11 +140,14 @@ AVStream_Fields = [
         ('pts_wrap_bits', c_int),
     ]
 
-compat.add_version_changes('avformat', 58, AVStream, AVStream_Fields, removals=None)
+compat.add_version_changes('avformat', 58, AVStream, AVStream_Fields, removals=('av_class',))
 
 compat.add_version_changes('avformat', 59, AVStream, AVStream_Fields,
-                           removals=('codec', 'recommended_encoder_configuration', 'info'))
+                           removals=('av_class', 'codec', 'recommended_encoder_configuration', 'info'))
 
+compat.add_version_changes('avformat', 60, AVStream, AVStream_Fields,
+                           removals=('codec', 'recommended_encoder_configuration', 'info'),
+                           repositions=(compat.Reposition("codecpar", "id"),))
 
 class AVProgram(Structure):
     pass
@@ -259,6 +263,8 @@ compat.add_version_changes('avformat', 58, AVFormatContext, AVFormatContext_Fiel
 compat.add_version_changes('avformat', 59, AVFormatContext, AVFormatContext_Fields,
                            removals=('filename', 'internal'))
 
+compat.add_version_changes('avformat', 60, AVFormatContext, AVFormatContext_Fields,
+                           removals=('filename', 'internal'))
 
 avformat.av_find_input_format.restype = c_int
 avformat.av_find_input_format.argtypes = [c_int]

--- a/pyglet/media/codecs/ffmpeg_lib/libavutil.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavutil.py
@@ -12,8 +12,8 @@ _debug = debug_print('debug_media')
 
 avutil = pyglet.lib.load_library(
     'avutil',
-    win32=('avutil-57', 'avutil-56'),
-    darwin=('avutil.57', 'avutil.56')
+    win32=('avutil-58', 'avutil-57', 'avutil-56'),
+    darwin=('avutil.58', 'avutil.57', 'avutil.56')
 )
 
 avutil.avutil_version.restype = c_int
@@ -167,6 +167,9 @@ compat.add_version_changes('avutil', 56, AVFrame, AVFrame_Fields,
                            removals=('time_base',))
 
 compat.add_version_changes('avutil', 57, AVFrame, AVFrame_Fields,
+                           removals=('pkt_pts', 'error', 'qscale_table', 'qstride', 'qscale_type', 'qp_table_buf'))
+
+compat.add_version_changes('avutil', 58, AVFrame, AVFrame_Fields,
                            removals=('pkt_pts', 'error', 'qscale_table', 'qstride', 'qscale_type', 'qp_table_buf'))
 
 AV_NOPTS_VALUE = -0x8000000000000000

--- a/pyglet/media/codecs/ffmpeg_lib/libswscale.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libswscale.py
@@ -13,8 +13,8 @@ _debug = debug_print('debug_media')
 
 swscale = pyglet.lib.load_library(
     'swscale',
-    win32=('swscale-6', 'swscale-5'),
-    darwin=('swscale.6', 'swscale.5')
+    win32=('swscale-7', 'swscale-6', 'swscale-5'),
+    darwin=('swscale.7', 'swscale.6', 'swscale.5')
 )
 
 swscale.swscale_version.restype = c_int

--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -821,7 +821,7 @@ class WMFDecoder(MediaDecoder):
             extensions.extend(['.3g2', '.3gp', '.3gp2', '.3gp',
                                '.aac', '.adts',
                                '.avi',
-                               '.m4a', '.m4v', '.mov', '.mp4',
+                               '.m4a', '.m4v',
                                # '.wav'  # Can do wav, but we have a WAVE decoder.
                                ])
 


### PR DESCRIPTION
Added support for FFmpeg 6.0. Tested with versions 4.4, 5.1, and 6.0; both audio and video on Windows.

Needs testing on Mac and Linux.

Also:
Added a warning if the loaded FFmpeg versions are not the expected versions we have tested with.

FFmpeg debug message now shows some extra information when FFmpeg is not available.

Added a missing print for OSError in the load_library to prevent hidden errors when loaded.

Removed mp4/mov extension from WMF. (Experimental in the first place, and had no acceleration. Just use FFmpeg for smoothest experience)