### PR TITLE
Enable intersphinx to link main Python doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,11 +128,17 @@ inheritance_graph_attrs = dict(rankdir="LR", size='""')
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.intersphinx',
               'sphinx.ext.inheritance_diagram',
               'sphinx.ext.todo',
               'sphinx.ext.napoleon']
 
 autodoc_member_order = 'groupwise'
+
+# Enable links to Python's main doc
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None)
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
### Changes

* Add intersphinx to the extensions list
* Add the main Python repo to the externally linkable doc

### Purpose

Keep pyglet documentation brief by linking external documentation more succinctly and reliably than full URLs. 

Example use cases include:

* Suggesting existing Python built-ins in the programming guide
* Linking relevant dev dependency doc (pytest, sphinx) in future contributor doc