### PR TITLE
minor sprite group fix

### DIFF
--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -400,7 +400,8 @@ class Sprite(event.EventDispatcher):
                                        self._group.blend_dest,
                                        self._group.program,
                                        group)
-        self._batch.migrate(self._vertex_list, GL_TRIANGLES, self._group, self._batch)
+        if self._batch is not None:
+            self._batch.migrate(self._vertex_list, GL_TRIANGLES, self._group, self._batch)
 
     @property
     def image(self):


### PR DESCRIPTION
batch migrates only if it exists now to avoid error.