### PR TITLE
Update examples for 2.1 by scheduling redraw

### DIFF
--- a/examples/dpi_scaled_window.py
+++ b/examples/dpi_scaled_window.py
@@ -40,4 +40,6 @@ def on_scale(scale, dpi):
     print("Window Pixel Ratio:", window.get_pixel_ratio())
     print("Window Frame Buffer Size:", window.get_framebuffer_size())
 
+
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/dpi_scaled_window.py
+++ b/examples/dpi_scaled_window.py
@@ -41,5 +41,8 @@ def on_scale(scale, dpi):
     print("Window Frame Buffer Size:", window.get_framebuffer_size())
 
 
-pyglet.clock.schedule_interval(window.draw, 1/60)
+# Schedule redraw with the default FPS
+pyglet.clock.schedule(window.draw)
+
+# Run the application
 pyglet.app.run()

--- a/examples/dpi_scaled_window.py
+++ b/examples/dpi_scaled_window.py
@@ -41,8 +41,8 @@ def on_scale(scale, dpi):
     print("Window Frame Buffer Size:", window.get_framebuffer_size())
 
 
-# Schedule redraw with the default FPS
-pyglet.clock.schedule(window.draw)
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
 # Run the application
 pyglet.app.run()

--- a/examples/events/events_key_state_handler.py
+++ b/examples/events/events_key_state_handler.py
@@ -27,6 +27,7 @@ def on_draw():
 
 
 pyglet.clock.schedule_interval(update, 1/60)
+pyglet.clock.schedule_interval(window.draw, 1/60)
 
 
 if __name__ == '__main__':

--- a/examples/events/window_events.py
+++ b/examples/events/window_events.py
@@ -16,4 +16,6 @@ def on_draw():
 win_event_logger = pyglet.window.event.WindowEventLogger()
 window.push_handlers(win_event_logger)
 
+
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/events/window_events.py
+++ b/examples/events/window_events.py
@@ -16,6 +16,8 @@ def on_draw():
 win_event_logger = pyglet.window.event.WindowEventLogger()
 window.push_handlers(win_event_logger)
 
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
-pyglet.clock.schedule(window.draw)
+# Run the application
 pyglet.app.run()

--- a/examples/events/window_platform_event.py
+++ b/examples/events/window_platform_event.py
@@ -50,5 +50,5 @@ class MyWindow(pyglet.window.Window):
 
 if __name__ == '__main__':
     window = MyWindow()
-    pyglet.clock.schedule(window.draw)
+    pyglet.clock.schedule_interval(window.draw, 1 / 60)
     pyglet.app.run()

--- a/examples/events/window_platform_event.py
+++ b/examples/events/window_platform_event.py
@@ -50,4 +50,5 @@ class MyWindow(pyglet.window.Window):
 
 if __name__ == '__main__':
     window = MyWindow()
+    pyglet.clock.schedule(window.draw)
     pyglet.app.run()

--- a/examples/game/version1/asteroid.py
+++ b/examples/game/version1/asteroid.py
@@ -29,8 +29,8 @@ def on_draw():
 
 
 if __name__ == "__main__":
-    # Schedule redraw at the default frame rate
-    pyglet.clock.schedule(game_window.draw)
+    # Schedule redraw at 60 FPS
+    pyglet.clock.schedule_interval(game_window.draw, 1 / 60)
 
     # Tell pyglet to do its thing
     pyglet.app.run()

--- a/examples/game/version1/asteroid.py
+++ b/examples/game/version1/asteroid.py
@@ -29,5 +29,8 @@ def on_draw():
 
 
 if __name__ == "__main__":
+    # Schedule redraw at the default frame rate
+    pyglet.clock.schedule(game_window.draw)
+
     # Tell pyglet to do its thing
     pyglet.app.run()

--- a/examples/game/version2/asteroid.py
+++ b/examples/game/version2/asteroid.py
@@ -42,5 +42,8 @@ if __name__ == "__main__":
     # Update the game 120 times per second
     pyglet.clock.schedule_interval(update, 1 / 120.0)
 
+    # Draw at 120 fps
+    pyglet.clock.schedule_interval(game_window.draw, 1 / 120.0)
+
     # Tell pyglet to do its thing
     pyglet.app.run()

--- a/examples/game/version3/asteroid.py
+++ b/examples/game/version3/asteroid.py
@@ -64,5 +64,8 @@ if __name__ == "__main__":
     # Update the game 120 times per second
     pyglet.clock.schedule_interval(update, 1 / 120.0)
 
+    # Draw at 120 fps
+    pyglet.clock.schedule_interval(game_window.draw, 1 / 120.0)
+
     # Tell pyglet to do its thing
     pyglet.app.run()

--- a/examples/game/version4/asteroid.py
+++ b/examples/game/version4/asteroid.py
@@ -77,5 +77,8 @@ if __name__ == "__main__":
     # Update the game 120 times per second
     pyglet.clock.schedule_interval(update, 1 / 120.0)
 
+    # Draw at 120 fps
+    pyglet.clock.schedule_interval(game_window.draw, 1 / 120.0)
+
     # Tell pyglet to do its thing
     pyglet.app.run()

--- a/examples/game/version5/asteroid.py
+++ b/examples/game/version5/asteroid.py
@@ -159,5 +159,8 @@ if __name__ == "__main__":
     # Update the game 120 times per second
     pyglet.clock.schedule_interval(update, 1 / 120.0)
 
+    # Draw at 120 fps
+    pyglet.clock.schedule_interval(game_window.draw, 1 / 120.0)
+
     # Tell pyglet to do its thing
     pyglet.app.run()

--- a/examples/graphics/image_display.py
+++ b/examples/graphics/image_display.py
@@ -46,4 +46,5 @@ if __name__ == '__main__':
     window.height = img.height
     window.set_visible()
 
+    pyglet.clock.schedule(window.draw)
     pyglet.app.run()

--- a/examples/graphics/image_display.py
+++ b/examples/graphics/image_display.py
@@ -46,5 +46,8 @@ if __name__ == '__main__':
     window.height = img.height
     window.set_visible()
 
-    pyglet.clock.schedule(window.draw)
+    # Redraw at 60 FPS
+    pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+    # Run the application
     pyglet.app.run()

--- a/examples/gui/widgets.py
+++ b/examples/gui/widgets.py
@@ -79,4 +79,5 @@ text_entry.set_handler('on_commit', text_entry_handler)
 text_entry_label = pyglet.text.Label("Text: None", x=300, y=100, batch=batch, color=(0, 0, 0, 255))
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/gui/widgets.py
+++ b/examples/gui/widgets.py
@@ -79,5 +79,8 @@ text_entry.set_handler('on_commit', text_entry_handler)
 text_entry_label = pyglet.text.Label("Text: None", x=300, y=100, batch=batch, color=(0, 0, 0, 255))
 
 
-pyglet.clock.schedule(window.draw)
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -15,5 +15,8 @@ def on_draw():
     label.draw()
 
 
+# Set redraw rate to 60 FPS
 pyglet.clock.schedule_interval(window.draw, 1/60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/input/controller.py
+++ b/examples/input/controller.py
@@ -109,6 +109,8 @@ if controllers := controller_manager.get_controllers():
     on_connect(controllers[0])
 
 
-# Set redraw to occur at the default frame rate & run the application
-pyglet.clock.schedule(window.draw)
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/input/controller.py
+++ b/examples/input/controller.py
@@ -108,4 +108,7 @@ controller_manager.on_disconnect = on_disconnect
 if controllers := controller_manager.get_controllers():
     on_connect(controllers[0])
 
+
+# Set redraw to occur at the default frame rate & run the application
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/input/joystick.py
+++ b/examples/input/joystick.py
@@ -59,5 +59,8 @@ def on_draw():
     d_pad_rect.position = d_pad_x, d_pad_y
 
 
-pyglet.clock.schedule(window.draw)
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/input/joystick.py
+++ b/examples/input/joystick.py
@@ -59,4 +59,5 @@ def on_draw():
     d_pad_rect.position = d_pad_x, d_pad_y
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -370,7 +370,9 @@ def main(target, dbg_file, debug):
     window.gui_update_source()
     window.set_visible(True)
     window.set_default_video_size()
-    pyglet.clock.schedule(window.draw)
+
+    # Redraw at 60 FPS
+    pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
     # this is an async call
     player.play()

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -370,6 +370,7 @@ def main(target, dbg_file, debug):
     window.gui_update_source()
     window.set_visible(True)
     window.set_default_video_size()
+    pyglet.clock.schedule(window.draw)
 
     # this is an async call
     player.play()

--- a/examples/media/synthesizer.py
+++ b/examples/media/synthesizer.py
@@ -51,9 +51,6 @@ class Keyboard:
             self.instructions.draw()
             self.current_note.draw()
 
-        # Redraw at 60 FPS
-        pyglet.clock.schedule_interval(self.window.draw, 1 / 60)
-
     def play_note(self, frequency, length=0.6):
         if frequency in self.note_cache:
             note_wave = self.note_cache[frequency]
@@ -68,4 +65,8 @@ class Keyboard:
 
 if __name__ == "__main__":
     keyboard = Keyboard()
+
+    # Redraw at 60 FPS
+    pyglet.clock.schedule_interval(keyboard.window.draw, 1 / 60)
+
     pyglet.app.run()

--- a/examples/media/synthesizer.py
+++ b/examples/media/synthesizer.py
@@ -51,7 +51,8 @@ class Keyboard:
             self.instructions.draw()
             self.current_note.draw()
 
-        pyglet.clock.schedule(self.window.draw)
+        # Redraw at 60 FPS
+        pyglet.clock.schedule_interval(self.window.draw, 1 / 60)
 
     def play_note(self, frequency, length=0.6):
         if frequency in self.note_cache:

--- a/examples/media/synthesizer.py
+++ b/examples/media/synthesizer.py
@@ -51,6 +51,8 @@ class Keyboard:
             self.instructions.draw()
             self.current_note.draw()
 
+        pyglet.clock.schedule(self.window.draw)
+
     def play_note(self, frequency, length=0.6):
         if frequency in self.note_cache:
             note_wave = self.note_cache[frequency]

--- a/examples/media/video.py
+++ b/examples/media/video.py
@@ -38,5 +38,8 @@ def on_draw():
     player.texture.blit(0, 0)
 
 
-pyglet.clock.schedule(window.draw)
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/media/video.py
+++ b/examples/media/video.py
@@ -38,4 +38,5 @@ def on_draw():
     player.texture.blit(0, 0)
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/opengl/opengl.py
+++ b/examples/opengl/opengl.py
@@ -122,6 +122,9 @@ batch = pyglet.graphics.Batch()
 shader = pyglet.model.get_default_shader()
 torus_model = create_torus(1.0, 0.3, 50, 30, shader, batch)
 
-pyglet.clock.schedule(update)
-pyglet.clock.schedule_interval(window.draw, 1/60)
+# Update & redraw at 60 FPS
+pyglet.clock.schedule_interval(update, 1 / 60)
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/opengl/opengl.py
+++ b/examples/opengl/opengl.py
@@ -123,4 +123,5 @@ shader = pyglet.model.get_default_shader()
 torus_model = create_torus(1.0, 0.3, 50, 30, shader, batch)
 
 pyglet.clock.schedule(update)
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/opengl/opengl_core.py
+++ b/examples/opengl/opengl_core.py
@@ -95,4 +95,5 @@ def update(dt):
 if __name__ == "__main__":
     pyglet.gl.glClearColor(0.2, 0.3, 0.3, 1)
     pyglet.clock.schedule_interval(update, 1/60)
+    pyglet.clock.schedule_interval(window.draw, 1/60)
     pyglet.app.run()

--- a/examples/opengl/opengl_scissor.py
+++ b/examples/opengl/opengl_scissor.py
@@ -92,4 +92,5 @@ def on_mouse_drag(x, y, dx, dy, *etc):
     scissor_group.y += dy
 
 
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/opengl/opengl_shader.py
+++ b/examples/opengl/opengl_shader.py
@@ -132,4 +132,5 @@ vertex_list = shader_program.vertex_list_indexed(4, GL_TRIANGLES, indices, batch
 #####################
 # Enter the main loop
 #####################
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/programming_guide/animation.py
+++ b/examples/programming_guide/animation.py
@@ -41,9 +41,8 @@ def on_draw():
     sprite.draw()
 
 
-# Schedule redraw at the default frame rate
-pyglet.clock.schedule(window.draw)
-
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
 # Start the application
 pyglet.app.run()

--- a/examples/programming_guide/animation.py
+++ b/examples/programming_guide/animation.py
@@ -41,4 +41,9 @@ def on_draw():
     sprite.draw()
 
 
+# Schedule redraw at the default frame rate
+pyglet.clock.schedule(window.draw)
+
+
+# Start the application
 pyglet.app.run()

--- a/examples/programming_guide/events.py
+++ b/examples/programming_guide/events.py
@@ -35,4 +35,5 @@ def on_draw():
     window.clear()
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/programming_guide/events.py
+++ b/examples/programming_guide/events.py
@@ -34,6 +34,8 @@ def on_mouse_press(x, y, button, modifiers):
 def on_draw():
     window.clear()
 
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
-pyglet.clock.schedule(window.draw)
+# Run the application
 pyglet.app.run()

--- a/examples/programming_guide/hello_world.py
+++ b/examples/programming_guide/hello_world.py
@@ -21,4 +21,5 @@ def on_draw():
     label.draw()
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/programming_guide/hello_world.py
+++ b/examples/programming_guide/hello_world.py
@@ -21,5 +21,8 @@ def on_draw():
     label.draw()
 
 
-pyglet.clock.schedule(window.draw)
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/programming_guide/image_viewer.py
+++ b/examples/programming_guide/image_viewer.py
@@ -17,4 +17,5 @@ def on_draw():
     image.blit(0, 0)
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/programming_guide/image_viewer.py
+++ b/examples/programming_guide/image_viewer.py
@@ -17,5 +17,8 @@ def on_draw():
     image.blit(0, 0)
 
 
-pyglet.clock.schedule(window.draw)
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+# Run the application
 pyglet.app.run()

--- a/examples/programming_guide/window_subclass.py
+++ b/examples/programming_guide/window_subclass.py
@@ -19,5 +19,9 @@ class HelloWorldWindow(pyglet.window.Window):
 
 if __name__ == '__main__':
     window = HelloWorldWindow()
-    pyglet.clock.schedule(window.draw)
+
+    # Redraw at 60 FPS
+    pyglet.clock.schedule_interval(window.draw, 1 / 60)
+
+    # Run the application
     pyglet.app.run()

--- a/examples/programming_guide/window_subclass.py
+++ b/examples/programming_guide/window_subclass.py
@@ -19,4 +19,5 @@ class HelloWorldWindow(pyglet.window.Window):
 
 if __name__ == '__main__':
     window = HelloWorldWindow()
+    pyglet.clock.schedule(window.draw)
     pyglet.app.run()

--- a/examples/sprite/depth_sprite.py
+++ b/examples/sprite/depth_sprite.py
@@ -96,4 +96,5 @@ def on_draw():
     batch.draw()
 
 
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/sprite/display_sprite.py
+++ b/examples/sprite/display_sprite.py
@@ -26,5 +26,6 @@ def on_resize(width, height):
 def on_draw():
     window.clear()
     sprite.draw()
-    
+
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/sprite/multi_texture_sprite.py
+++ b/examples/sprite/multi_texture_sprite.py
@@ -194,4 +194,5 @@ def on_draw():
     batch.draw()
 
 
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/sprite/sprite_batching.py
+++ b/examples/sprite/sprite_batching.py
@@ -43,5 +43,7 @@ for i in range(1000):
 def on_draw():
     window.clear()
     batch.draw()
-    
+
+
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/text/advanced_font.py
+++ b/examples/text/advanced_font.py
@@ -46,4 +46,5 @@ def on_draw():
     batch.draw()
 
 
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/text/font_comparison.py
+++ b/examples/text/font_comparison.py
@@ -126,4 +126,5 @@ if __name__ == '__main__':
     font_names.sort()
     window = Window(1024, 600)
     window.on_text_motion(None)
+    pyglet.clock.schedule_interval(window.draw, 1 / 60)
     pyglet.app.run()

--- a/examples/text/html_label.py
+++ b/examples/text/html_label.py
@@ -41,4 +41,5 @@ def on_draw():
 
 
 pyglet.gl.glClearColor(1, 1, 1, 1)
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/text/text_input.py
+++ b/examples/text/text_input.py
@@ -127,4 +127,5 @@ class Window(pyglet.window.Window):
 
 
 window = Window(resizable=True)
+pyglet.clock.schedule_interval(window.draw, 1/60)
 pyglet.app.run()

--- a/examples/timer.py
+++ b/examples/timer.py
@@ -56,7 +56,11 @@ def on_draw():
 
 
 timer = Timer()
+
+# Set timer and redraw update rate to 30 FPS
 pyglet.clock.schedule_interval(timer.update, 1/30.0)
 pyglet.clock.schedule_interval(window.draw, 1/30)
+
+# Launch the application
 pyglet.app.run()
 

--- a/examples/window/camera_group.py
+++ b/examples/window/camera_group.py
@@ -156,6 +156,9 @@ if __name__ == "__main__":
         # Update position text label
         position_text.text = repr(round(camera.position))
 
-    # Start the demo
+    # Schedule game state and redraw updates with the default frame rate
     pyglet.clock.schedule(on_update)
+    pyglet.clock.schedule(window.draw)
+
+    # Start the demo
     pyglet.app.run()

--- a/examples/window/camera_group.py
+++ b/examples/window/camera_group.py
@@ -156,9 +156,9 @@ if __name__ == "__main__":
         # Update position text label
         position_text.text = repr(round(camera.position))
 
-    # Schedule game state and redraw updates with the default frame rate
-    pyglet.clock.schedule(on_update)
-    pyglet.clock.schedule(window.draw)
+    # Schedule game state updates & redraw at 60 FPS
+    pyglet.clock.schedule_interval(on_update, 1 / 60)
+    pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
     # Start the demo
     pyglet.app.run()

--- a/examples/window/fixed_resolution.py
+++ b/examples/window/fixed_resolution.py
@@ -95,7 +95,12 @@ def on_draw():
 rectangle = pyglet.shapes.Rectangle(x=160, y=90, color=(200, 50, 50), width=100, height=100)
 rectangle.anchor_position = 50, 50
 
-# Schedule the update function at 60fps
+
+# Schedule the update & redraw functions at 60fps
 pyglet.clock.schedule_interval(update, 1/60)
+pyglet.clock.schedule_interval(window.draw, 1/60)
+
+
+# Start the example
 pyglet.app.run()
 

--- a/examples/window/fixed_resolution.py
+++ b/examples/window/fixed_resolution.py
@@ -72,11 +72,6 @@ window = pyglet.window.Window(960, 540, resizable=True)
 fixed_res = FixedResolution(window, width=320, height=180)
 
 
-def update(dt):
-    global rectangle
-    rectangle.rotation += dt * 10
-
-
 @window.event
 def on_draw():
     window.clear()
@@ -91,14 +86,23 @@ def on_draw():
     # fixed_res.end()
 
 
+# Combine update & drawing to avoid stutter from mismatched update rates
+def update(dt):
+    global rectangle
+    rectangle.rotation += dt * 10
+
+    # This method automatically calls any on_draw method registered
+    # using @window.event, as we did above.
+    window.draw(dt)
+
+
 # Create a simple Rectangle to show the effect
 rectangle = pyglet.shapes.Rectangle(x=160, y=90, color=(200, 50, 50), width=100, height=100)
 rectangle.anchor_position = 50, 50
 
 
-# Schedule the update & redraw functions at 60fps
+# Call the combined update & redraw function at 60 FPS
 pyglet.clock.schedule_interval(update, 1/60)
-pyglet.clock.schedule_interval(window.draw, 1/60)
 
 
 # Start the example

--- a/examples/window/fps_change.py
+++ b/examples/window/fps_change.py
@@ -39,5 +39,8 @@ def on_refresh(dt):
     fps.draw()
 
 
+# Set the initial frame rate to 60 FPS
 pyglet.clock.schedule_interval(window.draw, 1/60)
+
+# Start the application
 pyglet.app.run()

--- a/examples/window/multiple_windows.py
+++ b/examples/window/multiple_windows.py
@@ -16,8 +16,8 @@ def on_draw():
     s1.rotation -= 0.5
     s1.draw()
 
-# Schedule redraw for Window 1 at the default frame rate
-pyglet.clock.schedule(w1.draw)
+# Redraw Window 1 at 60 FPS
+pyglet.clock.schedule_interval(w1.draw, 1 / 60)
 
 
 w2 = pyglet.window.Window(300, 300, caption='Second window', resizable=True)
@@ -32,9 +32,9 @@ def on_draw():
     s2.rotation += 0.5
     s2.draw()
 
-# Schedule redraw for Window 2 at the default frame rate
-pyglet.clock.schedule(w2.draw)
 
+# Redraw Window 2 at 60 FPS
+pyglet.clock.schedule_interval(w2.draw, 1 / 60)
 
 # Run the demo
 pyglet.app.run()

--- a/examples/window/multiple_windows.py
+++ b/examples/window/multiple_windows.py
@@ -10,12 +10,14 @@ w1.switch_to()
 s1 = pyglet.shapes.Rectangle(100, 100, 100, 100, color=(50, 50, 200))
 s1.anchor_position = 50, 50
 
-
 @w1.event
 def on_draw():
     w1.clear()
     s1.rotation -= 0.5
     s1.draw()
+
+# Schedule redraw for Window 1 at the default frame rate
+pyglet.clock.schedule(w1.draw)
 
 
 w2 = pyglet.window.Window(300, 300, caption='Second window', resizable=True)
@@ -30,5 +32,9 @@ def on_draw():
     s2.rotation += 0.5
     s2.draw()
 
+# Schedule redraw for Window 2 at the default frame rate
+pyglet.clock.schedule(w2.draw)
 
+
+# Run the demo
 pyglet.app.run()

--- a/examples/window/overlay_window.py
+++ b/examples/window/overlay_window.py
@@ -20,4 +20,5 @@ def on_draw():
     batch.draw()
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/window/overlay_window.py
+++ b/examples/window/overlay_window.py
@@ -19,6 +19,8 @@ def on_draw():
     window.clear()
     batch.draw()
 
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
-pyglet.clock.schedule(window.draw)
+# Run the application
 pyglet.app.run()

--- a/examples/window/transparent_window.py
+++ b/examples/window/transparent_window.py
@@ -20,4 +20,5 @@ def on_draw():
     batch.draw()
 
 
+pyglet.clock.schedule(window.draw)
 pyglet.app.run()

--- a/examples/window/transparent_window.py
+++ b/examples/window/transparent_window.py
@@ -19,6 +19,8 @@ def on_draw():
     window.clear()
     batch.draw()
 
+# Redraw at 60 FPS
+pyglet.clock.schedule_interval(window.draw, 1 / 60)
 
-pyglet.clock.schedule(window.draw)
+# Run the application
 pyglet.app.run()


### PR DESCRIPTION
### Changes

tl;dr schedule drawing intervals per [description of breaking changes on Discord](https://discord.com/channels/438622377094414346/477394331112701952/1134825532354216058):
> ...there is a breaking change for 2.1. You need to explicitly scheudle the Window redraw

### ~~I need help with~~ Done

- [x] Testing Windows-specific examples:
     - [x] `python examples/text/advanced_font.py`
     - [x] `python examples/text/font_comparison.py`

- [x] Testing controller input examples (Works according to Ben)
     - [x] `python examples/input/controller.py`
     - [x] `python examples/input/joystick.py`

### Follow-up questions

1. Should we add frame rate constants to make scheduling cleaner?
2. Q: How should we describe the pros and cons of using `schedule` vs `schedule_interval` for readers?
   A: Examples should use `schedule_interval`