### PR TITLE
Sprite height/width @setters

### DIFF
--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -655,23 +655,31 @@ class Sprite(event.EventDispatcher):
     def width(self):
         """Scaled width of the sprite.
 
-        Read-only.  Invariant under rotation.
+        Invariant under rotation.
 
         :type: int
         """
         w = self._texture.width * abs(self._scale_x) * abs(self._scale)
         return w if self._subpixel else int(w)
 
+    @width.setter
+    def width(self, width):
+        self.scale_x = width / (self._texture.width * abs(self._scale))
+
     @property
     def height(self):
         """Scaled height of the sprite.
 
-        Read-only.  Invariant under rotation.
+        Invariant under rotation.
 
         :type: int
         """
         h = self._texture.height * abs(self._scale_y) * abs(self._scale)
         return h if self._subpixel else int(h)
+
+    @height.setter
+    def height(self, height):
+        self.scale_y = height / (self._texture.height * abs(self._scale))
 
     @property
     def opacity(self):

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -659,10 +659,8 @@ class Sprite(event.EventDispatcher):
 
         :type: int
         """
-        if self._subpixel:
-            return self._texture.width * abs(self._scale_x) * abs(self._scale)
-        else:
-            return int(self._texture.width * abs(self._scale_x) * abs(self._scale))
+        w = self._texture.width * abs(self._scale_x) * abs(self._scale)
+        return w if self._subpixel else int(w)
 
     @property
     def height(self):
@@ -672,10 +670,8 @@ class Sprite(event.EventDispatcher):
 
         :type: int
         """
-        if self._subpixel:
-            return self._texture.height * abs(self._scale_y) * abs(self._scale)
-        else:
-            return int(self._texture.height * abs(self._scale_y) * abs(self._scale))
+        h = self._texture.height * abs(self._scale_y) * abs(self._scale)
+        return h if self._subpixel else int(h)
 
     @property
     def opacity(self):


### PR DESCRIPTION
In the app I am coding, I need to work with pixel sizes, not with scale. Seems to work now like this:

```
sprite = pyglet.sprite.Sprite(img=image)
sprite.width = 1920
sprite.height = 1440
```
Currently width/height are read-only.