### PR TITLE
Fix text.Caret batch and blink

### DIFF
--- a/pyglet/text/caret.py
+++ b/pyglet/text/caret.py
@@ -127,6 +127,7 @@ class Caret:
 
         Also disconnects the caret from further layout events.
         """
+        clock.unschedule(self._blink)
         self._list.delete()
         self._layout.remove_handlers(self)
 

--- a/pyglet/text/caret.py
+++ b/pyglet/text/caret.py
@@ -98,7 +98,7 @@ class Caret:
 
         colors = r, g, b, self._visible_alpha, r, g, b, self._visible_alpha
 
-        self._list = self._group.program.vertex_list(2, gl.GL_LINES, batch, self._group, colors=('Bn', colors))
+        self._list = self._group.program.vertex_list(2, gl.GL_LINES, self._batch, self._group, colors=('Bn', colors))
         self._ideal_x = None
         self._ideal_line = None
         self._next_attributes = {}


### PR DESCRIPTION
### Problem

- If no batch is provided to the text.Caret class, text.Caret won't be added to any batch.
- When deleting the text.Caret, the blink function isn't unscheduled.

### Change summary

- In the init function of text.Caret, create the vertex list with `self._batch` instead of only the parameter batch, as `self._batch` is the text layout's batch if no batch is provided as a parameter.
- Unschedule the blink function when deleting the Caret.