### PR TITLE
Check Homebrew for common libraries on macOS

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -100,6 +100,9 @@ if getattr(sys, 'frozen', None):
 #:     to True by default.
 #:
 #:     .. versionadded:: 1.2
+#: brew_library_path
+#:     If set, pyglet will check this directory rather than the default for
+#:     Homebrew installed libraries on macOS.  Use at your own risk.
 #:
 options = {
     'audio': ('xaudio2', 'directsound', 'openal', 'pulse', 'silent'),
@@ -124,6 +127,7 @@ options = {
     'xsync': True,
     'xlib_fullscreen_override_redirect': False,
     'search_local_libs': True,
+    'brew_library_path': '/opt/homebrew/lib',
     'win32_gdi_font': False,
     'headless': False,
     'headless_device': 0,
@@ -157,6 +161,7 @@ _option_types = {
     'xsync': bool,
     'xlib_fullscreen_override_redirect': bool,
     'search_local_libs': bool,
+    'brew_library_path': str,
     'win32_gdi_font': bool,
     'headless': bool,
     'headless_device': int,
@@ -166,6 +171,8 @@ _option_types = {
     'com_mta': bool,
     'osx_alt_loop': bool,
 }
+
+_option_dflts = dict(options)
 
 
 for key in options:
@@ -180,6 +187,8 @@ for key in options:
             options[key] = value in ('true', 'TRUE', 'True', '1')
         elif _option_types[key] is int:
             options[key] = int(value)
+        elif _option_types[key] is str:
+            options[key] = str(value)
     except KeyError:
         pass
 

--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -79,8 +79,8 @@ class LibraryLoader:
         platform = 'win32'
 
     def load_library(self, *names, **kwargs):
-        """Find and load a library.  
-        
+        """Find and load a library.
+
         More than one name can be specified, they will be tried in order.
         Platform-specific library names (given as kwargs) are tried first.
 
@@ -164,6 +164,9 @@ class MachOLibraryLoader(LibraryLoader):
         else:
             self.dyld_fallback_library_path = [os.path.expanduser('~/lib'), '/usr/local/lib', '/usr/lib']
 
+        # check homebrew for libs too
+        self.brew_library_path = ['/opt/homebrew/lib']
+
     def find_library(self, path):
         """Implements the dylib search as specified in Apple documentation:
 
@@ -205,11 +208,13 @@ class MachOLibraryLoader(LibraryLoader):
             search_path.extend([os.path.join(p, libname) for p in self.dyld_library_path])
             search_path.append(path)
             search_path.extend([os.path.join(p, libname) for p in self.dyld_fallback_library_path])
+            search_path.extend([os.path.join(p, libname) for p in self.brew_library_path])
         else:
             search_path.extend([os.path.join(p, libname) for p in self.ld_library_path])
             search_path.extend([os.path.join(p, libname) for p in self.dyld_library_path])
             search_path.append(path)
             search_path.extend([os.path.join(p, libname) for p in self.dyld_fallback_library_path])
+            search_path.extend([os.path.join(p, libname) for p in self.brew_library_path])
 
         for path in search_path:
             if os.path.exists(path):

--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -11,6 +11,7 @@ import ctypes
 import ctypes.util
 
 import pyglet
+import warnings
 
 _debug_lib = pyglet.options['debug_lib']
 _debug_trace = pyglet.options['debug_trace']
@@ -26,6 +27,8 @@ if pyglet.options['search_local_libs']:
 else:
     _local_lib_paths = None
 
+if pyglet.options['brew_library_path'] != pyglet._option_dflts['brew_library_path']:
+    warnings.warn("Changing the default Homebrew library path is not recommended.  Use at your own risk.")
 
 class _TraceFunction:
     def __init__(self, func):
@@ -165,7 +168,7 @@ class MachOLibraryLoader(LibraryLoader):
             self.dyld_fallback_library_path = [os.path.expanduser('~/lib'), '/usr/local/lib', '/usr/lib']
 
         # check homebrew for libs too
-        self.brew_library_path = ['/opt/homebrew/lib']
+        self.brew_library_path = [pyglet.options['brew_library_path']]
 
     def find_library(self, path):
         """Implements the dylib search as specified in Apple documentation:


### PR DESCRIPTION
I don't know if this is the most optimal way of including the path, but some Mac users will have the libraries Pyglet can depend upon (like for audio) installed through Homebrew and they may not be caught through the existing library paths that are checked by default.