### PR TITLE
fixed pyglet/media/drivers adaptation signature to the /pyglet/media/…

### DIFF
--- a/pyglet/media/drivers/directsound/adaptation.py
+++ b/pyglet/media/drivers/directsound/adaptation.py
@@ -236,7 +236,7 @@ class DirectSoundAudioPlayer(AbstractAudioPlayer):
         assert _debug('Remaining events: {}'.format(self._events))
 
         for event in pending_events:
-            event._sync_dispatch_to_player(self.player)
+            event.sync_dispatch_to_player(self.player)
 
     def _cleanup_timestamps(self):
         while self._timestamps and self._timestamps[0][0] < self._play_cursor:

--- a/pyglet/media/drivers/openal/adaptation.py
+++ b/pyglet/media/drivers/openal/adaptation.py
@@ -220,7 +220,7 @@ class OpenALAudioPlayer(AbstractAudioPlayer):
     def _dispatch_events(self):
         while self._events and self._events[0][0] <= self._play_cursor:
             _, event = self._events.pop(0)
-            event._sync_dispatch_to_player(self.player)
+            event.sync_dispatch_to_player(self.player)
 
     def _get_write_size(self):
         self._update_play_cursor()

--- a/pyglet/media/drivers/pulse/adaptation.py
+++ b/pyglet/media/drivers/pulse/adaptation.py
@@ -237,7 +237,7 @@ class PulseAudioPlayer(AbstractAudioPlayer):
         while self._events and self._events[0][0] <= read_index:
             _, event = self._events.pop(0)
             assert _debug('PulseAudioPlayer: Dispatch event', event)
-            event._sync_dispatch_to_player(self.player)
+            event.sync_dispatch_to_player(self.player)
 
     def _add_event_at_write_index(self, event_name):
         assert _debug('PulseAudioPlayer: Add event at index {}'.format(self._write_index))

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -230,7 +230,7 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
         assert _debug('Remaining events: {}'.format(self._events))
 
         for event in pending_events:
-            event._sync_dispatch_to_player(self.player)
+            event.sync_dispatch_to_player(self.player)
 
     def _cleanup_timestamps(self):
         while self._timestamps and self._timestamps[0][0] < self._play_cursor:


### PR DESCRIPTION
`pyglet/media/drivers/` adaptation files has an incorrect signature within the `_process_events method`

Fix typo according to the `MediaEvent` class of the `pyglet/media/drivers/base.py` file

@caffeinepills I'm sorry, but can you approve it once again? Made the mistake