### PR TITLE
Allows to pause the player at the end of the video

### DIFF
--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -122,6 +122,12 @@ class Player(pyglet.event.EventDispatcher):
         #: .. versionadded:: 1.4
         self.loop = False
 
+        #: Pause the current source on the last frame.
+        #: Defaults to ``False`` (ie. rewind to the first frame)
+        #:
+        #: :type: bool
+        self.pause_at_end = False
+
     def __del__(self):
         """Release the Player resources."""
         self.delete()
@@ -587,6 +593,8 @@ class Player(pyglet.event.EventDispatcher):
                 self._audio_player.clear()
             self._set_playing(was_playing)
 
+        elif self.pause_at_end:
+            self.pause()
         else:
             self.next_source()
 

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -573,6 +573,9 @@ class Player(pyglet.event.EventDispatcher):
         will start to play again until :meth:`next_source` is called or
         :attr:`.loop` is set to ``False``.
 
+        If the :attr:`.pause_at_end` attribute is set to ``True``,
+        the player pauses the source at the last frame.
+
         :event:
         """
         if _debug:


### PR DESCRIPTION
It was one of my needs. To stall the video at the last frame, instead of rewinding...

`player.pause_at_end = True` and the video stays on the last frame.

In the spirit of `loop`. Needs review.