### PR TITLE
Simplify debug_print and annotate non-codec utils

### DIFF
--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -2,18 +2,12 @@
 import ctypes
 import sys
 
-from typing import Union, Protocol, TypeVar, runtime_checkable
+from typing import Union, Callable
 
 __all__ = [
-    'R',
-    'R_co',
     "Buffer",
-    'CallableArgsKwargs'
+    "DebugPrintCallable"
 ]
-
-
-R = TypeVar('R')
-R_co = TypeVar('R_co', covariant=True)
 
 
 if sys.version_info >= (3, 12):
@@ -23,24 +17,4 @@ else:
     Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]
 
 
-@runtime_checkable
-class CallableArgsKwargs(Protocol[R_co]):
-    """3.8-friendly way of saying "a Callable taking *args & **kwargs."
-
-    Use the R generic parameter to specify a return type::
-
-        def report(
-             *args,
-             **kwargs,
-             out_func: CallableArgsKwargs[None] = default
-        ) -> None:
-            out_func(*args, **kwargs)
-
-    :py:class:`typing.Protocol` was added in Python 3.8, while
-    :py:class:`typing.ParamSpec` was added in 3.10. We also can't
-    use the ``typing_extensions`` backports due to the no hard
-    dependencies rule.
-    """
-
-    def __call__(self, *args, **kwargs) -> R:
-        raise NotImplementedError
+DebugPrintCallable = Callable[[str], bool]

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -7,23 +7,17 @@ from typing import Union, TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 __all__ = [
     'R',
     "Buffer",
-    'ByteString',
     'CallableArgsKwargs'
 ]
 
 
 R = TypeVar('R')
 
-
-# Backwards compatible placeholder for `collections.abc.Buffer` from Python 3.12
-Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]
-
-
-# Handle deprecation of ByteString since 3.9
-if TYPE_CHECKING or sys.version_info >= (3, 14):
-    ByteString = Union[bytes, bytearray, memoryview]
+if TYPE_CHECKING or sys.version_info >= (3, 12):
+    from collections.abc import Buffer
 else:
-    from typing import ByteString
+    # Backwards compatible placeholder for `collections.abc.Buffer` from Python 3.12
+    Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]
 
 
 @runtime_checkable

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -2,7 +2,7 @@
 import ctypes
 import sys
 
-from typing import Union, TYPE_CHECKING, Protocol, TypeVar
+from typing import Union, TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
 __all__ = [
     'R',
@@ -26,6 +26,7 @@ else:
     from typing import ByteString
 
 
+@runtime_checkable
 class CallableArgsKwargs(Protocol[R]):
     """3.8-friendly way of saying "a Callable taking *args & **kwargs."
 
@@ -45,4 +46,4 @@ class CallableArgsKwargs(Protocol[R]):
     """
 
     def __call__(self, *args, **kwargs) -> R:
-        ...
+        raise NotImplementedError

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -2,7 +2,7 @@
 import ctypes
 import sys
 
-from typing import Union, TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
+from typing import Union, Protocol, TypeVar, runtime_checkable
 
 __all__ = [
     'R',

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -1,12 +1,19 @@
 """Holds type aliases used throughout the codebase."""
 import ctypes
+import sys
 
-from typing import Union
-
+from typing import Union, TYPE_CHECKING
 
 __all__ = [
-    "Buffer"
+    "Buffer",
+    'ByteString'
 ]
 
 # Backwards compatible placeholder for `collections.abc.Buffer` from Python 3.12
 Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]
+
+# Handle deprecation of ByteString since 3.9
+if TYPE_CHECKING or sys.version_info >= (3, 14):
+    ByteString = Union[bytes, bytearray, memoryview]
+else:
+    from typing import ByteString

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -13,7 +13,7 @@ __all__ = [
 
 R = TypeVar('R')
 
-if TYPE_CHECKING or sys.version_info >= (3, 12):
+if sys.version_info >= (3, 12):
     from collections.abc import Buffer
 else:
     # Backwards compatible placeholder for `collections.abc.Buffer` from Python 3.12

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -2,18 +2,47 @@
 import ctypes
 import sys
 
-from typing import Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING, Protocol, TypeVar
 
 __all__ = [
+    'R',
     "Buffer",
-    'ByteString'
+    'ByteString',
+    'CallableArgsKwargs'
 ]
+
+
+R = TypeVar('R')
+
 
 # Backwards compatible placeholder for `collections.abc.Buffer` from Python 3.12
 Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]
+
 
 # Handle deprecation of ByteString since 3.9
 if TYPE_CHECKING or sys.version_info >= (3, 14):
     ByteString = Union[bytes, bytearray, memoryview]
 else:
     from typing import ByteString
+
+
+class CallableArgsKwargs(Protocol[R]):
+    """3.8-friendly way of saying "a Callable taking *args & **kwargs."
+
+    Use the R generic parameter to specify a return type::
+
+        def report(
+             *args,
+             **kwargs,
+             out_func: CallableArgsKwargs[None] = default
+        ) -> None:
+            out_func(*args, **kwargs)
+
+    :py:class:`typing.Protocol` was added in Python 3.8, while
+    :py:class:`typing.ParamSpec` was added in 3.10. We also can't
+    use the ``typing_extensions`` backports due to the no hard
+    dependencies rule.
+    """
+
+    def __call__(self, *args, **kwargs) -> R:
+        ...

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -6,7 +6,6 @@ from typing import Union, Callable
 
 __all__ = [
     "Buffer",
-    "DebugPrintCallable"
 ]
 
 
@@ -15,6 +14,3 @@ if sys.version_info >= (3, 12):
 else:
     # Best-effort placeholder for older Python versions
     Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]
-
-
-DebugPrintCallable = Callable[[str], bool]

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -2,7 +2,7 @@
 import ctypes
 import sys
 
-from typing import Union, Callable
+from typing import Union
 
 __all__ = [
     "Buffer",

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -12,6 +12,8 @@ __all__ = [
 
 
 R = TypeVar('R')
+R_co = TypeVar('R_co', covariant=True)
+
 
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer
@@ -21,7 +23,7 @@ else:
 
 
 @runtime_checkable
-class CallableArgsKwargs(Protocol[R]):
+class CallableArgsKwargs(Protocol[R_co]):
     """3.8-friendly way of saying "a Callable taking *args & **kwargs."
 
     Use the R generic parameter to specify a return type::

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -6,6 +6,7 @@ from typing import Union, Protocol, TypeVar, runtime_checkable
 
 __all__ = [
     'R',
+    'R_co',
     "Buffer",
     'CallableArgsKwargs'
 ]

--- a/pyglet/customtypes.py
+++ b/pyglet/customtypes.py
@@ -18,7 +18,7 @@ R_co = TypeVar('R_co', covariant=True)
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer
 else:
-    # Backwards compatible placeholder for `collections.abc.Buffer` from Python 3.12
+    # Best-effort placeholder for older Python versions
     Buffer = Union[bytes, bytearray, memoryview, ctypes.Array]
 
 

--- a/pyglet/experimental/net.py
+++ b/pyglet/experimental/net.py
@@ -235,12 +235,12 @@ class Server(_EventDispatcher):
 
     def on_connection(self, connection):
         """Event for new Client connections."""
-        assert _debug_net("Connected <---", connection)
+        assert _debug_net(f"Connected <--- {connection}")
         connection.set_handler('on_disconnect', self.on_disconnect)
 
     def on_disconnect(self, connection):
         """Event for disconnected Clients."""
-        assert _debug_net("Disconnected --->", connection)
+        assert _debug_net(f"Disconnected ---> {connection}")
 
 
 Server.register_event_type('on_connection')

--- a/pyglet/experimental/net.py
+++ b/pyglet/experimental/net.py
@@ -52,7 +52,7 @@ from pyglet.event import EventDispatcher as _EventDispatcher
 
 from pyglet.util import debug_print
 
-_debug_net = debug_print(True)
+_debug_net = debug_print('debug_net')
 
 
 class Client(_EventDispatcher):

--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -520,9 +520,9 @@ class WMFSource(Source):
             imfmedia.GetGUID(MF_MT_SUBTYPE, ctypes.byref(guid_compressed))
 
             if guid_compressed == MFAudioFormat_PCM or guid_compressed == MFAudioFormat_Float:
-                assert _debug('WMFAudioDecoder: Found Uncompressed Audio:', guid_compressed)
+                assert _debug(f'WMFAudioDecoder: Found Uncompressed Audio: {guid_compressed}')
             else:
-                assert _debug('WMFAudioDecoder: Found Compressed Audio:', guid_compressed)
+                assert _debug(f'WMFAudioDecoder: Found Compressed Audio: {guid_compressed}')
                 # If audio is compressed, attempt to decompress it by forcing source reader to use PCM
                 mf_mediatype = IMFMediaType()
 

--- a/pyglet/media/devices/win32.py
+++ b/pyglet/media/devices/win32.py
@@ -259,7 +259,7 @@ class Win32AudioDeviceManager(base.AbstractAudioDeviceManager):
             cached_dev.state = dev_state
             return cached_dev
         except OSError as err:
-            assert _debug("No default audio output was found.", err)
+            assert _debug(f"No default audio output was found. {err}")
             return None
 
     def get_default_input(self) -> Optional[Win32AudioDevice]:
@@ -274,7 +274,7 @@ class Win32AudioDeviceManager(base.AbstractAudioDeviceManager):
             cached_dev.state = dev_state
             return cached_dev
         except OSError as err:
-            assert _debug("No default input output was found.", err)
+            assert _debug(f"No default input output was found. {err}")
             return None
 
     def get_cached_device(self, dev_id) -> Win32AudioDevice:

--- a/pyglet/media/drivers/directsound/adaptation.py
+++ b/pyglet/media/drivers/directsound/adaptation.py
@@ -145,11 +145,11 @@ class DirectSoundAudioPlayer(AbstractAudioPlayer):
 
     def _refill(self, write_size):
         while write_size > 0:
-            assert _debug('_refill, write_size =', write_size)
+            assert _debug(f'_refill, write_size = {write_size}')
             audio_data = self._get_audiodata()
 
             if audio_data is not None:
-                assert _debug('write', audio_data.length)
+                assert _debug(f'write {audio_data.length}')
                 length = min(write_size, audio_data.length)
                 self.write(audio_data, length)
                 write_size -= length
@@ -191,14 +191,14 @@ class DirectSoundAudioPlayer(AbstractAudioPlayer):
         # Set the write cursor back to eos_cursor or play_cursor to prevent gaps
         if self._play_cursor < self._eos_cursor:
             cursor_diff = self._write_cursor - self._eos_cursor
-            assert _debug('Moving cursor back', cursor_diff)
+            assert _debug(f'Moving cursor back {cursor_diff}')
             self._write_cursor = self._eos_cursor
             self._write_cursor_ring -= cursor_diff
             self._write_cursor_ring %= self._buffer_size
 
         else:
             cursor_diff = self._play_cursor - self._eos_cursor
-            assert _debug('Moving cursor back', cursor_diff)
+            assert _debug(f'Moving cursor back {cursor_diff}')
             self._write_cursor = self._play_cursor
             self._write_cursor_ring -= cursor_diff
             self._write_cursor_ring %= self._buffer_size
@@ -207,7 +207,7 @@ class DirectSoundAudioPlayer(AbstractAudioPlayer):
         for event in audio_data.events:
             event_cursor = self._write_cursor + event.timestamp * \
                            self.source.audio_format.bytes_per_second
-            assert _debug('Adding event', event, 'at', event_cursor)
+            assert _debug(f'Adding event {event} at {event_cursor}')
             self._events.append((event_cursor, event))
 
     def _add_audiodata_timestamp(self, audio_data):

--- a/pyglet/media/drivers/openal/adaptation.py
+++ b/pyglet/media/drivers/openal/adaptation.py
@@ -245,7 +245,7 @@ class OpenALAudioPlayer(AbstractAudioPlayer):
         return False
 
     def _refill(self, write_size):
-        assert _debug('_refill', write_size)
+        assert _debug(f'_refill {write_size}')
 
         while write_size > self.min_buffer_size:
             audio_data = self._get_audiodata()

--- a/pyglet/media/drivers/pulse/adaptation.py
+++ b/pyglet/media/drivers/pulse/adaptation.py
@@ -236,7 +236,7 @@ class PulseAudioPlayer(AbstractAudioPlayer):
 
         while self._events and self._events[0][0] <= read_index:
             _, event = self._events.pop(0)
-            assert _debug('PulseAudioPlayer: Dispatch event', event)
+            assert _debug(f'PulseAudioPlayer: Dispatch event {event}')
             event.sync_dispatch_to_player(self.player)
 
     def _add_event_at_write_index(self, event_name):
@@ -313,7 +313,7 @@ class PulseAudioPlayer(AbstractAudioPlayer):
         else:
             read_index = 0
 
-        assert _debug('_get_read_index ->', read_index)
+        assert _debug(f'_get_read_index -> {read_index}')
         return read_index
 
     def _get_write_index(self):
@@ -323,7 +323,7 @@ class PulseAudioPlayer(AbstractAudioPlayer):
         else:
             write_index = 0
 
-        assert _debug('_get_write_index ->', write_index)
+        assert _debug(f'_get_write_index -> {write_index}')
         return write_index
 
     def _get_timing_info(self):
@@ -365,7 +365,7 @@ class PulseAudioPlayer(AbstractAudioPlayer):
         dt /= 1000000
         time = timestamp + dt
 
-        assert _debug('get_time ->', time)
+        assert _debug('get_time -> {time}')
         return time
 
     def set_volume(self, volume):

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -213,7 +213,7 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
     def _add_audiodata_events(self, audio_data):
         for event in audio_data.events:
             event_cursor = self._write_cursor + event.timestamp * self.source.audio_format.bytes_per_second
-            assert _debug('Adding event', event, 'at', event_cursor)
+            assert _debug(f'Adding event {event} at {event_cursor}')
             self._events.append((event_cursor, event))
 
     def _add_audiodata_timestamp(self, audio_data):

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -9,7 +9,7 @@ import pyglet
 from pyglet.customtypes import ByteString
 
 
-def asbytes(s):
+def asbytes(s: Union[str, ByteString]) -> bytes:
     if isinstance(s, bytes):
         return s
     elif isinstance(s, str):

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -38,28 +38,42 @@ def _debug_print_dummy(arg: str) -> bool:
 
 
 def debug_print(pyglet_option_name: str = 'debug') -> Callable[[str], bool]:
-    """Get a debug print callable based on a pyglet option name.
+    """Get a debug printer controlled by the given ``pyglet.options`` key.
 
-    The debug print function returned should be used in an assert so
-    it can automatically be removed when running Python with the -O
-    flag. Both of the returned functions return True to ensure the
-    types for this work.
+    This allows repurposing ``assert`` to write cleaner, more efficient
+    debug output:
+
+    #. Debug printers fit into a one-line ``assert`` statements instead
+       of longer, slower key-lookup``if`` statements
+    #. Running Python with the -O flag makes pyglet run faster by
+       skipping all ``assert`` statements
 
     Usage example::
 
-        from pyglet.debug import debug_print
+        from pyglet.util import debug_print
+
+
         _debug_media = debug_print('debug_media')
 
+
         def some_func():
+            # Python will skip the line below when run with -O
             assert _debug_media('My debug statement')
+
+            # The rest of the function will run as normal
+            ...
+
+    For more information, please see `the Python command line
+    documentation <https://docs.python.org/3/using/cmdline.html#cmdoption-O>`_.
 
     Args:
         `pyglet_option_name` :
-            The name of a pyglet option to load the debug flag from.
+            The name of a key in :attr:`pyglet.options` to read the
+            debug flag's value from.
 
     Returns:
-        A callable which returns ``True``  so it to be used
-        as a way of auto-removing it when run with ``-O``.
+        A callable which prints a passed string and returns ``True``
+        to allow auto-removal when running with ``-O``.
 
     """
     enabled = pyglet.options.get(pyglet_option_name, False)

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -38,13 +38,13 @@ def _debug_print_dummy(arg: str) -> bool:
 
 
 def debug_print(pyglet_option_name: str = 'debug') -> Callable[[str], bool]:
-    """Get a debug printer controlled by the given ``pyglet.options`` key.
+    """Get a debug printer controlled by the given ``pyglet.options`` name.
 
     This allows repurposing ``assert`` to write cleaner, more efficient
     debug output:
 
     #. Debug printers fit into a one-line ``assert`` statements instead
-       of longer, slower key-lookup``if`` statements
+       of longer, slower key-lookup ``if`` statements
     #. Running Python with the -O flag makes pyglet run faster by
        skipping all ``assert`` statements
 

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -3,10 +3,10 @@
 
 import os
 import sys
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 
 import pyglet
-from pyglet.customtypes import Buffer, DebugPrintCallable
+from pyglet.customtypes import Buffer
 
 
 def asbytes(s: Union[str, Buffer]) -> bytes:
@@ -45,7 +45,7 @@ def _debug_print_dummy(arg: str) -> bool:
     return True
 
 
-def debug_print(pyglet_option_name: str = 'debug') -> DebugPrintCallable:
+def debug_print(pyglet_option_name: str = 'debug') -> Callable[[str], bool]:
     """Get a debug print callable based on a pyglet option name.
 
     The debug print function returned should be used in an assert so

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -3,8 +3,10 @@
 
 import os
 import sys
+from typing import Optional, Union
 
 import pyglet
+from pyglet.customtypes import ByteString
 
 
 def asbytes(s):
@@ -23,12 +25,12 @@ def asbytes_filename(s):
         return s.encode(encoding=sys.getfilesystemencoding())
 
 
-def asstr(s):
+def asstr(s: Optional[Union[str, ByteString]]) -> str:
     if s is None:
         return ''
     if isinstance(s, str):
         return s
-    return s.decode("utf-8")
+    return s.decode("utf-8")  # type: ignore
 
 
 def debug_print(enabled_or_option='debug'):

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -61,12 +61,12 @@ def debug_print(pyglet_option_name: str = 'debug') -> DebugPrintCallable:
     """
     enabled = pyglet.options.get(pyglet_option_name, False)
     if enabled:
-        def _debug_print(*args, **kwargs) -> bool:
-            print(*args, **kwargs)
+        def _debug_print(arg: str) -> bool:
+            print(arg)
             return True
 
     else:
-        def _debug_print(*args, **kwargs) -> bool:
+        def _debug_print(arg: str) -> bool:
             return True
 
     return _debug_print

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -6,7 +6,7 @@ import sys
 from typing import Optional, Union
 
 import pyglet
-from pyglet.customtypes import Buffer, CallableArgsKwargs
+from pyglet.customtypes import Buffer, DebugPrintCallable
 
 
 def asbytes(s: Union[str, Buffer]) -> bytes:
@@ -34,10 +34,13 @@ def asstr(s: Optional[Union[str, Buffer]]) -> str:
     return s.decode("utf-8")  # type: ignore
 
 
-def debug_print(enabled_or_option: Union[bool, str] = 'debug') -> CallableArgsKwargs[bool]:
-    """Get a debug printer that is enabled based on a boolean input or a pyglet option.
-    The debug print function returned should be used in an assert. This way it can be
-    optimized out when running python with the -O flag.
+def debug_print(pyglet_option_name: str = 'debug') -> DebugPrintCallable:
+    """Get a debug print callable based on a pyglet option name.
+
+    The debug print function returned should be used in an assert so
+    it can automatically be removed when running Python with the -O
+    flag. Both of the returned functions return True to ensure the
+    types for this work.
 
     Usage example::
 
@@ -47,18 +50,16 @@ def debug_print(enabled_or_option: Union[bool, str] = 'debug') -> CallableArgsKw
         def some_func():
             assert _debug_media('My debug statement')
 
-    :parameters:
-        `enabled_or_options` :
-            If a bool is passed, debug printing is enabled if it is True. If str is passed
-            debug printing is enabled if the pyglet option with that name is True.
+    Args:
+        `pyglet_option_name` :
+            The name of a pyglet option to load the debug flag from.
 
-    :returns: Function for debug printing.
+    Returns:
+        A callable which returns ``True``  so it to be used
+        as a way of auto-removing it when run with ``-O``.
+
     """
-    if isinstance(enabled_or_option, bool):
-        enabled = enabled_or_option
-    else:
-        enabled = pyglet.options.get(enabled_or_option, False)
-
+    enabled = pyglet.options.get(pyglet_option_name, False)
     if enabled:
         def _debug_print(*args, **kwargs) -> bool:
             print(*args, **kwargs)

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -34,6 +34,17 @@ def asstr(s: Optional[Union[str, Buffer]]) -> str:
     return s.decode("utf-8")  # type: ignore
 
 
+# Keep these outside of the function since we don't need to re-define
+# the function each time we make a call since no state is persisted.
+def _debug_print_real(arg: str) -> bool:
+    print(arg)
+    return True
+
+
+def _debug_print_dummy(arg: str) -> bool:
+    return True
+
+
 def debug_print(pyglet_option_name: str = 'debug') -> DebugPrintCallable:
     """Get a debug print callable based on a pyglet option name.
 
@@ -61,15 +72,8 @@ def debug_print(pyglet_option_name: str = 'debug') -> DebugPrintCallable:
     """
     enabled = pyglet.options.get(pyglet_option_name, False)
     if enabled:
-        def _debug_print(arg: str) -> bool:
-            print(arg)
-            return True
-
-    else:
-        def _debug_print(arg: str) -> bool:
-            return True
-
-    return _debug_print
+        return _debug_print_real
+    return _debug_print_dummy
 
 
 class CodecRegistry:

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -18,8 +18,8 @@ def asbytes(s):
         return bytes(s)
 
 
-def asbytes_filename(s):
-    if isinstance(s, bytes):
+def asbytes_filename(s: Union[str, ByteString]) -> Optional[bytes]:
+    if isinstance(s, (bytes, bytearray, memoryview)):
         return s
     elif isinstance(s, str):
         return s.encode(encoding=sys.getfilesystemencoding())

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -18,14 +18,6 @@ def asbytes(s: Union[str, Buffer]) -> bytes:
         return bytes(s)
 
 
-def asbytes_filename(s: Union[str, Buffer]) -> Optional[bytes]:
-    if isinstance(s, (bytes, bytearray, memoryview)):
-        return s
-    elif isinstance(s, str):
-        return s.encode(encoding=sys.getfilesystemencoding())
-
-    return None
-
 def asstr(s: Optional[Union[str, Buffer]]) -> str:
     if s is None:
         return ''

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -45,7 +45,7 @@ def debug_print(pyglet_option_name: str = 'debug') -> Callable[[str], bool]:
 
     #. Debug printers fit into a one-line ``assert`` statements instead
        of longer, slower key-lookup ``if`` statements
-    #. Running Python with the -O flag makes pyglet run faster by
+    #. Running Python with the ``-O`` flag makes pyglet run faster by
        skipping all ``assert`` statements
 
     Usage example::

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -6,7 +6,7 @@ import sys
 from typing import Optional, Union
 
 import pyglet
-from pyglet.customtypes import ByteString
+from pyglet.customtypes import ByteString, CallableArgsKwargs
 
 
 def asbytes(s: Union[str, ByteString]) -> bytes:
@@ -33,7 +33,7 @@ def asstr(s: Optional[Union[str, ByteString]]) -> str:
     return s.decode("utf-8")  # type: ignore
 
 
-def debug_print(enabled_or_option='debug'):
+def debug_print(enabled_or_option: Union[bool, str] = 'debug') -> CallableArgsKwargs[bool]:
     """Get a debug printer that is enabled based on a boolean input or a pyglet option.
     The debug print function returned should be used in an assert. This way it can be
     optimized out when running python with the -O flag.
@@ -59,12 +59,12 @@ def debug_print(enabled_or_option='debug'):
         enabled = pyglet.options.get(enabled_or_option, False)
 
     if enabled:
-        def _debug_print(*args, **kwargs):
+        def _debug_print(*args, **kwargs) -> bool:
             print(*args, **kwargs)
             return True
 
     else:
-        def _debug_print(*args, **kwargs):
+        def _debug_print(*args, **kwargs) -> bool:
             return True
 
     return _debug_print

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -24,6 +24,7 @@ def asbytes_filename(s: Union[str, ByteString]) -> Optional[bytes]:
     elif isinstance(s, str):
         return s.encode(encoding=sys.getfilesystemencoding())
 
+    return None
 
 def asstr(s: Optional[Union[str, ByteString]]) -> str:
     if s is None:

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -47,7 +47,7 @@ def debug_print(enabled_or_option: Union[bool, str] = 'debug') -> CallableArgsKw
             assert _debug_media('My debug statement')
 
     :parameters:
-        `enabled_or_options` : bool or str
+        `enabled_or_options` :
             If a bool is passed, debug printing is enabled if it is True. If str is passed
             debug printing is enabled if the pyglet option with that name is True.
 

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -6,10 +6,10 @@ import sys
 from typing import Optional, Union
 
 import pyglet
-from pyglet.customtypes import ByteString, CallableArgsKwargs
+from pyglet.customtypes import Buffer, CallableArgsKwargs
 
 
-def asbytes(s: Union[str, ByteString]) -> bytes:
+def asbytes(s: Union[str, Buffer]) -> bytes:
     if isinstance(s, bytes):
         return s
     elif isinstance(s, str):
@@ -18,7 +18,7 @@ def asbytes(s: Union[str, ByteString]) -> bytes:
         return bytes(s)
 
 
-def asbytes_filename(s: Union[str, ByteString]) -> Optional[bytes]:
+def asbytes_filename(s: Union[str, Buffer]) -> Optional[bytes]:
     if isinstance(s, (bytes, bytearray, memoryview)):
         return s
     elif isinstance(s, str):
@@ -26,7 +26,7 @@ def asbytes_filename(s: Union[str, ByteString]) -> Optional[bytes]:
 
     return None
 
-def asstr(s: Optional[Union[str, ByteString]]) -> str:
+def asstr(s: Optional[Union[str, Buffer]]) -> str:
     if s is None:
         return ''
     if isinstance(s, str):


### PR DESCRIPTION
### Changes

* Add forward-compatible import of Buffer in addition to existing union type
* Add typing to annotations to non-codec portions of `pyglet.util`
* Alter returned _debug functions  & function which returns them per discussion with Ben

I've left the annotations off of the Codec portions since @Square789 may be moving or changing those in the proposed sound branch.