### PR TITLE
Allows to bypass EventLoop._redraw_windows() schedule

### DIFF
--- a/pyglet/app/base.py
+++ b/pyglet/app/base.py
@@ -127,7 +127,10 @@ class EventLoop(event.EventDispatcher):
         Developers are discouraged from overriding this method, as the
         implementation is platform-specific.
         """
-        if not interval:
+        if interval is None:
+            # User application will manage a custom _redraw_windows() method
+            pass
+        elif interval == 0:
             self.clock.schedule(self._redraw_windows)
         else:
             self.clock.schedule_interval(self._redraw_windows, interval)


### PR DESCRIPTION
Hi,
Here is a PR concerning a personal need. The purpose is to allow to bypass the default redraw schedule.

I don't know if it's a good practice or not. Maybe there is an official way to do that in pyglet, but I didn't find clear information about that in the doc. Tell me...

I need to have different framerates for different windows. It seems the `run()` just allow infinite framerate (`app.run(0)`) or custom framerate (`app.run(1/x)`). As I understand, this choice is shared for all app windows (https://github.com/jej/pyglet/blob/12e2009d4e31c26e7c350435ca5773929731ce68/pyglet/app/base.py#L114-L120)

With this change, it's possible to provide `None` to avoid the `EventLoop._redraw_windows()` schedule. Then each window can provide a custom refresh method:
```
class MyCustomWindow(pyglet.window.Window):

    def redraw_loop(self, dt=0):
        # hack it here
        self.switch_to()
        self.dispatch_event('on_draw')
        self.dispatch_event('on_refresh', dt)
        self.flip()


class MyWindow_1(MyCustomWindow):

    def __init__(...):
        .../...
        # schedule redraw
        pyglet.clock.schedule_interval(self.redraw_loop, 1/42) # <-- 42 frames/s


class MyWindow_2(MyCustomWindow):

    def __init__(...):
        .../...
        # schedule redraw
        pyglet.clock.schedule_interval(self.redraw_loop, 1/24) # <-- 24 frames/s


class MyWindow_3(MyCustomWindow):

    def __init__(...):
        .../...
        # no redraw schedule, on request with `self.redraw_loop()`

```
If this PR makes sense, I can update the documentation according to that. It works smoothly in my app.

Hope it helps.