### PR TITLE
Fix slowdowns and unexpected errors in integration when running all at once

### DIFF
--- a/tests/integration/app/test_eventloop.py
+++ b/tests/integration/app/test_eventloop.py
@@ -23,7 +23,7 @@ def test_multiple_start_stop(performance):
     with performance.timer(30.):
         for _ in range(100):
             test_start_stop(performance)
-    
+
 
 def test_events():
     enter_mock = mock.MagicMock()
@@ -58,4 +58,3 @@ def test_sleep(performance):
         event_loop.run()
     assert not event_loop.is_running
     assert _sleep.returned.wait(1.)
-

--- a/tests/integration/image/test_imagegrid.py
+++ b/tests/integration/image/test_imagegrid.py
@@ -44,6 +44,9 @@ class ImageGridTestCase(unittest.TestCase):
     def setUp(self):
         self.w = Window(visible=False)
 
+    def tearDown(self) -> None:
+        self.w.close()
+
     def testSquare(self):
         # Test a 3x3 grid with no padding and 4x4 images
         rows = cols = 3

--- a/tests/integration/image/test_texture3d.py
+++ b/tests/integration/image/test_texture3d.py
@@ -55,6 +55,9 @@ class TestTexture3D(unittest.TestCase):
     def setUp(self):
         self.w = Window(visible=False)
 
+    def tearDown(self) -> None:
+        self.w.close()
+
     def test2(self):
         # Test 2 images of 32x32
         images = [self.create_image(32, 32, i + 1) for i in range(2)]

--- a/tests/integration/media/test_driver.py
+++ b/tests/integration/media/test_driver.py
@@ -15,18 +15,6 @@ from pyglet.media.synthesis import Silence
 from .mock_player import MockPlayer
 
 
-def _delete_driver():
-    # if hasattr(pyglet.media.drivers._audio_driver, 'delete'):
-    #     pyglet.media.drivers._audio_driver.delete()
-    pyglet.media.drivers._audio_driver = None
-
-def test_get_platform_driver():
-    driver = pyglet.media.drivers.get_audio_driver()
-    assert driver is not None
-    assert driver is not None, 'Cannot load audio driver for your platform'
-    _delete_driver()
-
-
 class MockPlayerWithMockTime(MockPlayer):
 
     @property


### PR DESCRIPTION
- Removal of a test that set the audio driver to None without deleting it, causing later errors
- Some image tests were not cleaning up after themselves, creating two invisible windows that then stalled later tests