### PR TITLE
Fix screen resolution changes on Retina Mac running windowed Arcade app

### DIFF
--- a/pyglet/canvas/cocoa.py
+++ b/pyglet/canvas/cocoa.py
@@ -78,6 +78,12 @@ class CocoaScreen(Screen):
         self.height = mode.height
 
     def restore_mode(self):
+        match_attrs = ['width', 'height', 'depth', 'rate']
+        current_mode = self.get_mode()
+        if all(getattr(current_mode, attr) == getattr(self._default_mode, attr) for
+               attr in match_attrs):
+            # Already in default mode
+            return
         quartz.CGDisplaySetDisplayMode(self._cg_display_id, self._default_mode.cgmode, None)
         quartz.CGDisplayRelease(self._cg_display_id)
 


### PR DESCRIPTION
This fixes the easy part of #890 where starting a windowed arcade app changes the screen resolution on Mac. When a Window is created it calls set_fullscreen. If the Window is not fullscreen then this calls Screen.restore_mode. restore_mode calls CGDisplaySetDisplayMode with the mode saved when CocoaScreen was created. This is not necessary because the screen mode was never changed. In the meantime setting up OpenGL may have changed the GPU from integrated to discrete. This exposes a bug in CGDisplaySetDisplayMode where it sets the screen to a random resolution. You can fix it by calling it again but this takes a long time. If the default mode is the same as the current mode, skip calling CGDisplaySetDisplayMode. There may still be cases where the current screen mode is not the same as the default mode, this does not fix those cases. But it fixes the problem I ran into.