### PR TITLE
Implement RGBA color support on Sprite

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -99,3 +99,13 @@ def new_rgba_color():
 @fixture(params=[NEW_RGB_COLOR, NEW_RGBA_COLOR])
 def new_rgb_or_rgba_color(request):
     return request.param
+
+
+def new_color_expected_alpha(new_rgb_or_rgba_color):
+    return expected_alpha_for_color(new_rgb_or_rgba_color)
+
+
+@fixture(params=[0, 128, 254])
+def new_opacity_set_opacity_alone(request):
+    return request.param
+

--- a/tests/unit/test_sprite.py
+++ b/tests/unit/test_sprite.py
@@ -62,6 +62,33 @@ def scale_y(request):
     return request.param
 
 
+def test_color_initially_rgba_white(sprite):
+    assert sprite.color == (255, 255, 255, 255)
+
+
+def test_opacity_initially_255(sprite):
+    assert sprite.opacity == 255
+
+def test_color_changes_opacity_if_set_to_rgba(sprite, new_rgba_color):
+    sprite.color = new_rgba_color
+    assert sprite.opacity == new_rgba_color[3]
+
+
+def test_color_leaves_opacity_unchanged_if_set_to_rgb(sprite, new_rgb_color):
+    sprite.color = new_rgb_color
+    assert sprite.opacity == 255
+
+
+def test_color_changes_rgb_channels(sprite, new_rgb_or_rgba_color):
+    sprite.color = new_rgb_or_rgba_color
+    assert sprite.color[:3] == new_rgb_or_rgba_color[:3]
+
+
+def test_opacity_setter_changes_opacity_channel_in_color(sprite, new_opacity_set_opacity_alone):
+    sprite.opacity = new_opacity_set_opacity_alone
+    assert sprite.color[3] == new_opacity_set_opacity_alone
+
+
 def test_update_sets_passed_positions(sprite, x, y, z):
 
     sprite.update(x=x, y=y, z=z)


### PR DESCRIPTION
### Changes

- [x] Replace Sprite._rgb attribute with Sprite._rgba
- [x] Update getters to use _rgba attribute
- [x] Add unpacking and lazy update logic for opacity and color setters
- [x] Update docstrings
- ~~Add / update tests (on hold due to #913)~~ Deferred till a later PR per reviewer suggestion.