### PR TITLE
Catch thread exception

### DIFF
--- a/pyglet/media/mediathreads.py
+++ b/pyglet/media/mediathreads.py
@@ -59,6 +59,7 @@ class MediaThread:
         try:
             self._thread.join()
         except RuntimeError:
+            # Ignore on unclean shutdown
             pass
 
     def sleep(self, timeout):

--- a/pyglet/media/mediathreads.py
+++ b/pyglet/media/mediathreads.py
@@ -56,7 +56,10 @@ class MediaThread:
         with self._condition:
             self._stopped = True
             self._condition.notify()
-        self._thread.join()
+        try:
+            self._thread.join()
+        except RuntimeError:
+            pass
 
     def sleep(self, timeout):
         """Wait for some amount of time, or until notified.


### PR DESCRIPTION
During my desperation to find the bug in #861, I encountered this exception. Probably better to catch it? ([Thread.join doc](https://docs.python.org/3/library/threading.html#threading.Thread.join))