### PR TITLE
Allow all ShapeBase subclasses to rotate

### DIFF
--- a/doc/modules/shapes.rst
+++ b/doc/modules/shapes.rst
@@ -15,6 +15,7 @@ pyglet.shapes
   .. autoattribute:: x
   .. autoattribute:: y
   .. autoattribute:: position
+  .. autoattribute:: rotation
   .. autoattribute:: anchor_x
   .. autoattribute:: anchor_y
   .. autoattribute:: anchor_position
@@ -30,7 +31,6 @@ pyglet.shapes
 
   .. autoattribute:: angle
   .. autoattribute:: start_angle
-  .. autoattribute:: rotation
 
 
 .. autoclass:: BezierCurve
@@ -51,7 +51,6 @@ pyglet.shapes
 
   .. autoattribute:: a
   .. autoattribute:: b
-  .. autoattribute:: rotation
 
 
 .. autoclass:: Sector
@@ -60,7 +59,6 @@ pyglet.shapes
   .. autoattribute:: angle
   .. autoattribute:: start_angle
   .. autoattribute:: radius
-  .. autoattribute:: rotation
 
 
 .. autoclass:: Line
@@ -75,7 +73,6 @@ pyglet.shapes
 
   .. autoattribute:: width
   .. autoattribute:: height
-  .. autoattribute:: rotation
 
 
 .. autoclass:: BorderedRectangle
@@ -84,7 +81,6 @@ pyglet.shapes
   .. autoattribute:: width
   .. autoattribute:: height
   .. autoattribute:: border_color
-  .. autoattribute:: rotation
 
 
 .. autoclass:: Triangle
@@ -102,10 +98,7 @@ pyglet.shapes
   .. autoattribute:: outer_radius
   .. autoattribute:: inner_radius
   .. autoattribute:: num_spikes
-  .. autoattribute:: rotation
 
 
 .. autoclass:: Polygon
   :show-inheritance:
-
-  .. autoattribute:: rotation

--- a/examples/graphics/shapes.py
+++ b/examples/graphics/shapes.py
@@ -54,6 +54,7 @@ class ShapesDemo(pyglet.window.Window):
         self.square.rotation = self.time * 15
         self.rectangle.y = 200 + math.sin(self.time) * 190
         self.circle.radius = 75 + math.sin(self.time * 1.17) * 25
+        self.triangle.rotation = self.time * 15
 
         self.line.x = 360 + math.sin(self.time * 0.81) * 360
         self.line.x2 = 360 + math.sin(self.time * 1.34) * 360

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -198,6 +198,7 @@ class ShapeBase(ABC):
     """
 
     _rgba = (255, 255, 255, 255)
+    _rotation = 0
     _visible = True
     _x = 0
     _y = 0
@@ -258,6 +259,19 @@ class ShapeBase(ABC):
         """
         raise NotImplementedError("_update_vertices must be defined"
                                   "for every ShapeBase subclass")
+    @property
+    def rotation(self) -> float:
+        """Clockwise rotation of the shape in degrees.
+
+        It will be rotated about its (anchor_x, anchor_y)
+        position.
+        """
+        return self._rotation
+
+    @rotation.setter
+    def rotation(self, rotation: float) -> None:
+        self._rotation = rotation
+        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
 
     def draw(self):
         """Draw the shape at its current position.
@@ -550,22 +564,6 @@ class Arc(ShapeBase):
                 vertices.extend(chord_points)
 
         self._vertex_list.position[:] = vertices
-
-    @property
-    def rotation(self):
-        """Clockwise rotation of the arc, in degrees.
-
-        The arc will be rotated about its (anchor_x, anchor_y)
-        position.
-
-        :type: float
-        """
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
 
     @property
     def angle(self):
@@ -902,22 +900,6 @@ class Ellipse(ShapeBase):
         self._b = value
         self._update_vertices()
 
-    @property
-    def rotation(self):
-        """Clockwise rotation of the arc, in degrees.
-
-        The arc will be rotated about its (anchor_x, anchor_y)
-        position.
-
-        :type: float
-        """
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
-
 
 class Sector(ShapeBase):
     def __init__(self, x, y, radius, segments=None, angle=math.tau, start_angle=0,
@@ -1047,22 +1029,6 @@ class Sector(ShapeBase):
     def radius(self, value):
         self._radius = value
         self._update_vertices()
-
-    @property
-    def rotation(self):
-        """Clockwise rotation of the sector, in degrees.
-
-        The sector will be rotated about its (anchor_x, anchor_y)
-        position.
-
-        :type: float
-        """
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
 
 
 class Line(ShapeBase):
@@ -1286,22 +1252,6 @@ class Rectangle(ShapeBase):
         self._height = value
         self._update_vertices()
 
-    @property
-    def rotation(self):
-        """Clockwise rotation of the rectangle, in degrees.
-
-        The Rectangle will be rotated about its (anchor_x, anchor_y)
-        position.
-
-        :type: float
-        """
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
-
 
 class BorderedRectangle(ShapeBase):
     def __init__(self, x, y, width, height, border=1, color=(255, 255, 255),
@@ -1448,22 +1398,6 @@ class BorderedRectangle(ShapeBase):
     def height(self, value):
         self._height = value
         self._update_vertices()
-
-    @property
-    def rotation(self):
-        """Clockwise rotation of the rectangle, in degrees.
-
-        The Rectangle will be rotated about its (anchor_x, anchor_y)
-        position.
-
-        :type: float
-        """
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
 
     @property
     def border_color(self):
@@ -1771,17 +1705,6 @@ class Star(ShapeBase):
         self._num_spikes = value
         self._update_vertices()
 
-    @property
-    def rotation(self):
-        """Rotation of the star, in degrees.
-        """
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
-
 
 class Polygon(ShapeBase):
     def __init__(self, *coordinates, color=(255, 255, 255, 255), batch=None, group=None):
@@ -1845,22 +1768,6 @@ class Polygon(ShapeBase):
 
             # Flattening the list before setting vertices to it.
             self._vertex_list.position[:] = tuple(value for coordinate in triangles for value in coordinate)
-
-    @property
-    def rotation(self):
-        """Clockwise rotation of the polygon, in degrees.
-
-        The Polygon will be rotated about its (anchor_x, anchor_y)
-        position.
-
-        :type: float
-        """
-        return self._rotation
-
-    @rotation.setter
-    def rotation(self, rotation):
-        self._rotation = rotation
-        self._vertex_list.rotation[:] = (rotation,) * self._num_verts
 
 
 __all__ = 'Arc', 'BezierCurve', 'Circle', 'Ellipse', 'Line', 'Rectangle', 'BorderedRectangle', 'Triangle', 'Star', 'Polygon', 'Sector'

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -263,8 +263,18 @@ class ShapeBase(ABC):
     def rotation(self) -> float:
         """Clockwise rotation of the shape in degrees.
 
-        It will be rotated about its (anchor_x, anchor_y)
-        position.
+        It will be rotated about its (anchor_x, anchor_y) position,
+        which defaults to the first vertex point of the shape.
+
+        For most shapes, this is the lower left corner. The shapes
+        below default to the points their ``radius`` values are
+        measured from:
+
+            * :py:class:`.Circle`
+            * :py:class:`.Ellipse`
+            * :py:class:`.Arc`
+            * :py:class:`.Sector`
+            * :py:class:`.Star`
         """
         return self._rotation
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -99,3 +99,8 @@ def new_rgba_color():
 @fixture(params=[NEW_RGB_COLOR, NEW_RGBA_COLOR])
 def new_rgb_or_rgba_color(request):
     return request.param
+
+
+@fixture(params=[180, -180])
+def new_nonzero_rotation(request) -> float:
+    return request.param

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -59,7 +59,7 @@ def test_init_sets_opacity_to_255_for_rgb_value_as_color_argument(shape_keywords
 
 def test_init_sets_rotation_to_zero(rgb_or_rgba_shape, shape_type):
     if shape_type is Line:
-        pytest.skip(msg="Rotation test not yet valid for line due to design ambiguity")
+        pytest.xfail(msg="Rotation test not yet valid for line due to design ambiguity")
     assert rgb_or_rgba_shape.rotation == 0
 
 

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -59,7 +59,7 @@ def test_init_sets_opacity_to_255_for_rgb_value_as_color_argument(shape_keywords
 
 def test_init_sets_rotation_to_zero(rgb_or_rgba_shape, shape_type):
     if shape_type is Line:
-        pytest.xfail(msg="Rotation test not yet valid for line due to design ambiguity")
+        pytest.xfail("Rotation test not yet valid for line due to design ambiguity")
     assert rgb_or_rgba_shape.rotation == 0
 
 

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -23,8 +23,19 @@ from pyglet.shapes import *
     (Star, (1, 1, 20, 11, 5)),
     (Polygon, ((0, 0), (1, 1), (2, 2)))
 ])
-def shape_keywords_only(request):
-    class_, positional_args = request.param
+def shape_and_positionals(request):
+    return request.param
+
+
+# Enable type-specific behavior; just Line + rotation at the moment
+@pytest.fixture
+def shape_type(shape_and_positionals):
+    return shape_and_positionals[0]
+
+
+@pytest.fixture
+def shape_keywords_only(shape_and_positionals):
+    class_, positional_args = shape_and_positionals
     return partial(class_, *positional_args)
 
 
@@ -44,6 +55,17 @@ def test_init_sets_opacity_from_rgba_value_as_color_argument(rgba_shape):
 
 def test_init_sets_opacity_to_255_for_rgb_value_as_color_argument(shape_keywords_only):
     assert shape_keywords_only(color=(0, 0, 0)).opacity == 255
+
+
+def test_init_sets_rotation_to_zero(rgb_or_rgba_shape, shape_type):
+    if shape_type is Line:
+        pytest.skip(msg="Rotation test not yet valid for line due to design ambiguity")
+    assert rgb_or_rgba_shape.rotation == 0
+
+
+def test_rotation_prop_sets_rotation(rgb_or_rgba_shape, new_nonzero_rotation):
+    rgb_or_rgba_shape.rotation = new_nonzero_rotation
+    assert rgb_or_rgba_shape.rotation == new_nonzero_rotation
 
 
 def test_setting_color_sets_color_rgb_channels(rgb_or_rgba_shape, new_rgb_or_rgba_color):

--- a/tools/shape_rotation_translation_spotcheck.py
+++ b/tools/shape_rotation_translation_spotcheck.py
@@ -24,9 +24,8 @@ from pyglet.shapes import (
 from pyglet.text import Label
 
 
-INSTRUCTIONS = """Movement + rotation test rig:
-1. Use - / = keys to rotate
-2. Left click + drag to adjust positions
+INSTRUCTIONS = """- / = keys to rotate
+Left click + drag to adjust positions
 """
 
 PX_SIZE = 10
@@ -93,7 +92,11 @@ def main():
     padding = 50
     width, height = 600, 600
 
-    window = pyglet.window.Window(width, height, resizable=True)
+    window = pyglet.window.Window(
+        width, height,
+        caption="Shape Translation / Rotation Spotcheck",
+        resizable=True)
+
     shapes: Dict[Type, ShapeBase] = {}
     labels: Dict[Type, Label] = {}
     batch = pyglet.graphics.Batch()

--- a/tools/shape_rotation_translation_spotcheck.py
+++ b/tools/shape_rotation_translation_spotcheck.py
@@ -1,6 +1,3 @@
-"""
-
-"""
 import itertools
 import inspect
 from typing import Dict, Optional, Generator, Tuple, Type
@@ -140,7 +137,7 @@ def main():
         shapes[shape_type] = shape
         labels[shape_type] = label
 
-    instructions = pyglet.text.Label(
+    _instructions = pyglet.text.Label(
         INSTRUCTIONS,
         x=window.width // 2, y=padding,
         width=window.width,
@@ -178,4 +175,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/tools/shape_rotation_translation_spotcheck.py
+++ b/tools/shape_rotation_translation_spotcheck.py
@@ -1,0 +1,178 @@
+"""
+
+"""
+import itertools
+import inspect
+from typing import Dict, Optional, Generator, Tuple, Type
+
+import pyglet.window
+import math
+from pyglet.shapes import (
+    Arc,
+    BezierCurve,
+    Circle,
+    Ellipse,
+    Sector,
+    Line,
+    Rectangle,
+    BorderedRectangle,
+    Triangle,
+    Star,
+    Polygon,
+    ShapeBase
+)
+from pyglet.text import Label
+
+
+INSTRUCTIONS = """Movement + rotation test rig:
+1. Use - / = keys to rotate
+2. Left click + drag to adjust positions
+"""
+
+PX_SIZE = 10
+PX_SIZE_2 = PX_SIZE * 2
+
+# Call next() to get a new color; endlessly repeats
+colors = itertools.cycle(map(lambda c: c + (255,), [
+    (255, 0, 0),  # Red
+    (0, 255, 0),  # Blue
+    (0, 0, 255),  # Green
+    (255, 255, 0)  # Yellow
+]))
+
+# Default values for each shape type: Type, *args, **kwargs
+shape_configs = [
+    (Arc, (PX_SIZE,), {}),
+    (BezierCurve, [(0,0), (PX_SIZE,PX_SIZE_2), (PX_SIZE_2 , PX_SIZE)], {}),
+    (Circle, (PX_SIZE,), {}),
+    (Ellipse, (PX_SIZE, PX_SIZE_2,), {}),
+
+    (Sector, (PX_SIZE, ), {}),
+    (Line, (0, 0, PX_SIZE_2, PX_SIZE_2), {}),
+    (Rectangle, (PX_SIZE, PX_SIZE_2), {}),
+    (BorderedRectangle, (PX_SIZE_2, PX_SIZE), {}),
+
+    (Triangle, (-PX_SIZE, 0, 0, PX_SIZE, PX_SIZE, 0), {}),
+    (Star, (PX_SIZE_2, PX_SIZE, 5), {}),
+    (Polygon, ((-PX_SIZE,0), (0,PX_SIZE), (PX_SIZE,0)), {})
+]
+
+def layout_points(
+        width: int, height: int,
+        padding: int,
+        num_cols: int,
+        num_rows: Optional[int] = None
+) -> Generator[Tuple[int, int], None, None]:
+    """Yield points out in a col / row grid.
+
+    All units in px.
+    Args:
+        width: Width of the area
+        height: Height of the area
+        padding: How many px to pad on all sides
+        num_cols: How many columns each row should have
+        num_rows: Specify to prevent auto-calculation
+
+    Yields:
+        Bottom left screen position of the grid cell in px
+    """
+    x_step_range = width - 2 * padding
+    y_step_range = height - 2 * padding
+
+    if num_rows is None:
+        num_rows = math.ceil(len(shape_configs) / num_cols)
+
+    x_step = x_step_range // num_cols
+    y_step = y_step_range // num_rows
+
+    for y in range(height - padding, y_step, -y_step):
+        for x in range(padding, padding + x_step_range, x_step):
+            yield x, y
+
+def main():
+    padding = 50
+    width, height = 600, 600
+
+    window = pyglet.window.Window(width, height, resizable=True)
+    shapes: Dict[Type, ShapeBase] = {}
+    labels: Dict[Type, Label] = {}
+    batch = pyglet.graphics.Batch()
+
+    for shape_config, position in zip(shape_configs, layout_points(window.width, window.height, padding, 4)):
+        shape_type, args, kwargs = shape_config
+        sig = inspect.signature(shape_type)
+        params = list(sig.parameters)
+        print(shape_type.__name__, params)
+
+        # Arrange shape args
+        if params[:2] == ['x', 'y'] and params[2] != 'x2':
+            final_args = position + args
+        elif shape_type in (Polygon, BezierCurve):
+            raw = [(position[0] + p[0],  position[1] + p[1]) for p in args]
+            final_args = raw
+            print(shape_type.__name__, final_args)
+
+        elif shape_type in (Line, Triangle):
+            final_args = [
+                position[0] + args[0], position[1] + args[1],
+                position[0] + args[2], position[1] + args[3]]
+            if shape_type is Triangle:
+                final_args += [position[0] + args[4], position[1] + args[5]]
+            print(shape_type.__name__, final_args)
+
+        else:
+            raise TypeError("unhandled")
+
+        final_kwargs = dict(color=next(colors))
+        final_kwargs.update(kwargs)
+
+        label = pyglet.text.Label(
+            shape_type.__name__,
+            x=position[0], y=position[1] - padding,
+            batch=batch,
+            anchor_x='center',
+            **final_kwargs
+        )
+        shape = shape_type(*final_args, batch=batch, **final_kwargs)
+        shapes[shape_type] = shape
+        labels[shape_type] = label
+
+    instructions = pyglet.text.Label(
+        INSTRUCTIONS,
+        x=window.width // 2, y=padding,
+        width=window.width,
+        anchor_x='center',
+        align='center',
+        batch=batch,
+        multiline=True
+    )
+
+    @window.event
+    def on_draw():
+        window.clear()
+        batch.draw()
+
+    @window.event
+    def on_key_press(symbol, modifiers):
+        if symbol == pyglet.window.key.MINUS:
+            for item in shapes.values():
+                item.rotation -= 20
+        elif symbol == pyglet.window.key.EQUAL:
+            for item in shapes.values():
+                item.rotation += 20
+
+    @window.event
+    def on_mouse_drag(x, y, dx, dy, buttons, modifiers):
+        if buttons == pyglet.window.mouse.LEFT:
+            for item in itertools.chain(shapes.values(), labels.values()):
+                item_x, item_y, *item_z = item.position
+                item.position = item_x + dx, item_y + dy, *item_z
+
+    # This line is crucial for 2.1 / the development branch
+    pyglet.clock.schedule_interval(window.draw, 1 / 60)
+    pyglet.app.run()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Partially addresses #888 

EDIT:  This behavior is left unaddressed, but I didn't intend to fix it in this PR:

> As bestos: so the position works as rotation center and anchor as rotation offset

[Video link](https://discord.com/channels/438622377094414346/463526340168122368/1146295218824548402)

### Changes

1. Add `_rotation` class attribute and `rotation` property to `ShapeBase`
2. Remove `rotation` property from shapes
3. Add top-level new rotation value unit test fixture
4. Add tests for rotation value on shape `__init__`, skipping `Line`
5. Add tests for rotation property setter on all shapes
6. Add shape rotation  & translation visualization utility

### How to test

1. `pytest -k tests/unit`
2. Run `examples/graphics/shapes.py` and look for issues
2. Run `tools/shape_rotation_and_translation_spot_check.py` and interact with it, expecting the following issues:
    1. Shapes default to rotating around their lower left corner
    2. The following exceptions rotate around their centers: star, circle, ellipse, sector, and arc
    3. Beziers and Polygons have broken position properties and "teleport" toward the origin due to ignoring `_x` and _`y`
    4. Line sets its initial rotation value from the slope between the points

### Remaining tasks for this PR
- [x] Update `ShapeBase.rotation` per [Ben's comment](https://github.com/pyglet/pyglet/pull/943#discussion_r1319259653)
- [ ] Add interactive rotation tests iterating over shape classes
     - [ ] Add base interactive unit test for rotation
     - [ ] Figure out if fixtures should be re-used
     - [ ] Present context information for each shape:
          - [ ] "add some additional information to the test, such as explaining the default anchor point under the name. Just an idea, but something like: (anchor=center) or (anchor=bottom left) or (anchor=first vertex)."
          - [ ] Display info about rotation before test action is triggered
- [ ] Clean up visualization utility
     - [ ] Docstring at top of file
     - [ ] Clean up other docstrings
     - [ ] Spacing double check / linter run
     - [ ] Update [gist](https://gist.github.com/pushfoo/6102cc93713b1f6b9c95467aa76d3a61)

### Follow-up work (not yet assigned)

1. Resolve [the dilemma](https://github.com/pyglet/pyglet/issues/888#issuecomment-1704288681) over how to handle a future `rotation` keyword for `Line`
2. Resolve general shape argument / anchor issues
3. https://github.com/pyglet/pyglet/issues/946