### PR TITLE
Further incremental improvements to Qt example

### DIFF
--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -60,7 +60,7 @@ import argparse
 from pathlib import Path
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Final, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Final, Dict, List, Optional, Tuple, Mapping
 
 # Constants for choosing a Qt backend and summarizing their licensing
 ENV_VARIABLE: Final[str] = 'PYGLET_QT_BACKEND'
@@ -217,23 +217,30 @@ void main()
 
 
 class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
-    """A sprite group that uses multiple active textures.
-    """
+    """A sprite group which uses multiple textures and samplers."""
 
-    def __init__(self, textures, blend_src, blend_dest, program=None, parent=None):
+    def __init__(
+            self,
+            textures: Mapping[str, pyglet.image.Texture],
+            blend_src: int,
+            blend_dest: int,
+            program: Optional[pyglet.graphics.shader.ShaderProgram] = None,
+            parent: Optional[pyglet.graphics.Group] = None
+    ):
         """Create a sprite group for multiple textures and samplers.
-           All textures must share the same target type.
+
+        All textures must share the same target type.
 
         :Parameters:
-            `textures` : `dict`
-                Textures in samplername : texture.
-            `blend_src` : int
+            `textures` :
+                 A mapping of sampler names to texture data.
+            `blend_src` :
                 OpenGL blend source mode; for example,
                 ``GL_SRC_ALPHA``.
-            `blend_dest` : int
+            `blend_dest` :
                 OpenGL blend destination mode; for example,
                 ``GL_ONE_MINUS_SRC_ALPHA``.
-            `parent` : `~pyglet.graphics.Group`
+            `parent` :
                 Optional parent group.
         """
         self.images = textures

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -437,13 +437,18 @@ class Ui_MainWindow:
             self.program = pyglet.graphics.shader.ShaderProgram(vertex_, fragment_)
 
             if len(self.images) == 1:
-                self.sprite = pyglet.sprite.AdvancedSprite(self.images[0], x=self.SPRITE_POSITION[0],
-                                                           y=self.SPRITE_POSITION[1], group=self.group,
-                                                           batch=self.openGLWidget.batch, program=self.program)
+                self.sprite = pyglet.sprite.AdvancedSprite(
+                    self.images[0],
+                    x=self.SPRITE_POSITION[0], y=self.SPRITE_POSITION[1],
+                    group=self.group, batch=self.openGLWidget.batch,
+                    program=self.program)
             else:
                 textures = {image.shader_name: image.get_texture() for image in self.images}
-                self.sprite = MultiTextureSprite(textures, x=self.SPRITE_POSITION[0], y=self.SPRITE_POSITION[1],
-                                                 group=self.group, batch=self.openGLWidget.batch, program=self.program)
+                self.sprite = MultiTextureSprite(
+                    textures,
+                    x=self.SPRITE_POSITION[0], y=self.SPRITE_POSITION[1],
+                    group=self.group, batch=self.openGLWidget.batch,
+                    program=self.program)
 
             if self.program:
                 print("Successfully compiled shader.")

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -545,7 +545,7 @@ class Ui_MainWindow:
             vert_filename.write_text(self.vertex_source_edit.toPlainText())
             frag_filename.write_text(self.fragSourceEdit.toPlainText())
 
-    def removeImage(self, actionWidget) -> None:
+    def removeImage(self, actionWidget: QtWidgets.QAction) -> None:
         if self.imageMenu:
             self.imageMenu.removeAction(actionWidget)
 
@@ -565,7 +565,7 @@ class Ui_MainWindow:
     def closeProgram(self) -> None:
         app.exit()
 
-    def retranslateUi(self, MainWindow) -> None:
+    def retranslateUi(self, MainWindow: QtWidgets.QMainWindow) -> None:
         _translate = QtCore.QCoreApplication.translate
         MainWindow.setWindowTitle(_translate("MainWindow", "Sprite Shader Previewer"))
         self.label.setText(_translate("MainWindow", "Vertex Source:"))

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -336,7 +336,7 @@ class Ui_MainWindow:
 
         return options
 
-    def setupUi(self, MainWindow: QtWidgets.QMainWindow):
+    def setupUi(self, MainWindow: QtWidgets.QMainWindow) -> None:
         self._window = MainWindow
 
         # Set up the central window widget object
@@ -438,7 +438,7 @@ class Ui_MainWindow:
         self.retranslateUi(MainWindow)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
-    def compileClick(self):
+    def compileClick(self) -> None:
         if not self.images:
             print("No images have been loaded.")
             return
@@ -480,7 +480,7 @@ class Ui_MainWindow:
         except Exception as err:
             print("Unexpected error", err)
 
-    def loadImages(self):
+    def loadImages(self) -> None:
         options = self.get_file_dialog_options()
         fileNames, _ = QFileDialog.getOpenFileNames(
             self._window, "Select Image Files", "", "Image Files (*.png *.jpg *.jpeg *.bmp)",
@@ -503,7 +503,7 @@ class Ui_MainWindow:
             self.images.append(image)
             self.imageMenu.addAction(action)
 
-    def loadShaders(self):
+    def loadShaders(self) -> None:
         options = self.get_file_dialog_options()
         file_names, _ = QFileDialog.getOpenFileNames(
             self._window, "Load Shader Files", "", "Shader Files (*.vert *.frag *.txt)",
@@ -523,7 +523,7 @@ class Ui_MainWindow:
             text = file_path.read_text()
             dest.setText(text)
 
-    def saveShaders(self):
+    def saveShaders(self) -> None:
         options = self.get_file_dialog_options()
         file_name, _ = QFileDialog.getSaveFileName(
             self._window, "Saving Both Shader Files (vert and frag)", "",
@@ -537,7 +537,7 @@ class Ui_MainWindow:
             vert_filename.write_text(self.vertex_source_edit.toPlainText())
             frag_filename.write_text(self.fragSourceEdit.toPlainText())
 
-    def removeImage(self, actionWidget):
+    def removeImage(self, actionWidget) -> None:
         if self.imageMenu:
             self.imageMenu.removeAction(actionWidget)
 
@@ -554,10 +554,10 @@ class Ui_MainWindow:
             if len(self.images) == 0:
                 self.imageMenu.addAction(self.noImageAction)
 
-    def closeProgram(self):
+    def closeProgram(self) -> None:
         app.exit()
 
-    def retranslateUi(self, MainWindow):
+    def retranslateUi(self, MainWindow) -> None:
         _translate = QtCore.QCoreApplication.translate
         MainWindow.setWindowTitle(_translate("MainWindow", "Sprite Shader Previewer"))
         self.label.setText(_translate("MainWindow", "Vertex Source:"))

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -57,6 +57,7 @@ import os
 import sys
 import traceback
 import argparse
+from pathlib import Path
 
 from textwrap import dedent
 from typing import TYPE_CHECKING, Final, Dict, List, Optional
@@ -499,12 +500,14 @@ class Ui_MainWindow:
 
     def loadShaders(self):
         options = self.get_file_dialog_options()
-        fileNames, _ = QFileDialog.getOpenFileNames(
+        file_names, _ = QFileDialog.getOpenFileNames(
             self._window, "Load Shader Files", "", "Shader Files (*.vert *.frag *.txt)",
             options=options)
 
-        for fileName in fileNames:
-            ext = os.path.splitext(fileName)[1]
+        for file_name in file_names:
+            file_path = Path(file_name)
+            ext = file_path.suffixes[-1]
+
             if ext == '.vert':
                 dest = self.vertex_source_edit
             elif ext in ('.txt', '.frag'):
@@ -512,9 +515,8 @@ class Ui_MainWindow:
             else:
                 dest = self.fragSourceEdit
 
-            with open(fileName, 'r') as f:
-                text = f.read()
-                dest.setText(text)
+            text = file_path.read_text()
+            dest.setText(text)
 
     def saveShaders(self):
         options = self.get_file_dialog_options()

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -314,13 +314,21 @@ class MultiTextureSprite(pyglet.sprite.AdvancedSprite):
 class Ui_MainWindow:
     SPRITE_POSITION = (0, 0)
 
-    def __init__(self):
+    def __init__(self, use_native_file_dialog: bool = True):
+        self.use_native_file_dialog: bool = use_native_file_dialog
+
         self.images = []
 
         self.group = pyglet.graphics.Group()
 
         self.sprite = None
         self.program = None
+
+    def get_file_dialog_options(self):
+        options = QFileDialog.Options()
+        if not self.use_native_file_dialog:
+            options |= QFileDialog.DontUseNativeDialog
+        return options
 
     def setupUi(self, MainWindow: QtWidgets.QMainWindow):
         self._window = MainWindow
@@ -467,8 +475,7 @@ class Ui_MainWindow:
             print("Unexpected error", err)
 
     def loadImages(self):
-        options = QFileDialog.Options()
-        #options |= QFileDialog.DontUseNativeDialog
+        options = self.get_file_dialog_options()
         fileNames, _ = QFileDialog.getOpenFileNames(
             self._window, "Select Image Files", "", "Image Files (*.png *.jpg *.jpeg *.bmp)",
             options=options)
@@ -491,9 +498,7 @@ class Ui_MainWindow:
             self.imageMenu.addAction(action)
 
     def loadShaders(self):
-        options = QFileDialog.Options()
-
-        #options |= QFileDialog.DontUseNativeDialog
+        options = self.get_file_dialog_options()
         fileNames, _ = QFileDialog.getOpenFileNames(
             self._window, "Load Shader Files", "", "Shader Files (*.vert *.frag *.txt)",
             options=options)
@@ -512,9 +517,7 @@ class Ui_MainWindow:
                 dest.setText(text)
 
     def saveShaders(self):
-        options = QFileDialog.Options()
-
-        # options |= QFileDialog.DontUseNativeDialog
+        options = self.get_file_dialog_options()
         fileName, _ = QFileDialog.getSaveFileName(
             self._window, "Saving Both Shader Files (vert and frag)", "",
             options=options)

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -90,6 +90,15 @@ parser = argparse.ArgumentParser(
     '''),
     formatter_class=argparse.RawTextHelpFormatter)
 
+# On Python 3.9+, argparse.BooleanOptionalAction is more concise
+# See https://docs.python.org/3.9/library/argparse.html#action
+parser.add_argument(
+    '--use-qt-file-dialog', dest='native_file_dialog', action='store_false',
+    help="Use Qt's file chooser instead of the system's. Helpful on Gnome DE."
+)
+parser.set_defaults(native_file_dialog=True)
+
+
 # Generate options help text lines
 backend_column_width: Final[int] = max(map(len, valid_backends))
 help_lines: List[str] = ["Which Qt binding to use.\n"]
@@ -337,7 +346,12 @@ class Ui_MainWindow:
     def get_file_dialog_options(self) -> QFileDialog.Options:
         """Convert instance attributes to a file dialog options object.
 
-        You may want to expand on this in your own application.
+        At the moment, it supports choosing which dialog to use. This is
+        helpful on certain Gnome and tiling Linux desktop configurations
+        which can have issues with the system file picker.
+
+        You may want to expand on this in your own application with
+        additional options.
         """
         options = QFileDialog.Options()
         if not self.use_native_file_dialog:
@@ -747,7 +761,7 @@ def excepthook(exc_type, exc_value, exc_tb) -> None:
 if __name__ == "__main__":
     # Create the base Qt application and initialize the UI
     app = QtWidgets.QApplication(sys.argv)
-    ui = Ui_MainWindow()
+    ui = Ui_MainWindow(use_native_file_dialog=arguments.native_file_dialog)
     qt_window = QtWidgets.QMainWindow()
     ui.setupUi(qt_window)
     qt_window.show()

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -252,8 +252,8 @@ class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
         for idx, name in enumerate(self.images):
             try:
                 self.program[name] = idx
-            except Exception:
-                print(f"Uniform: {name} not found.")
+            except pyglet.graphics.shader.ShaderException as e:
+                print(e)
 
         self.program.stop()
 

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -397,7 +397,7 @@ class Ui_MainWindow:
 
         MainWindow.setCentralWidget(self.centralwidget)
 
-        # Set up the top menu
+        # Set up the root top menu & status bar
         self.menubar = QtWidgets.QMenuBar(MainWindow)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 820, 21))
         self.menubar.setObjectName("menubar")
@@ -408,6 +408,7 @@ class Ui_MainWindow:
         self.statusbar.setObjectName("statusbar")
         MainWindow.setStatusBar(self.statusbar)
 
+        # Add menu bar menus, entries, and hotkeys
         self.actionOpen_Image = QtWidgets.QAction(MainWindow)
         self.actionOpen_Image.setObjectName("actionOpen_Image")
         self.actionOpen_Image.triggered.connect(self.loadImages)

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -597,7 +597,7 @@ class PygletWidget(QOpenGLWidget):
         }
     """
 
-    def __init__(self, width, height, parent, mainWindow):
+    def __init__(self, width, height, parent, mainWindow) -> None:
         super().__init__(parent)
         self.mainWindow = mainWindow
         self.setMinimumSize(width, height)
@@ -687,7 +687,7 @@ class PygletWidget(QOpenGLWidget):
         return self._viewport
 
     @viewport.setter
-    def viewport(self, values: Tuple[int, int, int, int]):
+    def viewport(self, values: Tuple[int, int, int, int]) -> None:
         self._viewport = values
         pr = 1.0
         x, y, w, h = values
@@ -698,7 +698,7 @@ class PygletWidget(QOpenGLWidget):
         return self._projection_matrix
 
     @projection.setter
-    def projection(self, matrix: pyglet.math.Mat4):
+    def projection(self, matrix: pyglet.math.Mat4) -> None:
         with self.ubo as window_block:
             window_block.projection[:] = matrix
 
@@ -715,7 +715,7 @@ class PygletWidget(QOpenGLWidget):
         return self._view_matrix
 
     @view.setter
-    def view(self, matrix: pyglet.math.Mat4):
+    def view(self, matrix: pyglet.math.Mat4) -> None:
 
         with self.ubo as window_block:
             window_block.view[:] = matrix

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -722,7 +722,7 @@ class PygletWidget(QOpenGLWidget):
         self._view_matrix = matrix
 
 
-def excepthook(exc_type, exc_value, exc_tb):
+def excepthook(exc_type, exc_value, exc_tb) -> None:
     """Replacement for Python's default exception handler function.
 
     See the following for more information:

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -60,8 +60,7 @@ import argparse
 from pathlib import Path
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Final, Dict, List, Optional
-
+from typing import TYPE_CHECKING, Final, Dict, List, Optional, Tuple
 
 # Constants for choosing a Qt backend and summarizing their licensing
 ENV_VARIABLE: Final[str] = 'PYGLET_QT_BACKEND'
@@ -479,7 +478,6 @@ class Ui_MainWindow:
             print(f"Failed to compile shader: {err}")
         except Exception as err:
             print("Unexpected error", err)
-
     def loadImages(self) -> None:
         options = self.get_file_dialog_options()
         fileNames, _ = QFileDialog.getOpenFileNames(
@@ -615,7 +613,7 @@ class PygletWidget(QOpenGLWidget):
 
         pyglet.clock.schedule_interval(self.update_time_uniform, 1 / 60.0)
 
-    def wheelEvent(self, event: QWheelEvent):
+    def wheelEvent(self, event: QWheelEvent) -> None:
         super().wheelEvent(event)
         if event.angleDelta().y() > 0:
             self.zoom *= 2
@@ -627,7 +625,7 @@ class PygletWidget(QOpenGLWidget):
         self.view = pyglet.math.Mat4().scale((self.zoom, self.zoom, 1.0))
         event.accept()
 
-    def update_time_uniform(self, dt):
+    def update_time_uniform(self, dt: float) -> None:
         self.elapsed += dt
 
         if self.mainWindow.program:
@@ -641,25 +639,25 @@ class PygletWidget(QOpenGLWidget):
 
             self.mainWindow.program.stop()
 
-    def _pyglet_update(self):
+    def _pyglet_update(self) -> None:
         # Tick the pyglet clock, so scheduled events can work.
         pyglet.clock.tick()
 
         # Force widget to update, otherwise paintGL will not be called.
         self.update()  # self.updateGL() for pyqt5
 
-    def paintGL(self):
+    def paintGL(self) -> None:
         """Pyglet equivalent of on_draw event for window"""
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
 
         self.batch.draw()
 
-    def resizeGL(self, width, height):
+    def resizeGL(self, width: int, height: int) -> None:
         self.projection = pyglet.math.Mat4.orthogonal_projection(0, width, 0, height, -255, 255)
 
         self.viewport = 0, 0, width, height
 
-    def initializeGL(self):
+    def initializeGL(self) -> None:
         """Call anything that needs a context to be created."""
 
         self._projection_matrix = pyglet.math.Mat4()
@@ -678,25 +676,24 @@ class PygletWidget(QOpenGLWidget):
         self.viewport = 0, 0, self.width(), self.height()
 
     @property
-    def viewport(self):
+    def viewport(self) -> Tuple[int, int, int, int]:
         """The Window viewport
 
         The Window viewport, expressed as (x, y, width, height).
 
-        :rtype: (int, int, int, int)
         :return: The viewport size as a tuple of four ints.
         """
         return self._viewport
 
     @viewport.setter
-    def viewport(self, values):
+    def viewport(self, values: Tuple[int, int, int, int]):
         self._viewport = values
         pr = 1.0
         x, y, w, h = values
         pyglet.gl.glViewport(int(x * pr), int(y * pr), int(w * pr), int(h * pr))
 
     @property
-    def projection(self):
+    def projection(self) -> pyglet.math.Mat4:
         return self._projection_matrix
 
     @projection.setter
@@ -707,14 +704,12 @@ class PygletWidget(QOpenGLWidget):
         self._projection_matrix = matrix
 
     @property
-    def view(self):
+    def view(self) -> pyglet.math.Mat4:
         """The OpenGL window view matrix. Read-write.
 
         The default view is an identity matrix, but a custom
         :py:class:`pyglet.math.Mat4` instance can be set.
         Alternatively, you can supply a flat tuple of 16 values.
-
-        :type: :py:class:`pyglet.math.Mat4`
         """
         return self._view_matrix
 

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -322,7 +322,7 @@ class Ui_MainWindow:
         self.sprite = None
         self.program = None
 
-    def setupUi(self, MainWindow):
+    def setupUi(self, MainWindow: QtWidgets.QMainWindow):
         self._window = MainWindow
 
         MainWindow.setObjectName("MainWindow")
@@ -709,12 +709,18 @@ def excepthook(exc_type, exc_value, exc_tb):
     tb = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
     print(tb)
 
-   
+
 if __name__ == "__main__":
+    # Create the base Qt application and initialize the UI
     app = QtWidgets.QApplication(sys.argv)
     ui = Ui_MainWindow()
+    qt_window = QtWidgets.QMainWindow()
+    ui.setupUi(qt_window)
+    qt_window.show()
+
+    # Replace the default exception handling *after* everything is
+    # initialized to avoid swallowing fatal errors such as GL issues.
     sys.excepthook = excepthook
-    window = QtWidgets.QMainWindow()
-    ui.setupUi(window)
-    window.show()
+
+    # Start the application and return its exit code
     sys.exit(app.exec_())

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -621,8 +621,9 @@ class PygletWidget(QOpenGLWidget):
             self.zoom /= 2
 
         self.zoom = pyglet.math.clamp(self.zoom, 0.125, 40.0)
+        self.view = pyglet.math.Mat4().scale(pyglet.math.Vec3(
+            self.zoom, self.zoom, 1.0))
 
-        self.view = pyglet.math.Mat4().scale((self.zoom, self.zoom, 1.0))
         event.accept()
 
     def update_time_uniform(self, dt: float) -> None:

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -520,19 +520,17 @@ class Ui_MainWindow:
 
     def saveShaders(self):
         options = self.get_file_dialog_options()
-        fileName, _ = QFileDialog.getSaveFileName(
+        file_name, _ = QFileDialog.getSaveFileName(
             self._window, "Saving Both Shader Files (vert and frag)", "",
             options=options)
 
-        if fileName:
-            vert_filename = f"{fileName}.vert"
-            frag_filename = f"{fileName}.frag"
+        if file_name:
+            base_path = Path(file_name)
+            vert_filename = base_path.with_suffix(".vert")
+            frag_filename = base_path.with_suffix(".frag")
 
-            with open(vert_filename, 'w') as f:
-                f.write(self.vertex_source_edit.toPlainText())
-
-            with open(frag_filename, 'w') as f:
-                f.write(self.fragSourceEdit.toPlainText())
+            vert_filename.write_text(self.vertex_source_edit.toPlainText())
+            frag_filename.write_text(self.fragSourceEdit.toPlainText())
 
     def removeImage(self, actionWidget):
         if self.imageMenu:

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -704,8 +704,13 @@ class PygletWidget(QOpenGLWidget):
 
         self._view_matrix = matrix
 
-      
+
 def excepthook(exc_type, exc_value, exc_tb):
+    """Replacement for Python's default exception handler function.
+
+    See the following for more information:
+    https://docs.python.org/3/library/sys.html#sys.excepthook
+    """
     tb = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
     print(tb)
 

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -325,10 +325,15 @@ class Ui_MainWindow:
         self.sprite = None
         self.program = None
 
-    def get_file_dialog_options(self):
+    def get_file_dialog_options(self) -> QFileDialog.Options:
+        """Convert instance attributes to a file dialog options object.
+
+        You may want to expand on this in your own application.
+        """
         options = QFileDialog.Options()
         if not self.use_native_file_dialog:
             options |= QFileDialog.DontUseNativeDialog
+
         return options
 
     def setupUi(self, MainWindow: QtWidgets.QMainWindow):

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -290,14 +290,17 @@ class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
 
 class MultiTextureSprite(pyglet.sprite.AdvancedSprite):
 
-    def __init__(self,
-                 imgs, x=0, y=0, z=0,
-                 blend_src=pyglet.gl.GL_SRC_ALPHA,
-                 blend_dest=pyglet.gl.GL_ONE_MINUS_SRC_ALPHA,
-                 batch=None,
-                 group=None,
-                 subpixel=False,
-                 program=None):
+    def __init__(
+            self,
+            imgs: Mapping[str, pyglet.image.Texture],
+            x: float = 0, y: float = 0, z: float = 0,
+            blend_src: int = pyglet.gl.GL_SRC_ALPHA,
+            blend_dest: int = pyglet.gl.GL_ONE_MINUS_SRC_ALPHA,
+            batch: Optional[pyglet.graphics.Batch] = None,
+            group: Optional[MultiTextureSpriteGroup] = None,
+            subpixel: bool = False,
+            program: pyglet.graphics.shader.ShaderProgram = None
+    ) -> None:
 
         self._x = x
         self._y = y

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -226,7 +226,7 @@ class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
             blend_dest: int,
             program: Optional[pyglet.graphics.shader.ShaderProgram] = None,
             parent: Optional[pyglet.graphics.Group] = None
-    ):
+    ) -> None:
         """Create a sprite group for multiple textures and samplers.
 
         All textures must share the same target type.
@@ -257,7 +257,7 @@ class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
 
         self.program.stop()
 
-    def set_state(self):
+    def set_state(self) -> None:
         self.program.use()
 
         for i, texture in enumerate(self.images.values()):
@@ -267,22 +267,22 @@ class MultiTextureSpriteGroup(pyglet.sprite.SpriteGroup):
         glEnable(GL_BLEND)
         glBlendFunc(self.blend_src, self.blend_dest)
 
-    def unset_state(self):
+    def unset_state(self) -> None:
         glDisable(GL_BLEND)
         self.program.stop()
         glActiveTexture(GL_TEXTURE0)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{self.__class__.__name__}({self.texture!r}-{int(self.texture.id)})'
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return (other.__class__ is self.__class__ and
                 self.program is other.program and
                 self.images == other.textures and
                 self.blend_src == other.blend_src and
                 self.blend_dest == other.blend_dest)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((id(self.parent),
                      id(self.images),
                      self.blend_src, self.blend_dest))

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -469,8 +469,10 @@ class Ui_MainWindow:
     def loadImages(self):
         options = QFileDialog.Options()
         #options |= QFileDialog.DontUseNativeDialog
-        fileNames, _ = QFileDialog.getOpenFileNames(self._window, "Select Image Files", "", "Image Files (*.png *.jpg *.jpeg *.bmp)",
-                                                  options=options)
+        fileNames, _ = QFileDialog.getOpenFileNames(
+            self._window, "Select Image Files", "", "Image Files (*.png *.jpg *.jpeg *.bmp)",
+            options=options)
+
         for fileName in fileNames:
             if not self.images:
                 self.imageMenu.removeAction(self.noImageAction)
@@ -492,8 +494,10 @@ class Ui_MainWindow:
         options = QFileDialog.Options()
 
         #options |= QFileDialog.DontUseNativeDialog
-        fileNames, _ = QFileDialog.getOpenFileNames(self._window, "Load Shader Files", "", "Shader Files (*.vert *.frag *.txt)",
-                                                  options=options)
+        fileNames, _ = QFileDialog.getOpenFileNames(
+            self._window, "Load Shader Files", "", "Shader Files (*.vert *.frag *.txt)",
+            options=options)
+
         for fileName in fileNames:
             ext = os.path.splitext(fileName)[1]
             if ext == '.vert':
@@ -511,9 +515,10 @@ class Ui_MainWindow:
         options = QFileDialog.Options()
 
         # options |= QFileDialog.DontUseNativeDialog
-        fileName, _ = QFileDialog.getSaveFileName(self._window, "Saving Both Shader Files (vert and frag)", "",
+        fileName, _ = QFileDialog.getSaveFileName(
+            self._window, "Saving Both Shader Files (vert and frag)", "",
+            options=options)
 
-                                                  options=options)
         if fileName:
             vert_filename = f"{fileName}.vert"
             frag_filename = f"{fileName}.frag"

--- a/contrib/qt_sprite_preview.py
+++ b/contrib/qt_sprite_preview.py
@@ -325,10 +325,13 @@ class Ui_MainWindow:
     def setupUi(self, MainWindow: QtWidgets.QMainWindow):
         self._window = MainWindow
 
+        # Set up the central window widget object
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(820, 855)
         self.centralwidget = QtWidgets.QWidget(MainWindow)
         self.centralwidget.setObjectName("centralwidget")
+
+        # Create layout for shader editing
         self.gridLayout = QtWidgets.QGridLayout(self.centralwidget)
         self.gridLayout.setObjectName("gridLayout")
         self.verticalLayout_3 = QtWidgets.QVBoxLayout()
@@ -361,12 +364,17 @@ class Ui_MainWindow:
         self.compileShaderBtn.clicked.connect(self.compileClick)
         self.compileShaderBtn.setObjectName("compile_shader_btn")
         self.verticalLayout_3.addWidget(self.compileShaderBtn)
+
+        # Initialize the pyglet widget we'll draw to and lay out the window
         self.openGLWidget = PygletWidget(800, 400, self.centralwidget, self)
         self.openGLWidget.setMinimumSize(QtCore.QSize(800, 400))
         self.openGLWidget.setObjectName("openGLWidget")
         self.verticalLayout_3.addWidget(self.openGLWidget)
         self.gridLayout.addLayout(self.verticalLayout_3, 0, 0, 1, 1)
+
         MainWindow.setCentralWidget(self.centralwidget)
+
+        # Set up the top menu
         self.menubar = QtWidgets.QMenuBar(MainWindow)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 820, 21))
         self.menubar.setObjectName("menubar")
@@ -412,6 +420,7 @@ class Ui_MainWindow:
 
         self.menubar.addAction(self.imageMenu.menuAction())
 
+        # Perform localization & start accepting UI events
         self.retranslateUi(MainWindow)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 


### PR DESCRIPTION
### Change summary:

* Uncomment & improve the non-native file picker support to help with Gnome/Linux window management issues
   * Add a function which converts `Ui_MainWindow` attributes to `QFileDialog.Options`
   * Add CLI argument support for choosing which file picker to use
   * Explain this briefly in argparse help, docstrings, and comments
* Clarify source through comments & formatting
* Add type annotations
* Remove types from docstrings
* Use `pathlib` and other more current techniques where appropriate
* Improve some exception and type conversion specificity

### Unclear / Potential Future Items

* Is `Context.create_program` ready to use in this?
* Could we remove `AdvancedSprite` and only use `MultiTextureSprite`?