### PR TITLE
1.5: Fix coreaudio arg mismatch (+ brew check)

### DIFF
--- a/pyglet/lib.py
+++ b/pyglet/lib.py
@@ -113,8 +113,8 @@ class LibraryLoader:
         platform = 'win32'
 
     def load_library(self, *names, **kwargs):
-        """Find and load a library.  
-        
+        """Find and load a library.
+
         More than one name can be specified, they will be tried in order.
         Platform-specific library names (given as kwargs) are tried first.
 
@@ -198,6 +198,9 @@ class MachOLibraryLoader(LibraryLoader):
         else:
             self.dyld_fallback_library_path = [os.path.expanduser('~/lib'), '/usr/local/lib', '/usr/lib']
 
+        # check homebrew for libs too
+        self.brew_library_path = ['/opt/homebrew/lib']
+
     def find_library(self, path):
         """Implements the dylib search as specified in Apple documentation:
 
@@ -235,11 +238,13 @@ class MachOLibraryLoader(LibraryLoader):
             search_path.extend([os.path.join(p, libname) for p in self.dyld_library_path])
             search_path.append(path)
             search_path.extend([os.path.join(p, libname) for p in self.dyld_fallback_library_path])
+            search_path.extend([os.path.join(p, libname) for p in self.brew_library_path])
         else:
             search_path.extend([os.path.join(p, libname) for p in self.ld_library_path])
             search_path.extend([os.path.join(p, libname) for p in self.dyld_library_path])
             search_path.append(path)
             search_path.extend([os.path.join(p, libname) for p in self.dyld_fallback_library_path])
+            search_path.extend([os.path.join(p, libname) for p in self.brew_library_path])
 
         for path in search_path:
             if os.path.exists(path):

--- a/pyglet/media/codecs/coreaudio.py
+++ b/pyglet/media/codecs/coreaudio.py
@@ -170,7 +170,7 @@ class CoreAudioDecoder(MediaDecoder):
     def get_file_extensions(self):
         return '.aac', '.ac3', '.aif', '.aiff', '.aifc', '.caf', '.mp3', '.mp4', '.m4a', '.snd', '.au', '.sd2', '.wav'
 
-    def decode(self, filename, file, streaming=True):
+    def decode(self, file, filename, streaming=True):
         if streaming:
             return CoreAudioSource(filename, file)
         else:


### PR DESCRIPTION
This fixes a crash in the 1.5 branch that occurs when Pyglet tries to load the coreaudio media codec, and includes the open PR #954 for additional Mac support.