### PR TITLE
Add duration for schedule interval

### DIFF
--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -469,7 +469,7 @@ class Clock:
                 The function to call when the timer lapses.
             `interval` : float
                 The number of seconds to wait between each call.
-            `duration=` : float
+            `duration` : float
                 The number of seconds for which the function is scheduled.
 
         """

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1799,7 +1799,9 @@ class FPSDisplay:
     usage is to create an `FPSDisplay` for each window, and draw the display
     at the end of the windows' :py:meth:`~pyglet.window.Window.on_draw` event handler::
 
-        window = pyglet.window.Window()
+        from pyglet.window import Window, FPSDisplay
+
+        window = Window()
         fps_display = FPSDisplay(window)
 
         @window.event

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -52,6 +52,11 @@ class ClockTestCase(unittest.TestCase):
         self.advance_clock(2)
         self.assertEqual(self.callback_a.call_count, 2)
 
+    def test_schedule_interval_duration(self):
+        self.clock.schedule_interval(self.callback_a, 1, _duration=5)
+        self.advance_clock(10)
+        self.assertEqual(self.callback_a.call_count, 4)
+
     def test_schedule_interval_multiple(self):
         self.clock.schedule_interval(self.callback_a, 1)
         self.clock.schedule_interval(self.callback_b, 1)

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -52,6 +52,11 @@ class ClockTestCase(unittest.TestCase):
         self.advance_clock(2)
         self.assertEqual(self.callback_a.call_count, 2)
 
+    def test_schedule_interval_duration(self):
+        self.clock.schedule_interval(self.callback_a, 1, _duration=5)
+        self.advance_clock(10)
+        self.assertEqual(self.callback_a.call_count, 5)
+
     def test_schedule_interval_multiple(self):
         self.clock.schedule_interval(self.callback_a, 1)
         self.clock.schedule_interval(self.callback_b, 1)

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -52,8 +52,8 @@ class ClockTestCase(unittest.TestCase):
         self.advance_clock(2)
         self.assertEqual(self.callback_a.call_count, 2)
 
-    def test_schedule_interval_duration(self):
-        self.clock.schedule_interval(self.callback_a, 1, _duration=5)
+    def test_schedule_interval_for_duration(self):
+        self.clock.schedule_interval_for_duration(self.callback_a, 1, 5)
         self.advance_clock(10)
         self.assertEqual(self.callback_a.call_count, 4)
 

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -52,11 +52,6 @@ class ClockTestCase(unittest.TestCase):
         self.advance_clock(2)
         self.assertEqual(self.callback_a.call_count, 2)
 
-    def test_schedule_interval_duration(self):
-        self.clock.schedule_interval(self.callback_a, 1, _duration=5)
-        self.advance_clock(10)
-        self.assertEqual(self.callback_a.call_count, 5)
-
     def test_schedule_interval_multiple(self):
         self.clock.schedule_interval(self.callback_a, 1)
         self.clock.schedule_interval(self.callback_b, 1)


### PR DESCRIPTION
This PR adds a duration for a schedule. It was one of my needs.

```
The function can be scheduled for a given period of time by adding
the keyword argument `_duration=` (in seconds). After this delay,
the function is unscheduled automagically.
```
Example:
```
import time
x = 0

def myfunc(dt):
    global x
    x += 1
    print(x)
    if x == 5:
        print(time.time() - start)

start = time.time()
pyglet.clock.schedule_interval(myfunc, 1, _duration=5)
```
Result:
```
1
2
3
4
5
5.000953674316406
```

It's seems reliable, but experimental and need to be tested before merging.

Hope it helps,
J.
