### PR TITLE
Handle null return edge case in Win32Font.add_font_data

### DIFF
--- a/pyglet/font/win32.py
+++ b/pyglet/font/win32.py
@@ -236,7 +236,12 @@ class Win32Font(base.Font):
     @classmethod
     def add_font_data(cls, data):
         numfonts = c_uint32()
-        gdi32.AddFontMemResourceEx(data, len(data), 0, byref(numfonts))
+        _handle = gdi32.AddFontMemResourceEx(data, len(data), 0, byref(numfonts))
+
+        # None means a null handle was returned, ie something went wrong
+        if _handle is None:
+            raise ctypes.WinError()
+
 
 # --- GDI+ font rendering ---
 


### PR DESCRIPTION
Docstrings and annotations will be handled in #859

### Changes

Raise a WinError when a null return edge case [described in MSDN's AddFontMemResourceEx page](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-addfontmemresourceex#return-value) is detected:
> If the function succeeds, the return value specifies the handle to the font added. This handle uniquely identifies the fonts that were installed on the system. If the function fails, the return value is zero. No extended error information is available.