### PR TITLE
Warn about PulseAudio in the doc and rework related sections

### DIFF
--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -124,11 +124,26 @@ support hardware audio mixing or surround sound.
 OpenAL
 ^^^^^^
 
-OpenAL is included with Mac OS X. Windows users can download a generic
-driver from either `openal.org`_ or their sound device's manufacturer.
+By default, this is the most preferred driver. It will be used first
+if it is installed unless overridden. See :ref:`guide-audio-driver-order`
+to learn more.
 
-If a Linux distribution does not come with OpenAL pre-installed, it can
-usually be installed through the package manager.
+It is the best target for cross-platform consistency due to being either
+preinstalled or easy to install on all supported platforms. It implements
+software versions of common game audio features such as positional mixing
+on platforms which may not support them by default.
+
+OpenAL's main downside is that platforms other than Mac OS X are not
+guaranteed to have it preinstalled.
+
+Windows users can download a generic driver from either `openal.org`_
+or their sound device's manufacturer.
+
+On Linux, it may already be installed. It is strongly recommended to
+install it since the :ref:`guide-pulseaudio` backend has serious bugs
+and limitations. The commands to install OpenAL on the most common
+Linux distros are listed below. You may need to use ``sudo`` to run
+them.
 
 .. list-table::
     :header-rows: 1
@@ -145,7 +160,12 @@ usually be installed through the package manager.
     * - Fedora, Nobara
       - ``dnf install openal-soft``
 
-OpenAL does not appear to have a package on recent versions of RHEL.
+These commands should be safe to run when OpenAL is already
+installed. You will be informed the package is already installed
+if this is the case, and no action will take place.
+
+Note that OpenAL does not appear to have a package on recent versions of
+RHEL.
 
 .. _guide-pulseaudio:
 

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -194,14 +194,14 @@ occurs:
 It is not known to be affected by whether the PulseAudio implementation
 is the stand-alone or PipeWire compatibility layer.
 
-Do not expect the bug to be fixed quickly for multiple reasons:
+Consider the following when deciding whether to use this back-end:
 
 #. :ref:`guide-openal` is better in almost every way
-#. It unpleasant to fix because it appears to be a concurrency problem.
-   See the `original github issue <https://github.com/pyglet/pyglet/issues/952>`_
-   and discussion below it for more information.
+#. The `current understanding <https://github.com/pyglet/pyglet/issues/952>`_
+   of the bug is that is may be a concurrency issue, and therefore
+   inherently unpredictable
 #. PulseAudio is on its way to being replaced by PipeWire, so replacing
-   this driver may be a better use of developer time than fixing it.
+   this driver may be a better use of developer time than fixing it
 
 Missing features
 """"""""""""""""

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -24,10 +24,15 @@ small number of short sounds, in which case those applications need not distribu
 Audio drivers
 -------------
 
-pyglet can use OpenAL, XAudio2, DirectSound, or Pulseaudio to play back audio. Only one
-of these drivers can be used in an application. In most cases you won't need
-to concern yourself with choosing a driver, but you can manually select one if
-desired. This must be done before the :py:mod:`pyglet.media` module is loaded.
+pyglet can use OpenAL, XAudio2, DirectSound, or PulseAudio to play
+sound. Only one driver can be used at a time, but the selection can
+be changed by altering the configuration and restarting the program.
+
+The default driver preference order works well for most users. However,
+you may override it by setting a different preference sequence before
+the :py:mod:`pyglet.media` module is loaded. See
+:ref:`guide-audio-driver-order` to learn more.
+
 The available drivers depend on your operating system:
 
     .. list-table::
@@ -53,10 +58,17 @@ The available drivers depend on your operating system:
 .. [#openalf] OpenAL does not come preinstalled on Windows and some
      Linux distributions.
 
-The :mod:`pyglet.media` module reads the value for the ``'audio'`` key
-in :py:data:`pyglet.options`. It will try each entry until it either
-finds a working driver or runs out of entries. For example, the default
-is equivalent to setting the following value::
+.. _guide-audio-driver-order:
+
+Choosing the audio driver
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :mod:`pyglet.media` module reads the order of audio drivers to try
+from the value for the ``'audio'`` key in :py:data:`pyglet.options`. It
+will try each entry from first to last until it either finds a working
+driver or runs out of entries.
+
+For example, the default is equivalent to setting the following value::
 
     pyglet.options['audio'] = ('openal', 'pulse', 'xaudio2', 'directsound', 'silent')
 

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -135,16 +135,49 @@ usually be installed through the package manager.
 PulseAudio
 ^^^^^^^^^^
 
-Although a PulseAudio implementation is usually installed on modern
-Linux systems, the :ref:`guide-openal` driver is recommended instead.
-This is because:
+.. warning:: Install and use :ref:`guide-openal` instead of this driver
+             whenever possible!
 
-1. The pyglet PulseAudio driver has bugs which can crash games (see this
-   `github issue <https://github.com/pyglet/pyglet/issues/952>`_
-   for more information)
+Although most modern Linux distributions support PulseAudio, this pyglet
+driver has serious downsides:
 
-2. PulseAudio is limited to only plain stereo audio and does not support
-   spatial audio and other features
+#. It contains a bug which can crash your program
+#. PulseAudio lacks built-in support for standard game audio features
+
+The bug
+"""""""
+
+The bug is known to crash programs when one or more of the following
+occurs:
+
+#. A debugger pauses or resumes the program
+#. Unpredictably when 2 or more sounds are playing
+
+It is not known to be affected by whether the PulseAudio implementation
+is the stand-alone or PipeWire compatibility layer.
+
+Do not expect the bug to be fixed quickly for multiple reasons:
+
+#. :ref:`guide-openal` is better in almost every way
+#. It unpleasant to fix because it appears to be a concurrency problem.
+   See the `original github issue <https://github.com/pyglet/pyglet/issues/952>`_
+   and discussion below it for more information.
+#. PulseAudio is on its way to being replaced by PipeWire, so replacing
+   this driver may be a better use of developer time than fixing it.
+
+Missing features
+""""""""""""""""
+
+PulseAudio was designed with only desktop computer workloads in mind.
+This means it lacks built-in support for common features such as spatial
+audio mixing. The following features will not work properly with this
+driver:
+
+#. Changing the volume between individual speakers or earbuds based on
+   the position of the sound source relative to the listener
+#. Integration with surround sound
+
+Switching to :ref:`guide-openal` should automatically enable them.
 
 Supported media types
 ---------------------

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -63,12 +63,12 @@ The available drivers depend on your operating system:
 Choosing the audio driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :mod:`pyglet.media` module reads the order of audio drivers to try
-from the value for the ``'audio'`` key in :py:data:`pyglet.options`. It
-will try each entry from first to last until it either finds a working
-driver or runs out of entries.
+The ``'audio'`` key of :py:data:`pyglet.options` specifies the preference
+order for audio drivers.
 
-For example, the default is equivalent to setting the following value::
+On import, the :mod:`pyglet.media` will try each entry from first to
+last until it either finds a working driver or runs out of entries. For
+example, the default is equivalent to setting the following value::
 
     pyglet.options['audio'] = ('openal', 'pulse', 'xaudio2', 'directsound', 'silent')
 

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -206,10 +206,9 @@ Consider the following when deciding whether to use this back-end:
 Missing features
 """"""""""""""""
 
-PulseAudio was designed with only desktop computer workloads in mind.
-This means it lacks built-in support for common features such as spatial
-audio mixing. The following features will not work properly with this
-driver:
+Although PulseAudio can theoretically support advanced multi-channel
+audio, the pyglet back-end does not. The following features will not
+work properly with this driver:
 
 #. Changing the volume between individual speakers or earbuds based on
    the position of the sound source relative to the listener

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -2,7 +2,7 @@ Playing Sound and Video
 =======================
 
 pyglet can play many audio and video formats. Audio is played back with
-either OpenAL, XAudio2, DirectSound, or Pulseaudio, permitting hardware-accelerated
+either OpenAL, XAudio2, DirectSound, or PulseAudio, permitting hardware-accelerated
 mixing and surround-sound 3D positioning. Video is played into OpenGL
 textures, and so can be easily manipulated in real-time by applications
 and incorporated into 3D environments.

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -176,48 +176,62 @@ command. Consult your distro's documentation for more information.
 PulseAudio
 ^^^^^^^^^^
 
-.. warning:: Install and use :ref:`guide-openal` instead of this driver
-             whenever possible!
+The backend for this driver is nearly universally supported.
 
-Although most modern Linux distributions support PulseAudio, this pyglet
-driver has serious downsides:
+Even distros using PipeWire often come with a PulseAudio compatibility
+layer preinstalled. If this driver fails to initialize, consult your
+distro's documentation to learn which audio back-ends you can install.
 
-#. It contains a bug which can crash your program
-#. PulseAudio lacks built-in support for standard game audio features
+This driver has the following downsides:
 
-The bug
-"""""""
-
-The bug is known to crash programs when one or more of the following
-occurs:
-
-#. A debugger pauses or resumes the program
-#. Unpredictably when 2 or more sounds are playing
-
-It is not known to be affected by whether the PulseAudio implementation
-is the stand-alone or PipeWire compatibility layer.
-
-Consider the following when deciding whether to use this back-end:
-
-#. :ref:`guide-openal` is better in almost every way
-#. The `current understanding <https://github.com/pyglet/pyglet/issues/952>`_
-   of the bug is that is may be a concurrency issue, and therefore
-   inherently unpredictable
-#. PulseAudio is on its way to being replaced by PipeWire, so replacing
-   this driver may be a better use of developer time than fixing it
+#. Limited features compared to other drivers
+#. A bug which can crash your program under certain conditions.
 
 Missing features
 """"""""""""""""
 
 Although PulseAudio can theoretically support advanced multi-channel
-audio, the pyglet back-end does not. The following features will not
-work properly with this driver:
+audio, the pyglet driver does not. The following features will not
+work properly:
 
-#. Changing the volume between individual speakers or earbuds based on
-   the position of the sound source relative to the listener
+#. Positional audio: automatically changing the volume for individual
+   audio channels based on the position of the sound source
 #. Integration with surround sound
 
 Switching to :ref:`guide-openal` should automatically enable them.
+
+The bug
+"""""""
+
+.. _pulse-bug: https://github.com/pyglet/pyglet/issues/952
+
+The driver will initialize correctly, but pyglet will crash
+during execution.
+
+The traceback will contain a message like the one below:
+
+.. code-block:: console
+
+   Assertion 'q->front' failed at pulsecore/queue.c:81, function pa_queue_push(). Aborting.
+
+The following conditions can trigger the crash:
+
+#. A debugger paused or resumed the program while audio is playing
+#. Unpredictably when 2 or more sounds are playing
+
+The easiest fix is installing :ref:`installing OpenAL <guide-openal>`
+and restarting the program.
+
+See `the GitHub issue <pulse-bug_>`_ for more information. The following
+are currently unclear:
+
+#. How different PulseAudio implementations affect the bug (PipeWire vs original)
+#. How often the bug occurs for users on less common distros
+#. Its full details; it is believed to be an unpredictable
+   `concurrency issue involving locks <https://github.com/pyglet/pyglet/issues/952#issuecomment-1716821550>`_.
+#. Whether it is worth fixing; the workarounds are easy and PulseAudio
+   is being replaced by PipeWire.
+
 
 Supported media types
 ---------------------

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -132,8 +132,8 @@ usually be installed through the package manager.
 
 .. _guide-pulseaudio:
 
-Pulse
-^^^^^
+PulseAudio
+^^^^^^^^^^
 
 Although a PulseAudio implementation is usually installed on modern
 Linux systems, the :ref:`guide-openal` driver is recommended instead.

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -70,15 +70,20 @@ On import, the :mod:`pyglet.media` will try each entry from first to
 last until it either finds a working driver or runs out of entries. For
 example, the default is equivalent to setting the following value::
 
+   pyglet.options['audio'] = ('xaudio2', 'directsound', 'openal', 'pulse', 'silent')
+
+You can also set a custom preference order. For example, we could add
+this line before importing the media module::
+
     pyglet.options['audio'] = ('openal', 'pulse', 'xaudio2', 'directsound', 'silent')
 
-This tells pyglet to try using the OpenAL driver first. If is not
+It tells pyglet to try using the OpenAL driver first. If is not
 available,  try Pulseaudio, XAudio2, and DirectSound in that order.
 If all else fails, no driver will be instantiated and the game will
 run silently.
 
-You can override the default order of the ``'audio'`` key with your own
-list or tuple which contains one or more of the following values:
+The value for the ``'audio'`` key can be a list or tuple which contains
+one or more of the following strings:
 
     .. list-table::
         :header-rows: 1

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -51,9 +51,8 @@ The available drivers depend on your operating system:
           -
           - PulseAudio [#pulseaudiof]_
 
-.. [#pulseaudiof] PulseAudio support is buggy; using OpenAL
-     is recommended as a workaround. See the :ref:`guide-pulseaudio`
-     section below for install instructions.
+.. [#pulseaudiof] The :ref:`guide-pulseaudio` driver has limitations.
+     For audio-intensive programs, consider using :ref:`guide-openal`.
 
 .. [#openalf] OpenAL does not come preinstalled on Windows and some
      Linux distributions.

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -46,8 +46,14 @@ The available drivers depend on your operating system:
           -
           - Pulseaudio
 
-The audio driver can be set through the ``audio`` key of the
-:py:data:`pyglet.options` dictionary. For example::
+.. [#openalf] OpenAL does not come preinstalled on Windows and some
+     Linux distributions. See the :ref:`guide-openal` section below
+     for install instructions.
+
+The :mod:`pyglet.media` module reads the value for the ``'audio'`` key
+in :py:data:`pyglet.options`. It will try each entry until it either
+finds a working driver or runs out of entries. For example, the default
+is equivalent to setting the following value::
 
     pyglet.options['audio'] = ('openal', 'pulse', 'xaudio2', 'directsound', 'silent')
 
@@ -95,13 +101,32 @@ DirectSound is available only on Windows, and is installed by default.
 pyglet uses only DirectX 7 features. On Windows Vista, DirectSound does not
 support hardware audio mixing or surround sound.
 
+.. _guide-openal:
+
 OpenAL
 ^^^^^^
 
-OpenAL is included with Mac OS X. Windows users can download a generic driver
-from `openal.org`_, or from their sound device's manufacturer. Most Linux
-distributions will have OpenAL available in the repositories for download.
-For example, Arch users can ``pacman -S openal`` and Ubuntu users can ``apt install libopenal1``.
+OpenAL is included with Mac OS X. Windows users can download a generic
+driver from either `openal.org`_ or their sound device's manufacturer.
+
+If a Linux distribution does not come with OpenAL pre-installed, it can
+usually be installed through the package manager.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Common Linux Distros
+      - Install Command
+
+    * - Ubuntu, Pop!_OS, Debian
+      - ``apt install libopenal1``
+
+    * - Arch, Manjaro
+      - ``pacman -S openal``
+
+    * - Fedora, Nobara
+      - ``dnf install openal-soft``
+
 
 Pulse
 ^^^^^
@@ -110,10 +135,6 @@ Pulseaudio can also be used directly on Linux, and is installed by default
 with most modern Linux distributions. Pulseaudio does not support positional
 audio, and is limited to stereo. It is recommended to use OpenAL if positional
 audio is required.
-
-.. [#openalf] OpenAL is not installed by default on Windows, nor in many Linux
-    distributions. It can be downloaded separately from your audio device
-    manufacturer or `openal.org <https://www.openal.org/downloads>`_
 
 Supported media types
 ---------------------

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -161,12 +161,6 @@ them.
     * - Fedora, Nobara
       - ``dnf install openal-soft``
 
-These commands should be safe to run when OpenAL is already
-installed. You will be informed the package is already installed
-if this is the case, and no action will take place.
-
-Note that OpenAL does not appear to have a package on recent versions of
-RHEL.
 
 .. _guide-pulseaudio:
 

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -142,6 +142,8 @@ usually be installed through the package manager.
     * - Fedora, Nobara
       - ``dnf install openal-soft``
 
+OpenAL does not appear to have a package on recent versions of RHEL.
+
 .. _guide-pulseaudio:
 
 PulseAudio

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -46,13 +46,12 @@ The available drivers depend on your operating system:
           -
           - PulseAudio [#pulseaudiof]_
 
-.. [#pulseaudiof] PulseAudio support is currently buggy. Installing
-     OpenAL is recommended as a workaround. See the
-     :ref:`guide-pulseaudio` section below to learn more.
+.. [#pulseaudiof] PulseAudio support is buggy; using OpenAL
+     is recommended as a workaround. See the :ref:`guide-pulseaudio`
+     section below for install instructions.
 
 .. [#openalf] OpenAL does not come preinstalled on Windows and some
-     Linux distributions. See the :ref:`guide-openal` section below
-     for install instructions.
+     Linux distributions.
 
 The :mod:`pyglet.media` module reads the value for the ``'audio'`` key
 in :py:data:`pyglet.options`. It will try each entry until it either

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -63,8 +63,8 @@ The available drivers depend on your operating system:
 Choosing the audio driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``'audio'`` key of :py:data:`pyglet.options` specifies the preference
-order for audio drivers.
+The ``'audio'`` key of the :py:data:`pyglet.options` dictionary
+specifies the audio driver preference order.
 
 On import, the :mod:`pyglet.media` will try each entry from first to
 last until it either finds a working driver or runs out of entries. For
@@ -72,10 +72,13 @@ example, the default is equivalent to setting the following value::
 
     pyglet.options['audio'] = ('openal', 'pulse', 'xaudio2', 'directsound', 'silent')
 
-This tells pyglet to try using the OpenAL driver first, and if not available
-to try Pulseaudio, XAudio2 and DirectSound in that order. If all else fails,
-no driver will be instantiated. The ``audio`` option can be a list of any of these
-strings, giving the preference order for each driver:
+This tells pyglet to try using the OpenAL driver first. If is not
+available,  try Pulseaudio, XAudio2, and DirectSound in that order.
+If all else fails, no driver will be instantiated and the game will
+run silently.
+
+You can override the default order of the ``'audio'`` key with your own
+list or tuple which contains one or more of the following values:
 
     .. list-table::
         :header-rows: 1
@@ -93,8 +96,8 @@ strings, giving the preference order for each driver:
         * - ``'silent'``
           - No audio output
 
-You must set the ``audio`` option before importing :mod:`pyglet.media`.
-You  can alternatively set it through an environment variable;
+You must set any custom ``'audio'`` preference order before importing
+:mod:`pyglet.media`. This can also be set through an environment variable;
 see :ref:`guide_environment-settings`.
 
 The following sections describe the requirements and limitations of each audio

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -71,15 +71,15 @@ strings, giving the preference order for each driver:
 
         * - String
           - Audio driver
-        * - ``openal``
+        * - ``'openal'``
           - OpenAL
-        * - ``directsound``
+        * - ``'directsound'``
           - DirectSound
-        * - ``xaudio2``
+        * - ``'xaudio2'``
           - XAudio2
-        * - ``pulse``
-          - Pulseaudio
-        * - ``silent``
+        * - ``'pulse'``
+          - PulseAudio
+        * - ``'silent'``
           - No audio output
 
 You must set the ``audio`` option before importing :mod:`pyglet.media`.

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -108,14 +108,18 @@ see :ref:`guide_environment-settings`.
 The following sections describe the requirements and limitations of each audio
 driver.
 
+.. _guide-xaudio2:
+
 XAudio2
-^^^^^^^^^^^
+^^^^^^^
 XAudio2 is only available on Windows Vista and above and is the replacement of
 DirectSound. This provides hardware accelerated audio support for newer operating
 systems.
 
 Note that in some stripped down versions of Windows 10, XAudio2 may not be available
 until the required DLL's are installed.
+
+.. _guide-directsound:
 
 DirectSound
 ^^^^^^^^^^^
@@ -129,29 +133,31 @@ support hardware audio mixing or surround sound.
 OpenAL
 ^^^^^^
 
-By default, this is the first driver expected to load on POSIX systems.
-See :ref:`guide-audio-driver-order` to learn about overriding the driver
-preference order.
+The favored driver for Mac OS X, but also available on other systems.
 
 This driver has the following advantages:
 
-* It's either preinstalled or easy to install on supported platforms.
-* It implements features which may be absent from other drivers or
+* Either preinstalled or easy to install on supported platforms.
+* Implements features which may be absent from other drivers or
   OS-specific versions of their backing APIs.
 
-Its main downside is that platforms other than Mac OS X are not
-guaranteed to have it preinstalled.
+Its main downsides are:
+
+* Not guaranteed to be installed on platforms other than Mac OS X
+* On recent Windows versions, the :ref:`guide-xaudio2` and
+  :ref:`guide-directsound` backends may support more features.
 
 Windows users can download an OpenAL implementation from `openal.org`_
 or their sound device's manufacturer.
 
 On Linux, the following apply:
 
+* It can usually be installed through your distro's package manager.
 * It may already be installed as a dependency of other packages.
 * It lacks the limitations of the :ref:`guide-pulseaudio` driver.
 
-The commands to install OpenAL on the most common Linux distros are
-listed below.
+The commands below should install OpenAL on the most common Linux
+distros:
 
 .. list-table::
     :header-rows: 1

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -124,27 +124,29 @@ support hardware audio mixing or surround sound.
 OpenAL
 ^^^^^^
 
-By default, this is the most preferred driver. It will be used first
-if it is installed unless overridden. See :ref:`guide-audio-driver-order`
-to learn more.
+By default, this is the first driver expected to load on POSIX systems.
+See :ref:`guide-audio-driver-order` to learn about overriding the driver
+preference order.
 
-This driver is currently the best choice for POSIX systems because:
+This driver has the following advantages:
 
-* It's either preinstalled or easy to install.
-* It implements features which may be absent from OS-specific APIs,
-  such as positional audio
+* It's either preinstalled or easy to install on supported platforms.
+* It implements features which may be absent from other drivers or
+  OS-specific versions of their backing APIs.
 
-OpenAL's main downside is that platforms other than Mac OS X are not
+Its main downside is that platforms other than Mac OS X are not
 guaranteed to have it preinstalled.
 
-Windows users can download a generic driver from either `openal.org`_
+Windows users can download an OpenAL implementation from `openal.org`_
 or their sound device's manufacturer.
 
-On Linux, it may already be installed. It is strongly recommended to
-install it since the :ref:`guide-pulseaudio` backend has serious bugs
-and limitations. The commands to install OpenAL on the most common
-Linux distros are listed below. You may need to use ``sudo`` to run
-them.
+On Linux, the following apply:
+
+* It may already be installed as a dependency of other packages.
+* It lacks the limitations of the :ref:`guide-pulseaudio` driver.
+
+The commands to install OpenAL on the most common Linux distros are
+listed below.
 
 .. list-table::
     :header-rows: 1
@@ -161,6 +163,8 @@ them.
     * - Fedora, Nobara
       - ``dnf install openal-soft``
 
+You may need to prefix these commands with either ``sudo`` or another
+command. Consult your distro's documentation for more information.
 
 .. _guide-pulseaudio:
 

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -128,10 +128,11 @@ By default, this is the most preferred driver. It will be used first
 if it is installed unless overridden. See :ref:`guide-audio-driver-order`
 to learn more.
 
-It is the best target for cross-platform consistency due to being either
-preinstalled or easy to install on all supported platforms. It implements
-software versions of common game audio features such as positional mixing
-on platforms which may not support them by default.
+This driver is currently the best choice for POSIX systems because:
+
+* It's either preinstalled or easy to install.
+* It implements features which may be absent from OS-specific APIs,
+  such as positional audio
 
 OpenAL's main downside is that platforms other than Mac OS X are not
 guaranteed to have it preinstalled.

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -44,7 +44,11 @@ The available drivers depend on your operating system:
           -
         * - XAudio2
           -
-          - Pulseaudio
+          - PulseAudio [#pulseaudiof]_
+
+.. [#pulseaudiof] PulseAudio support is currently buggy. Installing
+     OpenAL is recommended as a workaround. See the
+     :ref:`guide-pulseaudio` section below to learn more.
 
 .. [#openalf] OpenAL does not come preinstalled on Windows and some
      Linux distributions. See the :ref:`guide-openal` section below
@@ -127,14 +131,21 @@ usually be installed through the package manager.
     * - Fedora, Nobara
       - ``dnf install openal-soft``
 
+.. _guide-pulseaudio:
 
 Pulse
 ^^^^^
 
-Pulseaudio can also be used directly on Linux, and is installed by default
-with most modern Linux distributions. Pulseaudio does not support positional
-audio, and is limited to stereo. It is recommended to use OpenAL if positional
-audio is required.
+Although a PulseAudio implementation is usually installed on modern
+Linux systems, the :ref:`guide-openal` driver is recommended instead.
+This is because:
+
+1. The pyglet PulseAudio driver has bugs which can crash games (see this
+   `github issue <https://github.com/pyglet/pyglet/issues/952>`_
+   for more information)
+
+2. PulseAudio is limited to only plain stereo audio and does not support
+   spatial audio and other features
 
 Supported media types
 ---------------------

--- a/doc/programming_guide/quickstart.rst
+++ b/doc/programming_guide/quickstart.rst
@@ -161,6 +161,16 @@ An example program using keyboard and mouse events is in
 Playing sounds and music
 ------------------------
 
+.. note::
+
+   Linux users should make sure they have OpenAL installed.
+
+   1. It prevents crashes from a PulseAudio-related bug
+   2. It automatically enables 2D and 3D surround sound
+
+   See the :ref:`guide-pulseaudio` and :ref:`guide-openal` sections for
+   more information.
+
 pyglet makes it easy to play and mix multiple sounds together.
 The following example plays an MP3 file [#mp3]_::
 

--- a/doc/programming_guide/quickstart.rst
+++ b/doc/programming_guide/quickstart.rst
@@ -161,16 +161,6 @@ An example program using keyboard and mouse events is in
 Playing sounds and music
 ------------------------
 
-.. note::
-
-   Linux users should make sure they have OpenAL installed.
-
-   1. It prevents crashes from a PulseAudio-related bug
-   2. It automatically enables 2D and 3D surround sound
-
-   See the :ref:`guide-pulseaudio` and :ref:`guide-openal` sections for
-   more information.
-
 pyglet makes it easy to play and mix multiple sounds together.
 The following example plays an MP3 file [#mp3]_::
 
@@ -200,8 +190,14 @@ The `examples/media_player.py` example demonstrates playback of streaming
 audio and video using pyglet.  The `examples/noisy/noisy.py` example
 demonstrates playing many short audio samples simultaneously, as in a game.
 
+.. note:: Linux users may want to install OpenAL.
+
+   See the :ref:`guide-pulseaudio` and :ref:`guide-openal` sections for
+   more information.
+
 .. [#mp3] MP3 and other compressed audio formats require FFmpeg to be installed.
           Uncompressed WAV files can be played without FFmpeg.
+
 
 Where to next?
 --------------

--- a/doc/programming_guide/quickstart.rst
+++ b/doc/programming_guide/quickstart.rst
@@ -190,11 +190,6 @@ The `examples/media_player.py` example demonstrates playback of streaming
 audio and video using pyglet.  The `examples/noisy/noisy.py` example
 demonstrates playing many short audio samples simultaneously, as in a game.
 
-.. note:: Linux users may want to install OpenAL.
-
-   See the :ref:`guide-pulseaudio` and :ref:`guide-openal` sections for
-   more information.
-
 .. [#mp3] MP3 and other compressed audio formats require FFmpeg to be installed.
           Uncompressed WAV files can be played without FFmpeg.
 

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -58,9 +58,9 @@ if getattr(sys, 'frozen', None):
 #:
 #:     * ``'xaudio2'``, the Windows Xaudio2 audio module (Windows only)
 #:     * ``'directsound'``, the Windows DirectSound audio module (Windows only)
-#:     * ``'pulse'``, the PulseAudio module (Linux only, buggy, use
-#:       :ref:`guide-openal` if possible)
-#:     * ``'openal'``, the OpenAL audio module (A library may need to be
+#:     * ``'pulse'``, the :ref:`guide-pulseaudio` module (Linux only, otherwise
+#:       nearly ubiquitous. Limited features; use ``'openal'`` for more.)
+#:     * ``'openal'``, the :ref:`guide-openal` audio module (A library may need to be
 #:       installed on Windows and Linux)
 #:     * ``'silent'``, no audio
 #:

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -50,14 +50,20 @@ if getattr(sys, 'frozen', None):
 #: The non-development options are:
 #:
 #: audio
-#:     A sequence of the names of audio modules to attempt to load, in
-#:     order of preference.  Valid driver names are:
+#:     A :py:class:`~typing.Sequence` of valid audio modules names. They will
+#:     be tried from first to last until either a driver loads or no entries
+#:     remain. See :ref:`guide-audio-driver-order` for more information.
 #:
-#:     * xaudio2, the Windows Xaudio2 audio module (Windows only)
-#:     * directsound, the Windows DirectSound audio module (Windows only)
-#:     * pulse, the PulseAudio module (Linux only)
-#:     * openal, the OpenAL audio module
-#:     * silent, no audio
+#:     Valid driver names are:
+#:
+#:     * ``'xaudio2'``, the Windows Xaudio2 audio module (Windows only)
+#:     * ``'directsound'``, the Windows DirectSound audio module (Windows only)
+#:     * ``'pulse'``, the PulseAudio module (Linux only, buggy, use
+#:       :ref:`guide-openal` if possible)
+#:     * ``'openal'``, the OpenAL audio module (A library may need to be
+#:       installed on Windows and Linux)
+#:     * ``'silent'``, no audio
+#:
 #: debug_lib
 #:     If True, prints the path of each dynamic library loaded.
 #: debug_gl

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -31,8 +31,10 @@ _enable_optimisations = not __debug__
 if getattr(sys, 'frozen', None):
     _enable_optimisations = True
 
-#: Global dict of pyglet options.  To change an option from its default, you
-#: must import ``pyglet`` before any sub-packages.  For example::
+#: Global dict of pyglet options.
+#:
+#: To change an option from its default, you must import
+#: ``pyglet`` before any sub-packages.  For example::
 #:
 #:      import pyglet
 #:      pyglet.options['debug_gl'] = False


### PR DESCRIPTION
### Changes

1. Document the PulseAudio bug (#952) 
2. Add "Choosing audio drivers" heading
3. `%s/Pulseaudio/PulseAudio/g` and rename the Pulse heading to PulseAudio for consistency
4. Expand the PulseAudio section with better pros / cons + bug
5. Expand the OpenAL section with Linux install command examples and other info
6. Add link targets for relevant headings
7. Rearrange + add table footnotes for cleanliness
8. Link the new doc from the quickstart
9. Link the doc from `pyglet/__init__.py`s doc for the `options['audio']` key