### PR TITLE
Fix MacOS Text issues

### DIFF
--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -543,6 +543,9 @@ kCTFontBoldTrait   = (1 << 1)
 ct.CTLineCreateWithAttributedString.restype = c_void_p
 ct.CTLineCreateWithAttributedString.argtypes = [c_void_p]
 
+ct.CTLineGetTypographicBounds.restype = c_double
+ct.CTLineGetTypographicBounds.argtypes = [c_void_p, POINTER(CGFloat), POINTER(CGFloat), POINTER(CGFloat)]
+
 ct.CTLineDraw.restype = None
 ct.CTLineDraw.argtypes = [c_void_p, c_void_p]
 

--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -40,8 +40,9 @@ class PygletTextView_Implementation:
         text = cfstring_to_string(text)
         self.setString_(self.empty_string)
         # Don't send control characters (tab, newline) as on_text events.
-        if unicodedata.category(text[0]) != 'Cc':
-            self._window.dispatch_event("on_text", text)
+        if text:
+            if unicodedata.category(text[0]) != 'Cc':
+                self._window.dispatch_event("on_text", text)
 
     @PygletTextView.method('v@')
     def insertNewline_(self, sender):

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -140,10 +140,6 @@ class PygletView_Implementation:
         self.addTrackingArea_(self._tracking_area)
 
     @PygletView.method('B')
-    def acceptsFirstResponder (self):
-        return True
-
-    @PygletView.method('B')
     def canBecomeKeyView(self):
         return True
 


### PR DESCRIPTION
Fix issue with TextView not able to receive events for text input purposes.

Fix issue with some zero length characters causing an IndexError.

Add some estimates for fallback metric detection for fonts for Mac OS (Labels and Documents). This is incase the font being used does not have the glyphs requested and the system falls back to another font (such as Chinese).  It is probably best you use the font that directly supports the language for the most accurate measurements, but this should help prevent text from breaking down into a jumbling of glyphs.