### PR TITLE
Add doc for adding motion constants, MOTION_COPY, MOTION_PASTE

### DIFF
--- a/doc/modules/window_key.rst
+++ b/doc/modules/window_key.rst
@@ -142,6 +142,10 @@ See :ref:`keyboard_motion_events` for more information.
     * ``MOTION_DOWN``
   *
     * ``MOTION_LEFT``
+
+    * ``MOTION_COPY``
+  *
+    * ``MOTION_PASTE``
   *
     * ``MOTION_NEXT_WORD``
   *
@@ -162,10 +166,7 @@ See :ref:`keyboard_motion_events` for more information.
     * ``MOTION_BACKSPACE``
   *
     * ``MOTION_DELETE``
-  *
-    * ``MOTION_COPY``
-  *
-    * ``MOTION_PASTE``
+
 
 Number pad
 ^^^^^^^^^^

--- a/doc/modules/window_key.rst
+++ b/doc/modules/window_key.rst
@@ -142,7 +142,7 @@ See :ref:`keyboard_motion_events` for more information.
     * ``MOTION_DOWN``
   *
     * ``MOTION_LEFT``
-
+  *
     * ``MOTION_COPY``
   *
     * ``MOTION_PASTE``

--- a/doc/modules/window_key.rst
+++ b/doc/modules/window_key.rst
@@ -127,7 +127,10 @@ Misc functions
 Text motion constants
 ^^^^^^^^^^^^^^^^^^^^^
 
-These are allowed to clash with key constants.
+These are allowed to clash with key constants because they abstract
+common text motions from their platform-specific keyboard shortcuts.
+See :ref:`keyboard_motion_events` for more information.
+
 
 .. list-table::
 
@@ -159,6 +162,10 @@ These are allowed to clash with key constants.
     * ``MOTION_BACKSPACE``
   *
     * ``MOTION_DELETE``
+  *
+    * ``MOTION_COPY``
+  *
+    * ``MOTION_PASTE``
 
 Number pad
 ^^^^^^^^^^

--- a/doc/programming_guide/keyboard.rst
+++ b/doc/programming_guide/keyboard.rst
@@ -220,6 +220,9 @@ Conversely, you never use :py:meth:`~pyglet.window.Window.on_text` when you
 require keys to be pressed (for example, to control the movement of the player
 in a game).
 
+
+.. _keyboard_motion_events:
+
 Motion events
 ^^^^^^^^^^^^^
 

--- a/doc/programming_guide/keyboard.rst
+++ b/doc/programming_guide/keyboard.rst
@@ -350,6 +350,7 @@ To add a new motion, do the following:
       * - Windows
         - :py:mod:`pyglet.window.win32`
         - .. raw:: html
+
              <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/win32/__init__.py">
              <pre>pyglet/window/win32/__init__.py</pre>
              </a>
@@ -357,6 +358,7 @@ To add a new motion, do the following:
       * - Mac
         - :py:mod:`pyglet.window.cocoa`
         - .. raw:: html
+
              <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/cocoa/__init__.py">
              <pre>pyglet/window/cocoa/__init__.py</pre>
              </a>
@@ -364,6 +366,7 @@ To add a new motion, do the following:
       * - Linux
         - :py:mod:`pyglet.window.xlib`
         - .. raw:: html
+
              <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/xlib/__init__.py">
              <pre>pyglet/window/xlib/__init__.py</pre>
              </a>

--- a/doc/programming_guide/keyboard.rst
+++ b/doc/programming_guide/keyboard.rst
@@ -277,6 +277,14 @@ and their keyboard mapping on each operating system.
           - Move the cursor right
           - Right
           - Right
+        * - ``MOTION_COPY``
+          - Copy the current selection to the clipboard
+          - Ctrl + C
+          - Command + C
+        * - ``MOTION_PASTE``
+          - Paste the clipboard contents into the current document
+          - Ctrl + V
+          - Command + V
         * - ``MOTION_PREVIOUS_WORD``
           - Move the cursor to the previous word
           - Ctrl + Left

--- a/doc/programming_guide/keyboard.rst
+++ b/doc/programming_guide/keyboard.rst
@@ -332,52 +332,47 @@ and their keyboard mapping on each operating system.
 Adding New Motions
 """"""""""""""""""
 
-To add a new motion, do the following:
+Before adding a new motion, please do the following:
 
 #. Consult the previous section to be sure it is:
-   #. A common, cross-platform text operation
-   #. Overlooked by pyglet
 
-#. Discuss the addition with maintainers by doing either of the following:
+   #. A common text operation present on every platform
+   #. Not already implemented by pyglet
+
+#. Attempt to find the corresponding functionality in
+   `Apple's NSTextView documentation
+   <https://developer.apple.com/documentation/appkit/nstextview/>`_
+
+#. Discuss the addition and any remaining questions with maintainers by either:
 
    * `Filing a GitHub Issue <https://github.com/pyglet/pyglet/issues>`_
-   * `Alternative means of contact <https://github.com/pyglet/pyglet#contact>`_
+   * `Discord or the mailing list <https://github.com/pyglet/pyglet#contact>`_
 
-#. Add the motion constant to :py:mod:`pyglet.key`
-#. Add an entry for the motion constant in the previous section's table
-#. Add the platform-specific keyboard shortcut for each motion constant
-   to the ``_motion_map`` dictionary in each of the following modules:
+Then, once you're ready:
 
-   .. list-table::
-      :header-rows: 1
+#. Add the motion constant to :py:mod:`pyglet.window.key`
+#. Add an entry for the constant in the :ref:`keyboard_motion_events`
+   section
 
-      * - Platform
-        - Module
-        - Path in Source
+#. Implement Mac support (the hardest step)
 
-      * - Windows
-        - :py:mod:`pyglet.window.win32`
-        - .. raw:: html
+   #. Open `pyglet/window/cocoa/pyglet_textview.py
+      <https://github.com/pyglet/pyglet/blob/master/pyglet/window/cocoa/pyglet_textview.py>`_
+   #. Implement a corresponding handler method on pyglet's subclass of ``NSTextView``
 
-             <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/win32/__init__.py">
-             <pre>pyglet/window/win32/__init__.py</pre>
-             </a>
+#. Add the Windows keyboard shortcut
 
-      * - Mac
-        - :py:mod:`pyglet.window.cocoa`
-        - .. raw:: html
+   #. Open `pyglet/window/win32/__init__.py
+      <https://github.com/pyglet/pyglet/blob/master/pyglet/window/win32/__init__.py>`_
+   #. Add the keyboard shortcut to the ``_motion_map`` dictionary
 
-             <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/cocoa/__init__.py">
-             <pre>pyglet/window/cocoa/__init__.py</pre>
-             </a>
+#. Add the Linux keyboard shortcut
 
-      * - Linux
-        - :py:mod:`pyglet.window.xlib`
-        - .. raw:: html
+   #. Open `pyglet/window/xlib/__init__.py
+      <https://github.com/pyglet/pyglet/blob/master/pyglet/window/xlib/__init__.py>`_
+   #. Add the keyboard shortcut to the ``_motion_map`` dictionary
 
-             <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/xlib/__init__.py">
-             <pre>pyglet/window/xlib/__init__.py</pre>
-             </a>
+Be sure to test your changes before making a PR!
 
 Keyboard exclusivity
 --------------------

--- a/doc/programming_guide/keyboard.rst
+++ b/doc/programming_guide/keyboard.rst
@@ -318,6 +318,56 @@ and their keyboard mapping on each operating system.
           - Delete
           - Delete
 
+
+.. _keyboard_motion_events_adding:
+
+Adding New Motions
+""""""""""""""""""
+
+To add a new motion, do the following:
+
+#. Consult the previous section to be sure it is:
+   #. A common, cross-platform text operation
+   #. Overlooked by pyglet
+
+#. Discuss the addition with maintainers by doing either of the following:
+
+   * `Filing a GitHub Issue <https://github.com/pyglet/pyglet/issues>`_
+   * `Alternative means of contact <https://github.com/pyglet/pyglet#contact>`_
+
+#. Add the motion constant to :py:mod:`pyglet.key`
+#. Add an entry for the motion constant in the previous section's table
+#. Add the platform-specific keyboard shortcut for each motion constant
+   to the ``_motion_map`` dictionary in each of the following modules:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Platform
+        - Module
+        - Path in Source
+
+      * - Windows
+        - :py:mod:`pyglet.window.win32`
+        - .. raw:: html
+             <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/win32/__init__.py">
+             <pre>pyglet/window/win32/__init__.py</pre>
+             </a>
+
+      * - Mac
+        - :py:mod:`pyglet.window.cocoa`
+        - .. raw:: html
+             <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/cocoa/__init__.py">
+             <pre>pyglet/window/cocoa/__init__.py</pre>
+             </a>
+
+      * - Linux
+        - :py:mod:`pyglet.window.xlib`
+        - .. raw:: html
+             <a href="https://github.com/pyglet/pyglet/blob/master/pyglet/window/xlib/__init__.py">
+             <pre>pyglet/window/xlib/__init__.py</pre>
+             </a>
+
 Keyboard exclusivity
 --------------------
 

--- a/pyglet/window/key.py
+++ b/pyglet/window/key.py
@@ -213,7 +213,16 @@ MODESWITCH    = 0xff7e
 SCRIPTSWITCH  = 0xff7e
 FUNCTION      = 0xffd2
 
-# Text motion constants: these are allowed to clash with key constants
+# Text motion constants
+# These are allowed to clash with key constants since they are
+# abstractions of keyboard shortcuts. See the following for more
+# information:
+#
+# 1. doc/programming_guide/keyboard.rst
+# 2. doc/modules/window_key.rst
+#
+# To add new motions, consult the Adding New Motions section of
+# doc/programming_guide/keyboard.rst
 MOTION_UP                = UP
 MOTION_RIGHT             = RIGHT
 MOTION_DOWN              = DOWN


### PR DESCRIPTION
Closes #934

### Changes

1. Document `MOTION_COPY` and `MOTION_PASTE`
2. Add overview of when and how to add & document new text motion constants
3. Add comments in `pyglet.window.key` referring to the the doc

### How to test

1. `cd doc`
2. `make html`
3. `python -m http.server -d _build/html` as usual

I've ran the doc build locally and there do not appear to be any new errors.

### What it helps with

Allowing developers to implement cross-platform text functionality.

