### PR TITLE
Add pyglet.types module & Buffer Union annotation

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -333,6 +333,7 @@ class _ModuleProxy:
 # Lazily load all modules, except if performing
 # type checking or code inspection.
 if TYPE_CHECKING:
+    from . import types
     from . import app
     from . import canvas
     from . import clock
@@ -353,6 +354,7 @@ if TYPE_CHECKING:
     from . import text
     from . import window
 else:
+    types = _ModuleProxy('types')
     app = _ModuleProxy('app')
     canvas = _ModuleProxy('canvas')
     clock = _ModuleProxy('clock')

--- a/pyglet/types.py
+++ b/pyglet/types.py
@@ -1,15 +1,19 @@
 """Holds type aliases used throughout the codebase."""
+import ctypes
 from typing import Union
 
 __all__ = [
     "Buffer"
 ]
 
-# This Union alias exists with this name for multiple reasons:
+# This Union alias has the given name & members for multiple reasons:
 # 1. We can't use typing_extensions.Buffer because pyglet bans runtime
 #    Python dependencies.
 # 2. We can't use the official Buffer type from PEP-688 until 3.12
 #    becomes pyglet's minimum version. This is 2027 according to the
 #    current release schedule.
 # 3. typing.ByteString is deprecated as of 3.9
-Buffer = Union[bytes, bytearray, memoryview]
+# 4. ctypes.Array is useful for integrating with other data sources but
+#    will not be recognized without explicit inclusion due to lack of
+#    buffer protocol support.
+Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]

--- a/pyglet/types.py
+++ b/pyglet/types.py
@@ -6,14 +6,5 @@ __all__ = [
     "Buffer"
 ]
 
-# This Union alias has the given name & members for multiple reasons:
-# 1. We can't use typing_extensions.Buffer because pyglet bans runtime
-#    Python dependencies.
-# 2. We can't use the official Buffer type from PEP-688 until 3.12
-#    becomes pyglet's minimum version. This is 2027 according to the
-#    current release schedule.
-# 3. typing.ByteString is deprecated as of 3.9
-# 4. ctypes.Array is useful for integrating with other data sources but
-#    will not be recognized without explicit inclusion due to lack of
-#    buffer protocol support.
+# Backwards compatible placeholder for `collections.abc.Buffer` from Python 3.12
 Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]

--- a/pyglet/types.py
+++ b/pyglet/types.py
@@ -1,0 +1,15 @@
+"""Holds type aliases used throughout the codebase."""
+from typing import Union
+
+__all__ = [
+    "Buffer"
+]
+
+# This Union alias exists with this name for multiple reasons:
+# 1. We can't use typing_extensions.Buffer because pyglet bans runtime
+#    Python dependencies.
+# 2. We can't use the official Buffer type from PEP-688 until 3.12
+#    becomes pyglet's minimum version. This is 2027 according to the
+#    current release schedule.
+# 3. typing.ByteString is deprecated as of 3.9
+Buffer = Union[bytes, bytearray, memoryview]


### PR DESCRIPTION
### Changes

1. Add a new `pyglet.types` module
2. Add a `pyglet.types.Buffer` alias which covers the most common buffer protocol implementations

### How to Test / Why `ctypes.Array` is Included in the Alias

1. Given the following file...
    ```py
    import ctypes
    from pyglet.types import Buffer

    def takes_buffer(b: Buffer) -> None:
        print(b)

    def passes_a_ctypes_array() -> None:
        tiny_array = (ctypes.Int * 2)(1,2)
        takes_buffer(tiny_array)
    ```
2.  `mypy path/to/file.py` will pass only if `ctypes.Array` is included in the `Buffer` alias

### Question for Reviewers

Before merging, could lead maintainers please double check the following reasoning?

We already have a class named `Buffer` here:
https://github.com/pyglet/pyglet/blob/3d0eb38b0114f34877e39a5590c6827dddbe9d8d/pyglet/model/codecs/gltf.py#L71

Despite this, it seems worth it to add `pyglet.types.Buffer` for the following reasons:

1. Brevity
2. It aligns with Python 3.12's adoption of [PEP-668's `Buffer` as a base type for all buffer protocol objects](https://peps.python.org/pep-0688/#collections-abc-buffer)
3. We can't use `typing_extensions.Buffer`
4. Conflict between names can be avoided via `from pyglet.types import Buffer as BufferProtocol`
5. Once we can use 3.12 features, we only need to change some imports to upgrade