### PR TITLE
Bug in triangles and rotation feature

### DIFF
--- a/examples/graphics/shapes.py
+++ b/examples/graphics/shapes.py
@@ -26,6 +26,8 @@ class ShapesDemo(pyglet.window.Window):
         self.line = shapes.Line(0, 0, 0, 480, width=4, color=(200, 20, 20), batch=self.batch)
 
         self.triangle = shapes.Triangle(10, 10, 190, 10, 100, 150, color=(55, 255, 255, 175), batch=self.batch)
+        self.triangle.anchor_position = 55, 80
+        self.triangle.position = 120, 100
 
         septagon_step = math.pi * 2 / 7
         self.fading_septagon = shapes.Polygon(
@@ -57,6 +59,8 @@ class ShapesDemo(pyglet.window.Window):
 
         self.line.x = 360 + math.sin(self.time * 0.81) * 360
         self.line.x2 = 360 + math.sin(self.time * 1.34) * 360
+
+        self.triangle.rotation = self.time * 25
 
         self.arc.rotation = self.time * 30
 

--- a/examples/graphics/shapes.py
+++ b/examples/graphics/shapes.py
@@ -25,9 +25,11 @@ class ShapesDemo(pyglet.window.Window):
 
         self.line = shapes.Line(0, 0, 0, 480, width=4, color=(200, 20, 20), batch=self.batch)
 
-        self.triangle = shapes.Triangle(10, 10, 190, 10, 100, 150, color=(55, 255, 255, 175), batch=self.batch)
-        self.triangle.anchor_position = 55, 80
-        self.triangle.position = 120, 100
+        size = 200
+        self.triangle = shapes.Triangle(-size/2, 0, size/2, 0, 0, math.sqrt(3)/2*size, color=(55, 255, 255, 175), batch=self.batch)
+        self.triangle.anchor_position = 0, math.sqrt(3)/6*size
+        self.triangle.position = 100, 100
+        self.triangle_center = shapes.Circle(self.triangle.x, self.triangle.y, 5, color=(255, 0, 0, 255), batch=self.batch)
 
         septagon_step = math.pi * 2 / 7
         self.fading_septagon = shapes.Polygon(

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1483,12 +1483,12 @@ class Triangle(ShapeBase):
         if not self._visible:
             self._vertex_list.position[:] = (0, 0, 0, 0, 0, 0)
         else:
-            x1 = -self._anchor_x
-            y1 = -self._anchor_y
-            x2 = self._x2 + x1 - self._x
-            y2 = self._y2 + y1 - self._y
-            x3 = self._x3 + x1 - self._x
-            y3 = self._y3 + y1 - self._y
+            x1 = self._x - self._anchor_x
+            y1 = self._y - self._anchor_y
+            x2 = self._x2 - self._anchor_x
+            y2 = self._y2 - self._anchor_y
+            x3 = self._x3 - self._anchor_x
+            y3 = self._y3 - self._anchor_y
             self._vertex_list.position[:] = (x1, y1, x2, y2, x3, y3)
 
     @property

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1542,6 +1542,23 @@ class Triangle(ShapeBase):
     def y3(self, value):
         self._y3 = value
         self._update_vertices()
+    @property
+    def rotation(self):
+        """Clockwise rotation of the triangle, in degrees.
+
+        The Triangle will be rotated about its (anchor_x, anchor_y)
+        position.
+
+        :type: float
+        """
+        return self._rotation
+
+    @rotation.setter
+    def rotation(self, rotation):
+        self._rotation = rotation
+        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
+
+
 
 
 class Star(ShapeBase):


### PR DESCRIPTION
I had problems with triangle positioning (see #840). I guess it's a bug. Here is how I solved.

By the way, this PR adds rotation to triangle.

Test case:
```
import math
import pyglet
from pyglet import shapes


class ShapesDemo(pyglet.window.Window):

    def __init__(self, width, height):
        super().__init__(width, height, "Shapes")
        self.time = 0

        self.triangle = shapes.Triangle(
            0, -50, 50, 0, 0, 50, color=(55, 255, 255, 175))
        self.triangle.anchor_x = 25
        self.triangle.anchor_y = 0
        self.triangle.position = (100, 100)

    def on_draw(self):
        """Clear the screen and draw shapes"""
        self.clear()
        self.triangle.draw()

    def update(self, delta_time):
        """Animate the shapes"""
        self.time += delta_time

if __name__ == "__main__":
    demo = ShapesDemo(200, 200)
    pyglet.clock.schedule_interval(demo.update, 1/30)
    pyglet.app.run()
```

Without the patch it displays:
![screenshot_20230518-131040](https://github.com/pyglet/pyglet/assets/33821/8515371b-9332-45a8-9cc0-56b624d095c1)

The triangle should be centred. Adding a rotation shows the centre is not well positioned.

With the patch:
![screenshot_20230518-131123](https://github.com/pyglet/pyglet/assets/33821/2fa015dc-fbfa-4ba6-a8f9-b0b305c70097)

To see the rotation in action around the anchor point, try:
```
    def update(self, delta_time):
        """Animate the shapes"""
        self.time += delta_time
        self.triangle.rotation = self.time * 30
```

Hope it helps,
J.