### PR TITLE
Use degrees for angles in Arc and Sector

### DIFF
--- a/examples/graphics/shapes.py
+++ b/examples/graphics/shapes.py
@@ -33,7 +33,7 @@ class ShapesDemo(pyglet.window.Window):
             batch=self.batch
         )
 
-        self.arc = shapes.Arc(50, 300, radius=40, segments=25, angle=4, color=(255, 255, 255), batch=self.batch)
+        self.arc = shapes.Arc(50, 300, radius=40, segments=25, angle=270.0, color=(255, 255, 255), batch=self.batch)
 
         self.star = shapes.Star(600, 375, 50, 30, 5, color=(255, 255, 0), batch=self.batch)
 

--- a/examples/graphics/shapes.py
+++ b/examples/graphics/shapes.py
@@ -39,7 +39,7 @@ class ShapesDemo(pyglet.window.Window):
 
         self.ellipse = shapes.Ellipse(650, 150, a=50, b=30, color=(55, 255, 55), batch=self.batch)
 
-        self.sector = shapes.Sector(125, 400, 60, angle=0.9, color=(55, 255, 55), batch=self.batch)
+        self.sector = shapes.Sector(125, 400, 60, angle=0.45 * 360, color=(55, 255, 55), batch=self.batch)
 
         self.polygon = shapes.Polygon([400, 100], [500, 10], [600, 100], [550, 175], [450, 150], batch=self.batch)
 
@@ -66,7 +66,7 @@ class ShapesDemo(pyglet.window.Window):
         self.polygon.rotation = self.time * 45
 
         self.ellipse.b = abs(math.sin(self.time) * 100)
-        self.sector.angle = self.time % math.tau
+        self.sector.angle = (self.time * 30) % 360.0
 
 
 if __name__ == "__main__":

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1011,7 +1011,7 @@ class Sector(ShapeBase):
 
     @property
     def angle(self):
-        """The angle of the sector.
+        """The angle of the sector, in degrees.
 
         :type: float
         """
@@ -1024,7 +1024,7 @@ class Sector(ShapeBase):
 
     @property
     def start_angle(self):
-        """The start angle of the sector.
+        """The start angle of the sector, in degrees.
 
         :type: float
         """

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -462,7 +462,7 @@ class ShapeBase(ABC):
 class Arc(ShapeBase):
     _draw_mode = GL_LINES
 
-    def __init__(self, x, y, radius, segments=None, angle=math.tau, start_angle=0,
+    def __init__(self, x, y, radius, segments=None, angle=360.0, start_angle=0.0,
                  closed=False, color=(255, 255, 255, 255), batch=None, group=None):
         """Create an Arc.
 
@@ -481,10 +481,10 @@ class Arc(ShapeBase):
                 automatically calculated using the formula:
                 `max(14, int(radius / 1.25))`.
             `angle` : float
-                The angle of the arc, in radians. Defaults to tau (pi * 2),
-                which is a full circle.
+                The angle of the arc, in degrees. Defaults to 360.0, which is
+                a full circle.
             `start_angle` : float
-                The start angle of the arc, in radians. Defaults to 0.
+                The start angle of the arc, in degrees. Defaults to 0.
             `closed` : bool
                 If True, the ends of the arc will be connected with a line.
                 defaults to False.
@@ -532,12 +532,12 @@ class Arc(ShapeBase):
             x = -self._anchor_x
             y = -self._anchor_y
             r = self._radius
-            tau_segs = self._angle / self._segments
-            start_angle = self._start_angle - math.radians(self._rotation)
+            segment_radians = math.radians(self._angle) / self._segments
+            start_radians = math.radians(self._start_angle - self._rotation)
 
             # Calculate the outer points of the arc:
-            points = [(x + (r * math.cos((i * tau_segs) + start_angle)),
-                       y + (r * math.sin((i * tau_segs) + start_angle))) for i in range(self._segments + 1)]
+            points = [(x + (r * math.cos((i * segment_radians) + start_radians)),
+                       y + (r * math.sin((i * segment_radians) + start_radians))) for i in range(self._segments + 1)]
 
             # Create a list of doubled-up points from the points:
             vertices = []

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -920,7 +920,7 @@ class Ellipse(ShapeBase):
 
 
 class Sector(ShapeBase):
-    def __init__(self, x, y, radius, segments=None, angle=math.tau, start_angle=0,
+    def __init__(self, x, y, radius, segments=None, angle=360.0, start_angle=0,
                  color=(255, 255, 255, 255), batch=None, group=None):
         """Create a Sector of a circle.
 
@@ -939,10 +939,10 @@ class Sector(ShapeBase):
                         be automatically calculated using the formula:
                         `max(14, int(radius / 1.25))`.
                     `angle` : float
-                        The angle of the sector, in radians. Defaults to tau (pi * 2),
+                        The angle of the sector, in degrees. Defaults to 360.0,
                         which is a full circle.
                     `start_angle` : float
-                        The start angle of the sector, in radians. Defaults to 0.
+                        The start angle of the sector, in degrees. Defaults to 0.
                     `color` : (int, int, int, int)
                         The RGB or RGBA color of the circle, specified as a
                         tuple of 3 or 4 ints in the range of 0-255. RGB colors
@@ -994,12 +994,12 @@ class Sector(ShapeBase):
             x = -self._anchor_x
             y = -self._anchor_y
             r = self._radius
-            tau_segs = self._angle / self._segments
-            start_angle = self._start_angle - math.radians(self._rotation)
+            segment_radians = math.radians(self._angle) / self._segments
+            start_radians = math.radians(self._start_angle - self._rotation)
 
             # Calculate the outer points of the sector.
-            points = [(x + (r * math.cos((i * tau_segs) + start_angle)),
-                       y + (r * math.sin((i * tau_segs) + start_angle))) for i in range(self._segments + 1)]
+            points = [(x + (r * math.cos((i * segment_radians) + start_radians)),
+                       y + (r * math.sin((i * segment_radians) + start_radians))) for i in range(self._segments + 1)]
 
             # Create a list of triangles from the points
             vertices = []

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -569,7 +569,7 @@ class Arc(ShapeBase):
 
     @property
     def angle(self):
-        """The angle of the arc.
+        """The angle of the arc, in degrees.
 
         :type: float
         """
@@ -582,7 +582,7 @@ class Arc(ShapeBase):
 
     @property
     def start_angle(self):
-        """The start angle of the arc.
+        """The start angle of the arc, in degrees.
 
         :type: float
         """


### PR DESCRIPTION
### Changes

Closes #868 by switching `angle` and `angle_start` to use degrees per discussion in that issue's comments.

### Follow-up Work

It may be a good idea to add radians versions of these properties to prevent having to convert between degrees and radians.