### PR TITLE
Fix on_key_press for Mac OS

### DIFF
--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -30,10 +30,17 @@ class PygletTextView_Implementation:
         self.empty_string.release()
 
     # Other functions still seem to work?
-    # @PygletTextView.method('v@')
-    # def keyDown_(self, nsevent):
-    #     array = NSArray.arrayWithObject_(nsevent)
-    #     self.interpretKeyEvents_(array)
+    @PygletTextView.method('v@')
+    def keyDown_(self, nsevent):
+        array = NSArray.arrayWithObject_(nsevent)
+        self.interpretKeyEvents_(array)
+
+        if not self.performKeyEquivalent_(nsevent):
+            self.nextResponder().keyDown_(nsevent)
+
+    @PygletTextView.method('v@')
+    def keyUp_(self, nsevent):
+        self.nextResponder().keyUp_(nsevent)
 
     @PygletTextView.method('v@')
     def insertText_(self, text):


### PR DESCRIPTION
Fix issue with keyDown and keyUp events not being passed onto the NSView.

It doesn't seem to pass the events on manually, so here we manually pass it off.

Needs a little more testing to ensure modifiers, on_text, and text inputs all work properly. Preliminary tests all work for me.