### PR TITLE
Remove `pyglet.util.with_metaclass` and usage sites

### DIFF
--- a/pyglet/libs/win32/com.py
+++ b/pyglet/libs/win32/com.py
@@ -148,11 +148,8 @@ class InterfacePtrMeta(type(ctypes.POINTER(COMInterface))):
         return super(InterfacePtrMeta, cls).__new__(cls, name, bases, dct)
 
 
-# pyglet.util.with_metaclass does not work here, as the base class is from _ctypes.lib
-# See https://wiki.python.org/moin/PortingToPy3k/BilingualQuickRef
-pInterface = InterfacePtrMeta(str('Interface'),
-                              (ctypes.POINTER(COMInterface),),
-                              {'__doc__': 'Base COM interface pointer.'})
+class pInterface(ctypes.POINTER(COMInterface), metaclass=InterfacePtrMeta):
+    """Base COM interface pointer."""
 
 
 class COMInterfaceMeta(type):

--- a/pyglet/media/devices/base.py
+++ b/pyglet/media/devices/base.py
@@ -3,7 +3,6 @@ from enum import Enum, auto
 from typing import Dict, Optional
 
 from pyglet import event
-from pyglet.util import with_metaclass
 
 
 class DeviceState(Enum):
@@ -37,7 +36,7 @@ class AudioDevice:
             self.__class__.__name__, self.name, self.platform_state[self.state].name, self.platform_flow[self.flow].name)
 
 
-class AbstractAudioDeviceManager(with_metaclass(ABCMeta, event.EventDispatcher, object)):
+class AbstractAudioDeviceManager(event.EventDispatcher, metaclass=ABCMeta):
 
     def __del__(self):
         """Required to remove handlers before exit, as it can cause problems with the event system's weakrefs."""

--- a/pyglet/media/drivers/base.py
+++ b/pyglet/media/drivers/base.py
@@ -4,10 +4,9 @@ import weakref
 from abc import ABCMeta, abstractmethod
 
 import pyglet
-from pyglet.util import with_metaclass
 
 
-class AbstractAudioPlayer(with_metaclass(ABCMeta)):
+class AbstractAudioPlayer(metaclass=ABCMeta):
     """Base class for driver audio players.
     """
 
@@ -176,7 +175,7 @@ class AbstractAudioPlayer(with_metaclass(ABCMeta)):
         self._source = weakref.proxy(value)
 
 
-class AbstractAudioDriver(with_metaclass(ABCMeta)):
+class AbstractAudioDriver(metaclass=ABCMeta):
     @abstractmethod
     def create_audio_player(self, source, player):
         pass

--- a/pyglet/media/drivers/listener.py
+++ b/pyglet/media/drivers/listener.py
@@ -1,9 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
-from pyglet.util import with_metaclass
 
-
-class AbstractListener(with_metaclass(ABCMeta, object)):
+class AbstractListener(metaclass=ABCMeta):
     """The listener properties for positional audio.
 
     You can obtain the singleton instance of this class by calling

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -31,37 +31,6 @@ def asstr(s):
     return s.decode("utf-8")
 
 
-def with_metaclass(meta, *bases):
-    """
-    Function from jinja2/_compat.py. License: BSD.
-    Use it like this::
-        class BaseForm:
-            pass
-        class FormType(type):
-            pass
-        class Form(with_metaclass(FormType, BaseForm)):
-            pass
-    This requires a bit of explanation: the basic idea is to make a
-    dummy metaclass for one level of class instantiation that replaces
-    itself with the actual metaclass.  Because of internal type checks
-    we also need to make sure that we downgrade the custom metaclass
-    for one level to something closer to type (that's why __call__ and
-    __init__ comes back from type etc.).
-    This has the advantage over six.with_metaclass of not introducing
-    dummy classes into the final MRO.
-    """
-    class MetaClass(meta):
-        __call__ = type.__call__
-        __init__ = type.__init__
-
-        def __new__(cls, name, this_bases, d):
-            if this_bases is None:
-                return type.__new__(cls, name, (), d)
-            return meta(name, bases, d)
-
-    return MetaClass('temporary_class', None, {})
-
-
 def debug_print(enabled_or_option='debug'):
     """Get a debug printer that is enabled based on a boolean input or a pyglet option.
     The debug print function returned should be used in an assert. This way it can be

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -99,7 +99,6 @@ from pyglet import gl
 from pyglet.math import Mat4
 from pyglet.event import EventDispatcher
 from pyglet.window import key, event
-from pyglet.util import with_metaclass
 from pyglet.graphics import shader
 
 
@@ -256,7 +255,7 @@ class _WindowMetaclass(type):
         super(_WindowMetaclass, cls).__init__(name, bases, dict)
 
 
-class BaseWindow(with_metaclass(_WindowMetaclass, EventDispatcher)):
+class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
     """Platform-independent application window.
 
     A window is a "heavyweight" object occupying operating system resources.


### PR DESCRIPTION
- Compatability not needed anymore.
- Also, ease out `pInterface` creation in `libs.win32.com` which used another way of creating a type with a metaclass.