### PR TITLE
Fixes and changes to AudioDevice/AudioDeviceManager

### DIFF
--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -136,6 +136,8 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
         Unlike the other drivers this does not carve pieces of audio from the buffer and slowly
         consume it. This submits the buffer retrieved from the decoder in it's entirety.
         """
+        if not self._xa2_source_voice:
+            return
 
         buffers_queued = self._xa2_source_voice.buffers_queued
 

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -1,6 +1,8 @@
 import weakref
 from collections import namedtuple, defaultdict
 
+from pyglet.media.devices.base import DeviceFlow
+
 import pyglet
 from pyglet.libs.win32.types import *
 from pyglet.util import debug_print
@@ -69,15 +71,16 @@ class XAudio2Driver:
 
                 self._players.clear()
 
-    def on_default_changed(self, device):
-        """Callback derived from the Audio Devices to help us determine when the system no longer has output."""
-        if device is None:
-            assert _debug('Error: Default audio device was removed or went missing.')
-            self._dead = True
-        else:
-            if self._dead:
-                assert _debug('Warning: Default audio device added after going missing.')
-                self._dead = False
+    def on_default_changed(self, device, flow: DeviceFlow):
+        if flow == DeviceFlow.OUTPUT:
+            """Callback derived from the Audio Devices to help us determine when the system no longer has output."""
+            if device is None:
+                assert _debug('Error: Default audio device was removed or went missing.')
+                self._dead = True
+            else:
+                if self._dead:
+                    assert _debug('Warning: Default audio device added after going missing.')
+                    self._dead = False
 
     def _create_xa2(self, device_id=None):
         self._xaudio2 = lib.IXAudio2()


### PR DESCRIPTION
These are all win32 related for now.

Fix: Crash when all of the devices are deleted and new ones added. For instance when you RDP into a computer, all of the audio devices are deleted and a Remote Audio is added.
Added: Now deletes and adds devices to the list as devices are added and removed. This keeps the cached device list up to date after initial enumeration.

Fix: Xaudio2 crash when trying to remove a player that was deleted mid callback and it tries to refill a packet.
Fix: Wrong ctypes calls. Fixes names, descriptions being unknown, and freeing of resources in get_pkey_value.

Changed: Use debug_input for AudioDevices instead of media as it usually involves removing and adding devices.
Changed: Cleanup and changes to AudioDevices and added some typings.
Changed: on_default_changed now includes the DeviceFlow. Since the device can be None, the driver needs to know about the flow.
Audio will now resume if inputs were destroyed and re-created .