### PR TITLE
Audio backend rework

### DIFF
--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -597,7 +597,6 @@ class SourceGroup:
 
             if isinstance(old_source, StreamingSource):
                 old_source.delete()
-                del old_source
 
     def get_audio_data(self, num_bytes: float, compensation_time=0.0) -> Optional[AudioData]:
         """Get next audio packet.

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -563,10 +563,15 @@ class SourceGroup:
     def __init__(self) -> None:
         self.audio_format = None
         self.video_format = None
+        self.info = None
         self.duration = 0.0
         self._timestamp_offset = 0.0
         self._dequeued_durations = []
         self._sources = []
+        self.is_player_source = False
+
+    def is_precise(self) -> bool:
+        return False
 
     def seek(self, time: float) -> None:
         if self._sources:
@@ -574,6 +579,7 @@ class SourceGroup:
 
     def add(self, source: Source) -> None:
         self.audio_format = self.audio_format or source.audio_format
+        self.info = self.info or source.info
         source = source.get_queue_source()
         assert (source.audio_format == self.audio_format), "Sources must share the same audio format."
         self._sources.append(source)

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -152,10 +152,6 @@ class AudioData:
                 self.pointer = ctypes.addressof(ctypes.c_int.from_buffer(data))
             except TypeError:
                 raise TypeError("Unsupported AudioData type.")
-        #       try:
-        #           self.pointer = ctypes.addressof(ctypes.c_int.from_buffer_copy(data))
-        #       except TypeError:
-        #           raise TypeError("Unsupported AudioData type.")
 
         self.data = data
         # In any case, `data` will support the buffer protocol by delivering at least
@@ -488,6 +484,7 @@ class StaticSource(Source):
     def get_queue_source(self) -> Optional['StaticMemorySource']:
         if self._data is not None:
             return StaticMemorySource(self._data, self.audio_format)
+        return None
 
     def get_audio_data(self, num_bytes: float, compensation_time: float = 0.0) -> Optional[AudioData]:
         """The StaticSource does not provide audio data.

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -1,6 +1,16 @@
+import ctypes
 import io
+from typing import TYPE_CHECKING, BinaryIO, List, Optional, Union
 
 from pyglet.media.exceptions import MediaException, CannotSeekException
+from pyglet.util import next_or_equal_power_of_two
+
+if TYPE_CHECKING:
+    from pyglet.image import AbstractImage
+    from pyglet.image.animation import Animation
+    from pyglet.media.codecs import MediaEncoder
+    from pyglet.media.drivers.base import MediaEvent
+    from pyglet.media.player import Player
 
 
 class AudioFormat:
@@ -17,26 +27,52 @@ class AudioFormat:
         sample_rate (int): Samples per second (in Hertz).
     """
 
-    def __init__(self, channels, sample_size, sample_rate):
+    def __init__(self, channels: int, sample_size: int, sample_rate: int) -> None:
         self.channels = channels
         self.sample_size = sample_size
         self.sample_rate = sample_rate
 
         # Convenience
-        self.bytes_per_sample = (sample_size >> 3) * channels
-        self.bytes_per_second = self.bytes_per_sample * sample_rate
 
-    def __eq__(self, other):
-        if other is None:
-            return False
-        return (self.channels == other.channels and
-                self.sample_size == other.sample_size and
-                self.sample_rate == other.sample_rate)
+        self.bytes_per_frame = (sample_size // 8) * channels
+        self.bytes_per_second = self.bytes_per_frame * sample_rate
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
+        self.bytes_per_sample = self.bytes_per_frame
+        """This attribute is kept for compatibility and should not be used due
+        to a terminology error.
+        This value contains the bytes per audio frame, and using
+        `bytes_per_frame` should be preferred.
+        For the actual amount of bytes per sample, divide `sample_size` by
+        eight.
+        """
 
-    def __repr__(self):
+    def align(self, num_bytes: int) -> int:
+        """Align a given amount of bytes to the audio frame size of this
+        audio format, downwards.
+        """
+        return num_bytes - (num_bytes % self.bytes_per_frame)
+
+    def align_ceil(self, num_bytes: int) -> int:
+        """Align a given amount of bytes to the audio frame size of this
+        audio format, upwards.
+        """
+        return num_bytes + (-num_bytes % self.bytes_per_frame)
+
+    def timestamp_to_bytes_aligned(self, timestamp: float) -> int:
+        """Given a timestamp, return the amount of bytes that an emitter with
+        this audio format would have to have played to reach it, aligned
+        to the audio frame size.
+        """
+        return self.align(int(timestamp * self.bytes_per_second))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, AudioFormat):
+            return (self.channels == other.channels and
+                    self.sample_size == other.sample_size and
+                    self.sample_rate == other.sample_rate)
+        return NotImplemented
+
+    def __repr__(self) -> str:
         return '%s(channels=%d, sample_size=%d, sample_rate=%d)' % (
             self.__class__.__name__, self.channels, self.sample_size,
             self.sample_rate)
@@ -63,13 +99,13 @@ class VideoFormat:
             .. versionadded:: 1.2
     """
 
-    def __init__(self, width, height, sample_aspect=1.0):
+    def __init__(self, width: int, height: int, sample_aspect: float = 1.0) -> None:
         self.width = width
         self.height = height
         self.sample_aspect = sample_aspect
         self.frame_rate = None
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, VideoFormat):
             return (self.width == other.width and
                     self.height == other.height and
@@ -84,67 +120,51 @@ class AudioData:
     This class is used internally by pyglet.
 
     Args:
-        data (str or ctypes array or pointer): Sample data.
+        data (bytes, ctypes array, or supporting buffer protocol): Sample data.
         length (int): Size of sample data, in bytes.
         timestamp (float): Time of the first sample, in seconds.
         duration (float): Total data duration, in seconds.
         events (List[:class:`pyglet.media.drivers.base.MediaEvent`]): List of events
             contained within this packet. Events are timestamped relative to
             this audio packet.
+
+    .. deprecated:: 2.0.10
+            `timestamp` and `duration` are unused and will be removed eventually.
     """
 
-    __slots__ = 'data', 'length', 'timestamp', 'duration', 'events'
+    __slots__ = 'data', 'length', 'timestamp', 'duration', 'events', 'pointer'
 
-    def __init__(self, data, length, timestamp, duration, events):
+    def __init__(self,
+                 data: Union[bytes, ctypes.Array],
+                 length: int,
+                 timestamp: float = 0.0,
+                 duration: float = 0.0,
+                 events: Optional[List['MediaEvent']] = None) -> None:
+
+        if isinstance(data, bytes):
+            # bytes are treated specially by ctypes and can be cast to a void pointer, get
+            # their content's address like this
+            self.pointer = ctypes.cast(data, ctypes.c_void_p).value
+        elif isinstance(data, ctypes.Array):
+            self.pointer = ctypes.addressof(data)
+        else:
+            try:
+                self.pointer = ctypes.addressof(ctypes.c_int.from_buffer(data))
+            except TypeError:
+                raise TypeError("Unsupported AudioData type.")
+        #       try:
+        #           self.pointer = ctypes.addressof(ctypes.c_int.from_buffer_copy(data))
+        #       except TypeError:
+        #           raise TypeError("Unsupported AudioData type.")
+
         self.data = data
+        # In any case, `data` will support the buffer protocol by delivering at least
+        # a readable buffer.
+
         self.length = length
         self.timestamp = timestamp
         self.duration = duration
-        self.events = events
-
-    def __eq__(self, other):
-        if isinstance(other, AudioData):
-            return (self.data == other.data and
-                    self.length == other.length and
-                    self.timestamp == other.timestamp and
-                    self.duration == other.duration and
-                    self.events == other.events)
-        return False
-
-    def consume(self, num_bytes, audio_format):
-        """Remove some data from the beginning of the packet.
-
-        All events are cleared.
-
-        Args:
-            num_bytes (int): The number of bytes to consume from the packet.
-            audio_format (:class:`.AudioFormat`): The packet audio format.
-        """
-        self.events = ()
-        if num_bytes >= self.length:
-            self.data = None
-            self.length = 0
-            self.timestamp += self.duration
-            self.duration = 0.
-            return
-        elif num_bytes == 0:
-            return
-
-        self.data = self.data[num_bytes:]
-        self.length -= num_bytes
-        self.duration -= num_bytes / audio_format.bytes_per_second
-        self.timestamp += num_bytes / audio_format.bytes_per_second
-
-    def get_string_data(self):
-        """Return data as a bytestring.
-
-        Returns:
-            bytes: Data as a (byte)string.
-        """
-        if self.data is None:
-            return b''
-
-        return memoryview(self.data).tobytes()[:self.length]
+        self.events = [] if events is None else events
 
 
 class SourceInfo:
@@ -197,7 +217,7 @@ class Source:
     """
 
     _duration = None
-    _players = []  # List of players when calling Source.play
+    _players: List['Player'] = []  # Players created through Source.play
 
     audio_format = None
     video_format = None
@@ -205,7 +225,7 @@ class Source:
     is_player_source = False
 
     @property
-    def duration(self):
+    def duration(self) -> float:
         """float: The length of the source, in seconds.
 
         Not all source durations can be determined; in this case the value
@@ -215,7 +235,7 @@ class Source:
         """
         return self._duration
 
-    def play(self):
+    def play(self) -> 'Player':
         """Play the source.
 
         This is a convenience method which creates a Player for
@@ -232,14 +252,14 @@ class Source:
 
         def _on_player_eos():
             Source._players.remove(player)
-            # There is a closure on player. To get the refcount to 0,
-            # we need to delete this function.
+            # There is a closure on player. To break up that reference, delete this function.
             player.on_player_eos = None
+            player.delete()
 
         player.on_player_eos = _on_player_eos
         return player
 
-    def get_animation(self):
+    def get_animation(self) -> 'Animation':
         """
         Import all video frames into memory.
 
@@ -273,7 +293,7 @@ class Source:
                 next_ts = self.get_next_video_timestamp()
             return Animation(frames)
 
-    def get_next_video_timestamp(self):
+    def get_next_video_timestamp(self) -> Optional[float]:
         """Get the timestamp of the next video frame.
 
         .. versionadded:: 1.1
@@ -284,7 +304,7 @@ class Source:
         """
         pass
 
-    def get_next_video_frame(self):
+    def get_next_video_frame(self) -> Optional['AbstractImage']:
         """Get the next video frame.
 
         .. versionadded:: 1.1
@@ -296,7 +316,10 @@ class Source:
         """
         pass
 
-    def save(self, filename, file=None, encoder=None):
+    def save(self,
+             filename: str,
+             file: Optional[BinaryIO] = None,
+             encoder: Optional['MediaEncoder'] = None) -> None:
         """Save this Source to a file.
 
         :Parameters:
@@ -312,14 +335,52 @@ class Source:
 
         """
         if encoder:
-            return encoder.enccode(self, filename, file)
+            return encoder.encode(self, filename, file)
         else:
             import pyglet.media.codecs
             return pyglet.media.codecs.registry.encode(self, filename, file)
 
     # Internal methods that Player calls on the source:
 
-    def seek(self, timestamp):
+    def is_precise(self) -> bool:
+        """bool: Whether this source is considered precise.
+
+        ``x`` bytes on source ``s`` are considered aligned if
+        ``x % s.audio_format.bytes_per_frame == 0``, so there'd be no partial
+        audio frame in the returned data.
+
+        A source is precise if - for an aligned request of ``x`` bytes - it
+        returns:\\
+
+          - If ``x`` or more bytes are available, ``x`` bytes.
+          - If not enough bytes are available anymore, ``r`` bytes where
+            ``r < x`` and ``r`` is aligned.
+
+        A source is **not** precise if it does any of these:
+
+          - Return less than ``x`` bytes for an aligned request of ``x``
+            bytes although data still remains so that an additional request
+            would return additional :class:`.AudioData` / not ``None``.
+          - Return more bytes than requested.
+          - Return an unaligned amount of bytes for an aligned request.
+
+        pyglet's internals are guaranteed to never make unaligned
+        requests, or requests of less than 1024 bytes.
+
+        If this method returns ``False``, pyglet will wrap the source in an
+        alignment-forcing buffer creating additional overhead.
+
+        If this method is overridden to return ``True`` although the source
+        does not comply with the requirements above, audio playback may be
+        negatively impacted at best and memory access violations occurr at
+        worst.
+
+        :Returns:
+            bool: Whether the source is precise.
+        """
+        return False
+
+    def seek(self, timestamp: float) -> None:
         """Seek to given timestamp.
 
         Args:
@@ -328,20 +389,30 @@ class Source:
         """
         raise CannotSeekException()
 
-    def get_queue_source(self):
+    def get_queue_source(self) -> 'Source':
         """Return the ``Source`` to be used as the queue source for a player.
 
-        Default implementation returns self.
-        """
-        return self
+        Default implementation returns ``self`` if this source is precise as
+        specified by :meth:`is_precise` or if the ``imprecise_ok`` argument
+        is given. Otherwise, a new :class:`PreciseStreamingSource` wrapping
+        this source is returned.
 
-    def get_audio_data(self, num_bytes, compensation_time=0.0):
+        Returns:
+            :class:`Source`
+        """
+        return self if self.is_precise() else PreciseStreamingSource(self)
+
+    def get_audio_data(self, num_bytes: int, compensation_time=0.0) -> Optional[AudioData]:
         """Get next packet of audio data.
 
         Args:
-            num_bytes (int): Maximum number of bytes of data to return.
+            num_bytes (int): A size hint for the amount of bytes to return,
+                but the returned amount may be lower or higher.
             compensation_time (float): Time in sec to compensate due to a
                 difference between the master clock and the audio clock.
+
+        .. deprecated:: 2.0.10
+            compensation_time: Will always be given as ``0.0``.
 
         Returns:
             :class:`.AudioData`: Next packet of audio data, or ``None`` if
@@ -357,7 +428,7 @@ class StreamingSource(Source):
     :class:`~pyglet.media.player.Player`.
     """
 
-    def get_queue_source(self):
+    def get_queue_source(self) -> 'StreamingSource':
         """Return the ``Source`` to be used as the source for a player.
 
         Default implementation returns self.
@@ -368,9 +439,9 @@ class StreamingSource(Source):
         if self.is_player_source:
             raise MediaException('This source is already queued on a player.')
         self.is_player_source = True
-        return self
+        return super().get_queue_source()
 
-    def delete(self):
+    def delete(self) -> None:
         """Release the resources held by this StreamingSource."""
         pass
 
@@ -388,15 +459,15 @@ class StaticSource(Source):
             from.
     """
 
-    def __init__(self, source):
+    def __init__(self, source: Source) -> None:
         source = source.get_queue_source()
         if source.video_format:
             raise NotImplementedError('Static sources not supported for video.')
 
         self.audio_format = source.audio_format
-        if not self.audio_format:
+        if self.audio_format is None:
             self._data = None
-            self._duration = 0.
+            self._duration = 0.0
             return
 
         # Arbitrary: number of bytes to request at a time.
@@ -407,18 +478,18 @@ class StaticSource(Source):
         data = io.BytesIO()
         while True:
             audio_data = source.get_audio_data(buffer_size)
-            if not audio_data:
+            if audio_data is None:
                 break
-            data.write(audio_data.get_string_data())
+            data.write(audio_data.data)
         self._data = data.getvalue()
 
         self._duration = len(self._data) / self.audio_format.bytes_per_second
 
-    def get_queue_source(self):
+    def get_queue_source(self) -> Optional['StaticMemorySource']:
         if self._data is not None:
             return StaticMemorySource(self._data, self.audio_format)
 
-    def get_audio_data(self, num_bytes, compensation_time=0.0):
+    def get_audio_data(self, num_bytes: float, compensation_time: float = 0.0) -> Optional[AudioData]:
         """The StaticSource does not provide audio data.
 
         When the StaticSource is queued on a
@@ -439,59 +510,49 @@ class StaticMemorySource(StaticSource):
     Do not use directly. This class is used internally by pyglet.
 
     Args:
-        data (AudioData): The audio data.
+        data (readable buffer): The audio data.
         audio_format (AudioFormat): The audio format.
     """
 
-    def __init__(self, data, audio_format):
+    def __init__(self, data, audio_format: AudioFormat) -> None:
         """Construct a memory source over the given data buffer."""
         self._file = io.BytesIO(data)
         self._max_offset = len(data)
         self.audio_format = audio_format
         self._duration = len(data) / float(audio_format.bytes_per_second)
 
-    def seek(self, timestamp):
+    def is_precise(self) -> bool:
+        return True
+
+    def seek(self, timestamp: float) -> None:
         """Seek to given timestamp.
 
         Args:
             timestamp (float): Time where to seek in the source.
         """
         offset = int(timestamp * self.audio_format.bytes_per_second)
+        # Align to audio frame to not corrupt audio data.
+        self._file.seek(self.audio_format.align(offset))
 
-        # Align to sample
-        if self.audio_format.bytes_per_sample == 2:
-            offset &= 0xfffffffe
-        elif self.audio_format.bytes_per_sample == 4:
-            offset &= 0xfffffffc
-
-        self._file.seek(offset)
-
-    def get_audio_data(self, num_bytes, compensation_time=0.0):
+    def get_audio_data(self, num_bytes: float, compensation_time: float = 0.0) -> Optional[AudioData]:
         """Get next packet of audio data.
 
         Args:
             num_bytes (int): Maximum number of bytes of data to return.
-            compensation_time (float): Not used in this class.
 
         Returns:
             :class:`.AudioData`: Next packet of audio data, or ``None`` if
             there is no (more) data.
         """
-        offset = self._file.tell()
-        timestamp = float(offset) / self.audio_format.bytes_per_second
-
-        # Align to sample size
-        if self.audio_format.bytes_per_sample == 2:
-            num_bytes &= 0xfffffffe
-        elif self.audio_format.bytes_per_sample == 4:
-            num_bytes &= 0xfffffffc
+        offset_before = self._file.tell()
 
         data = self._file.read(num_bytes)
-        if not len(data):
+        if not data:
             return None
 
-        duration = float(len(data)) / self.audio_format.bytes_per_second
-        return AudioData(data, len(data), timestamp, duration, [])
+        timestamp = float(offset_before) / self.audio_format.bytes_per_second
+        duration = len(data) / self.audio_format.bytes_per_second
+        return AudioData(data, len(data), timestamp, duration)
 
 
 class SourceGroup:
@@ -502,7 +563,7 @@ class SourceGroup:
     The first source added sets the format.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.audio_format = None
         self.video_format = None
         self.duration = 0.0
@@ -510,24 +571,24 @@ class SourceGroup:
         self._dequeued_durations = []
         self._sources = []
 
-    def seek(self, time):
+    def seek(self, time: float) -> None:
         if self._sources:
             self._sources[0].seek(time)
 
-    def add(self, source):
+    def add(self, source: Source) -> None:
         self.audio_format = self.audio_format or source.audio_format
         source = source.get_queue_source()
         assert (source.audio_format == self.audio_format), "Sources must share the same audio format."
         self._sources.append(source)
         self.duration += source.duration
 
-    def has_next(self):
+    def has_next(self) -> bool:
         return len(self._sources) > 1
 
-    def get_queue_source(self):
+    def get_queue_source(self) -> 'SourceGroup':
         return self
 
-    def _advance(self):
+    def _advance(self) -> None:
         if self._sources:
             self._timestamp_offset += self._sources[0].duration
             self._dequeued_durations.insert(0, self._sources[0].duration)
@@ -538,7 +599,7 @@ class SourceGroup:
                 old_source.delete()
                 del old_source
 
-    def get_audio_data(self, num_bytes, compensation_time=0.0):
+    def get_audio_data(self, num_bytes: float, compensation_time=0.0) -> Optional[AudioData]:
         """Get next audio packet.
 
         :Parameters:
@@ -565,4 +626,107 @@ class SourceGroup:
             else:
                 self._advance()
 
-        return AudioData(buffer, len(buffer), timestamp, duration, [])
+        return AudioData(buffer, len(buffer), timestamp, duration)
+
+
+class PreciseStreamingSource(StreamingSource):
+    """Wrap non-precise sources that may over- or undershoot.
+
+    Purpose of this source is to always return data whose length is equal or
+    less than in length, where less hints at definite source exhaustion.
+
+    This source is used by pyglet internally, you probably don't need to
+    bother with it.
+
+    This source erases AudioData-contained timestamp/duration information and
+    events.
+    """
+
+    def __init__(self, source: Source) -> None:
+        self._source = source
+        self._buffer = bytearray()
+        self._exhausted = False
+        self._is_player_source = False
+
+        # Forward formats, info and duration
+        self.audio_format = source.audio_format
+        self.video_format = source.video_format
+        self.info = source.info
+
+        self._duration = source.duration
+
+    @property
+    def is_player_source(self) -> bool:
+        return self._source.is_player_source
+
+    @is_player_source.setter
+    def is_player_source(self, n: bool) -> None:
+        self._source.is_player_source = n
+
+    def is_precise(self) -> bool:
+        return True
+
+    def seek(self, timestamp: float) -> None:
+        self._buffer.clear()
+        self._exhausted = False
+        self._source.seek(timestamp)
+
+    def get_audio_data(self, num_bytes: int) -> Optional[AudioData]:
+        if self._exhausted:
+            return None
+
+        if len(self._buffer) < num_bytes:
+            # Buffer is incapable of fulfilling request, get more
+
+            # Reduce amount of required bytes by buffer length
+            required_bytes = num_bytes - len(self._buffer)
+
+            # Don't bother with super-small requests to something that likely does some form of I/O
+            # Also, intentionally overshoot since some sources may just barely undercut.
+            base_attempt = next_or_equal_power_of_two(max(4096, required_bytes + 16))
+            attempts = (base_attempt, base_attempt, base_attempt * 2, base_attempt * 8)
+            cur_attempt_idx = 0
+            # A malicious decoder could technically trap us by delivering empty AudioData, though
+            # the argument that this is unnecessarily defensive programming is definitely valid.
+            empty_bailout = 4
+
+            while True:
+                if cur_attempt_idx + 1 < 4: # len(attempts)
+                    cur_attempt_idx += 1
+                res = self._source.get_audio_data(attempts[cur_attempt_idx])
+
+                if res is None:
+                    self._exhausted = True
+                elif res.length == 0:
+                    empty_bailout -= 1
+                    if empty_bailout <= 0:
+                        self._exhausted = True
+                else:
+                    empty_bailout = 4
+                    self._buffer += res.data
+
+                if len(self._buffer) >= num_bytes or self._exhausted:
+                    break
+
+        res = self._buffer[:num_bytes]
+        if not res:
+            return None
+
+        del self._buffer[:num_bytes]
+        return AudioData(res, len(res))
+
+    def get_next_video_timestamp(self) -> Optional[float]:
+        return self._source.get_next_video_timestamp()
+
+    def get_next_video_frame(self) -> Optional['AbstractImage']:
+        return self._source.get_next_video_frame()
+
+    def save(self,
+             filename: str,
+             file: Optional[BinaryIO] = None,
+             encoder: Optional['MediaEncoder'] = None) -> None:
+        self._source.save(filename, file, encoder)
+
+    def delete(self) -> None:
+        self._source.delete()
+        self._buffer.clear()

--- a/pyglet/media/drivers/__init__.py
+++ b/pyglet/media/drivers/__init__.py
@@ -74,15 +74,14 @@ def get_audio_driver():
 
 
 def _delete_audio_driver():
-    # First cleanup any remaining spontaneous Player
+    global _audio_driver
+
     from .. import Source
     for p in Source._players:
-        # Remove the reference to _on_player_eos which had a closure on the player
-        p.on_player_eos = None
-        del p
-
+        p.delete()
     del Source._players
-    global _audio_driver
+
+    _audio_driver.delete()
     _audio_driver = None
 
 

--- a/pyglet/media/drivers/base.py
+++ b/pyglet/media/drivers/base.py
@@ -424,9 +424,6 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         pass
 
 
-AbstractAudioPlayer = AbstractAudioPlayer
-
-
 class AbstractAudioDriver(metaclass=ABCMeta):
     @abstractmethod
     def create_audio_player(self, source, player):

--- a/pyglet/media/drivers/base.py
+++ b/pyglet/media/drivers/base.py
@@ -1,19 +1,21 @@
-import math
-import time
+from collections import deque
+import ctypes
 import weakref
 from abc import ABCMeta, abstractmethod
 
 import pyglet
+from pyglet.media.codecs import AudioData
+from pyglet.util import debug_print
+
+
+_debug = debug_print('debug_media')
 
 
 class AbstractAudioPlayer(metaclass=ABCMeta):
-    """Base class for driver audio players.
+    """Base class for driver audio players to be used by the high-level
+    player. Relies on a thread to regularly call a `work` method in order
+    for it to operate.
     """
-
-    # Audio synchronization constants
-    AUDIO_DIFF_AVG_NB = 20
-    # no audio correction is done if too big error
-    AV_NOSYNC_THRESHOLD = 10.0
 
     def __init__(self, source, player):
         """Create a new audio player.
@@ -28,14 +30,33 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         # We only keep weakref to the player and its source to avoid
         # circular references. It's the player who owns the source and
         # the audio_player
-        self.source = source
+        self.source = weakref.proxy(source)
         self.player = weakref.proxy(player)
 
+        afmt = source.audio_format
+        # How much data should ideally be in memory ready to be played.
+        self._singlebuffer_ideal_size = max(32768, afmt.timestamp_to_bytes_aligned(0.9))
+
+        # At which point a driver should try and refill data from the source
+        self._buffered_data_comfortable_limit = int(self._singlebuffer_ideal_size * (2/3))
+
+        # A deque of (play_cursor, MediaEvent)
+        self._events = deque()
+
         # Audio synchronization
-        self.audio_diff_avg_count = 0
-        self.audio_diff_cum = 0.0
-        self.audio_diff_avg_coef = math.exp(math.log10(0.01) / self.AUDIO_DIFF_AVG_NB)
-        self.audio_diff_threshold = 0.1  # Experimental. ffplay computes it differently
+        self.AUDIO_SYNC_REQUIRED_MEASUREMENTS = 8
+        # Consider critical desync when any measurement is off by more than 280ms
+        self.audio_sync_critical_difference = afmt.timestamp_to_bytes_aligned(0.280)
+        # Only initiate sync when average is off by more than 30ms
+        self.audio_sync_minimal_difference = afmt.timestamp_to_bytes_aligned(0.030)
+
+        self.audio_sync_measurements = deque(maxlen=self.AUDIO_SYNC_REQUIRED_MEASUREMENTS)
+        self.audio_sync_cumul_measurements = 0
+
+        # Bytes that have been skipped or artificially added to compensate for audio
+        # desync since initialization or the last call to `clear`.
+        # Negative when data was skipped, positive if it was padded in.
+        self._compensated_bytes = 0
 
     def on_driver_destroy(self):
         """Called before the audio driver is going to be destroyed (a planned destroy)."""
@@ -43,6 +64,113 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
 
     def on_driver_reset(self):
         """Called after the audio driver has been re-initialized."""
+        pass
+
+    def set_source(self, source):
+        """Change the player's source for a new one.
+        It must be of the same audio format.
+        Will clear the player, make sure you paused it beforehand.
+        """
+        assert self.source.audio_format == source.audio_format
+
+        self.clear()
+        self.source = weakref.proxy(source)
+
+    @abstractmethod
+    def prefill_audio(self):
+        """Prefill the audio buffer with audio data.
+
+        This method is called before the audio player starts in order to
+        have it play as soon as possible.
+        """
+        # It is illegal to call this method while the player is playing.
+
+    @abstractmethod
+    def work(self):
+        """Ran regularly by the worker thread. This method should fill up
+        the player's buffers if required, and dispatch any necessary events.
+        """
+        # The general flow for a work method should be something like:
+        # update_play_cursor()
+        # dispatch_media_events()
+        # if not source_exhausted:
+        #   if play_cursor_too_close_to_write_cursor():
+        #     get_and_submit_new_audio_data()
+        #     if not source_exhausted:
+        #       return
+        #     else:
+        #       update_play_cursor()
+        #   else:
+        #     return
+        # if play_cursor > write_cursor and not _has_underrun:
+        #   _has_underrun = True
+        #   dispatch_on_eos()
+        #
+        # Player backends might report an underflow or buffer ends via a callback.
+        # In that case, it should look something like this, but beware to protect
+        # appropiate sections (any time variables and buffers are used which get accessed by both
+        # callbacks and the work method) with a lock, otherwise you are probably opening yourself
+        # up to really unlucky issues where the callback is unscheduled in favor of the work
+        # method or vice versa, which may leave some variables in inconclusive states.
+        # work:
+        #  update_play_cursor()
+        #  dispatch_media_events()
+        #  if not source_exhausted:
+        #    if play_cursor_too_close_to_write_cursor():
+        #      get_and_submit_new_audio_data()
+        #      if _has_underrun:
+        #        if source_exhausted:
+        #          dispatch_eon_eos()
+        #        else:
+        #          restart_player()
+        #          _has_underrun = False
+        #
+        # on_underrun:
+        #   if source_exhausted:
+        #     dispatch_on_eos()
+        #   else:
+        #     _has_underrun = True
+        #
+        # Implementing this method in tandem with the others safely is prone to pitfalls,
+        # so here's some hints:
+        # It may get called from the worker thread. While that happens, the worker thread
+        # will hold its operation lock.
+        # These things could theoretically happen to the player while `work` is being
+        # called:
+        #
+        # It may get paused/unpaused.
+        # - Receiving data after getting paused/unpaused is typically not a problem.
+        #   Realistically, this won't happen as all implementations include a
+        #   `self.driver.worker.remove/add(self)` snippet in their `play`/`pause`
+        #   implementations.
+        #
+        # It may get deleted.
+        # - In this case, attempting to continue with the data will cause some sort of error
+        #   To combat this, all `delete` implementations contain a form of
+        #   `self.driver.worker.remove(self)`.
+        #
+        # It may *not* get cleared.
+        # - It is illegal to call `clear`` on an unpaused player, and only playing players
+        #   are in the worker thread.
+        #
+        # A native callback may run which changes the internal state of the player
+        # - See above; protecting some sections with a lock local to the player
+        #   Be sure to never hold the lock around get_audio_data; that ruins the entire
+        #   point of running work outside of native callbacks.
+        #
+        # NOTE: In order for these calls to be more reliable, `remove` should be the first
+        # statement in such implementations and `add` the last one, to ensure that `work`
+        # will not be run after/not start before player attributes have been changed.
+        #
+        # Don't assume `work` stops being called just because it dispatched `on_eos`!
+        #
+        # This method may also be called from the main thread through `prefill_audio`.
+        # This will only happen before the player is started: `work` will never interfere
+        # with itself.
+        # Audioplayers are not threadsafe and should only be interacted with through the main
+        # thread.
+        # TODO: That last line is more directed to pyglet users, maybe throw it into the docs
+        # somewhere.
         pass
 
     @abstractmethod
@@ -54,8 +182,49 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         """Stop (pause) playback."""
 
     @abstractmethod
+    def clear(self):
+        """Clear all buffered data and prepare for replacement data.
+
+        The player must be stopped before calling this method.
+        """
+        self._events.clear()
+        self._compensated_bytes = 0
+        self.audio_sync_measurements.clear()
+        self.audio_sync_cumul_measurements = 0
+
+    @abstractmethod
     def delete(self):
         """Stop playing and clean up all resources used by player."""
+        # This may be called from high level Players on shutdown after the player's driver
+        # has been deleted. AudioPlayer implementations must handle this.
+
+    @abstractmethod
+    def get_play_cursor(self):
+        """Get this player's most recent play cursor/read index/byte offset,
+        starting from the last clear operation or initialization.
+
+        ``0`` is an acceptable return value when unavailable or unknown.
+        """
+        # This method should not/does not need to ask the audio backend for the
+        # most recent play cursor position.
+        # It is not supposed to be accurate; accurate play cursor info is always
+        # passed into the corresponding methods from the implementation subclass.
+
+    def get_time(self):
+        """Retrieve the time in the current source the player is at, in seconds.
+        By default, calculated using :meth:`get_play_cursor`, divided by the
+        bytes per second played.
+        """
+        # See notes on `get_play_cursor` as well.
+        return self._raw_play_cursor_to_time(self.get_play_cursor()) + self.player.last_seek_time
+
+    def _raw_play_cursor_to_time(self, cursor):
+        if cursor is None:
+            return None
+        return self._to_perceived_play_cursor(cursor) / self.source.audio_format.bytes_per_second
+
+    def _to_perceived_play_cursor(self, play_cursor):
+        return play_cursor - self._compensated_bytes
 
     def _play_group(self, audio_players):
         """Begin simultaneous playback on a list of audio players."""
@@ -69,62 +238,154 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         for player in audio_players:
             player.stop()
 
-    @abstractmethod
-    def clear(self):
-        """Clear all buffered data and prepare for replacement data.
+    def append_events(self, start_index, events):
+        """Append the given :class:`MediaEvent`s to the events deque using
+        the current source's audio format and the supplied ``start_index``
+        to convert their timestamps to dispatch indices.
 
-        The player should be stopped before calling this method.
+        The high level player's ``last_seek_time`` will be subtracted from
+        each event's timestamp.
         """
-        self.audio_diff_avg_count = 0
-        self.audio_diff_cum = 0.0
+        bps = self.source.audio_format.bytes_per_second
+        lst = self.player.last_seek_time
+        for event in events:
+            event_cursor = start_index + (max(0.0, event.timestamp - lst) * bps)
+            assert _debug(f'AbstractAudioPlayer: Adding event {event} at {event_cursor}')
+            self._events.append((event_cursor, event))
 
-    @abstractmethod
-    def get_time(self):
-        """Return approximation of current playback time within current source.
-
-        Returns ``None`` if the audio player does not know what the playback
-        time is (for example, before any valid audio data has been read).
-
-        :rtype: float
-        :return: current play cursor time, in seconds.
+    def dispatch_media_events(self, until_cursor):
+        """Dispatch all :class:`MediaEvent`s whose index is less than or equal
+        to the specified ``until_cursor`` (which should be a very recent play
+        cursor position).
+        Please note that :attr:`_compensated_bytes` will be subtracted from
+        the passed ``until_cursor``.
         """
-        # TODO determine which source within group
+        until_cursor = self._to_perceived_play_cursor(until_cursor)
 
-    @abstractmethod
-    def prefill_audio(self):
-        """Prefill the audio buffer with audio data.
+        while self._events and self._events[0][0] <= until_cursor:
+            self._events.popleft()[1].sync_dispatch_to_player(self.player)
 
-        This method is called before the audio player starts in order to 
-        reduce the time it takes to fill the whole audio buffer.
+    def get_audio_time_diff(self, audio_time):
+        """Query the difference between the provided time and the high
+        level `Player`'s master clock.
+
+        The time difference returned is calculated as an average on previous
+        audio time differences.
+
+        Return a tuple of the bytes the player is off by, aligned to correspond
+        to an integer number of audio frames, as well as bool designating
+        whether the difference is extreme. If it is, it should be rectified
+        immediately and all previous measurements will have been cleared.
+
+        This method will return ``0, False`` if the difference is not
+        significant or ``audio_time`` is ``None``.
+
+        :rtype: int, bool
         """
+        if audio_time is not None:
+            p_time = self.player.time
+            audio_time += self.player.last_seek_time
 
-    def get_audio_time_diff(self):
-        """Queries the time difference between the audio time and the `Player`
-        master clock.
+            diff_bytes = self.source.audio_format.timestamp_to_bytes_aligned(audio_time - p_time)
 
-        The time difference returned is calculated using a weighted average on
-        previous audio time differences. The algorithms will need at least 20
-        measurements before returning a weighted average.
+            if abs(diff_bytes) >= self.audio_sync_critical_difference:
+                self.audio_sync_measurements.clear()
+                self.audio_sync_cumul_measurements = 0
+                return diff_bytes, True
 
-        :rtype: float
-        :return: weighted average difference between audio time and master
-            clock from `Player`
+            if len(self.audio_sync_measurements) == self.AUDIO_SYNC_REQUIRED_MEASUREMENTS:
+                self.audio_sync_cumul_measurements -= self.audio_sync_measurements[0]
+            self.audio_sync_measurements.append(diff_bytes)
+            self.audio_sync_cumul_measurements += diff_bytes
+
+        if len(self.audio_sync_measurements) == self.AUDIO_SYNC_REQUIRED_MEASUREMENTS:
+            avg_diff = self.source.audio_format.align(
+                self.audio_sync_cumul_measurements // self.AUDIO_SYNC_REQUIRED_MEASUREMENTS)
+
+            # print(
+            #     f"{diff_bytes:>6}, {avg_diff:>6} | "
+            #     f"{(diff_bytes / self.source.audio_format.bytes_per_second):>9.6f}, "
+            #     f"{(avg_diff / self.source.audio_format.bytes_per_second):>9.6f}"
+            # )
+            if abs(avg_diff) > self.audio_sync_minimal_difference:
+                return avg_diff, False
+        # else:
+        #     if audio_time is not None:
+        #         print(
+        #             f"{diff_bytes:>6}, | "
+        #             f"{(diff_bytes / self.source.audio_format.bytes_per_second):>9.6f}, "
+        #         )
+
+        return 0, False
+
+    def _get_and_compensate_audio_data(self, requested_size, audio_position=None):
         """
-        audio_time = self.get_time() or 0
-        p_time = self.player.time
-        diff = audio_time - p_time
-        if abs(diff) < self.AV_NOSYNC_THRESHOLD:
-            self.audio_diff_cum = diff + self.audio_diff_cum * self.audio_diff_avg_coef
-            if self.audio_diff_avg_count < self.AUDIO_DIFF_AVG_NB:
-                self.audio_diff_avg_count += 1
-            else:
-                avg_diff = self.audio_diff_cum * (1 - self.audio_diff_avg_coef)
-                if abs(avg_diff) > self.audio_diff_threshold:
-                    return avg_diff
-        else:
-            self.audio_diff_avg_count = 0
-            self.audio_diff_cum = 0.0
-        return 0.0
+        Retrieve a packet of `AudioData` of the given size.
+        """
+        audio_time = self._raw_play_cursor_to_time(audio_position)
+        desync_bytes, extreme_desync = self.get_audio_time_diff(audio_time)
+
+        if desync_bytes == 0:
+            return self.source.get_audio_data(requested_size)
+
+        compensated_bytes = 0
+        afmt = self.source.audio_format
+
+        assert _debug(f"Audio desync, {desync_bytes=}, {extreme_desync=}")
+        assert desync_bytes % afmt.bytes_per_frame == 0
+
+        if desync_bytes > 0:
+            # Player running ahead
+            # Request at most 12ms less or only enough to not undercut the request size by 1024
+            # We can't do anything if this is a major desync (other than seeking backwards later),
+            # but trying to avoid seeking behind the high level player's back)
+            compensated_bytes = min(
+                requested_size - afmt.align_ceil(1024),
+                desync_bytes,
+                afmt.timestamp_to_bytes_aligned(0.012),
+            )
+
+            audio_data = self.source.get_audio_data(requested_size - compensated_bytes)
+            if audio_data is not None:
+                if audio_data.length < afmt.bytes_per_frame:
+                    raise RuntimeError("Partial audio frame returned?")
+
+                first_frame = ctypes.string_at(audio_data.pointer, afmt.bytes_per_frame)
+                ad = bytearray(audio_data.length + compensated_bytes)
+                ad[0:compensated_bytes] = first_frame * (compensated_bytes // afmt.bytes_per_frame)
+                ad[compensated_bytes:] = audio_data.data
+
+                audio_data = AudioData(ad, len(ad), audio_data.events)
+
+        elif desync_bytes < 0:
+            # Player falling behind
+            # Skip at most 12ms if this is a minor desync, otherwise skip the entire
+            # difference. this will be noticeable, but the desync is
+            # likely already noticable in context of whatever the application does.
+            compensated_bytes = (-desync_bytes
+                                 if extreme_desync
+                                 else min(-desync_bytes, afmt.timestamp_to_bytes_aligned(0.012)))
+
+            audio_data = self.source.get_audio_data(requested_size + compensated_bytes)
+            if audio_data is not None:
+                if audio_data.length <= compensated_bytes:
+                    compensated_bytes = -audio_data.length
+                    audio_data = None
+                else:
+                    audio_data = AudioData(
+                        ctypes.string_at(
+                            audio_data.pointer + compensated_bytes,
+                            audio_data.length - compensated_bytes,
+                        ),
+                        audio_data.length - compensated_bytes,
+                        audio_data.events,
+                    )
+                    compensated_bytes *= -1
+
+        assert _debug(f"Compensated {compensated_bytes} after audio desync")
+        self._compensated_bytes += compensated_bytes
+
+        return audio_data
 
     def set_volume(self, volume):
         """See `Player.volume`."""
@@ -162,17 +423,8 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         """See `Player.cone_outer_gain`."""
         pass
 
-    @property
-    def source(self):
-        """Source to play from.
-        May be swapped out for one of an equal audio format, but ensure that
-        the player has been paused and cleared beforehand.
-        """
-        return self._source
 
-    @source.setter
-    def source(self, value):
-        self._source = weakref.proxy(value)
+AbstractAudioPlayer = AbstractAudioPlayer
 
 
 class AbstractAudioDriver(metaclass=ABCMeta):
@@ -204,7 +456,7 @@ class MediaEvent:
 
     __slots__ = 'event', 'timestamp', 'args'
 
-    def __init__(self, event, timestamp=0, *args):
+    def __init__(self, event, timestamp=0.0, *args):
         # Meaning of timestamp is dependent on context; and not seen by application.
         self.event = event
         self.timestamp = timestamp
@@ -212,11 +464,11 @@ class MediaEvent:
 
     def sync_dispatch_to_player(self, player):
         pyglet.app.platform_event_loop.post_event(player, self.event, *self.args)
-        time.sleep(0)
-        # TODO sync with media.dispatch_events
 
     def __repr__(self):
         return f"MediaEvent({self.event}, {self.timestamp}, {self.args})"
 
     def __lt__(self, other):
-        return hash(self) < hash(other)
+        if not isinstance(other, MediaEvent):
+            return NotImplemented
+        return self.timestamp < other.timestamp

--- a/pyglet/media/drivers/directsound/adaptation.py
+++ b/pyglet/media/drivers/directsound/adaptation.py
@@ -2,10 +2,10 @@ import math
 import ctypes
 
 from . import interface
-from pyglet.util import debug_print
-from pyglet.media.mediathreads import PlayerWorkerThread
 from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer, MediaEvent
 from pyglet.media.drivers.listener import AbstractListener
+from pyglet.media.player_worker_thread import PlayerWorkerThread
+from pyglet.util import debug_print
 
 _debug = debug_print('debug_media')
 
@@ -33,31 +33,91 @@ def _db2gain(db):
     return math.pow(10.0, float(db)/1000.0)
 
 
+class DirectSoundDriver(AbstractAudioDriver):
+    def __init__(self):
+        self._ds_driver = interface.DirectSoundDriver()
+        self._ds_listener = self._ds_driver.create_listener()
+        self._listener = DirectSoundListener(self._ds_listener, self._ds_driver.primary_buffer)
+
+        assert self._ds_driver is not None
+        assert self._ds_listener is not None
+
+        self.worker = PlayerWorkerThread()
+        self.worker.start()
+
+    def create_audio_player(self, source, player):
+        assert self._ds_driver is not None
+        return DirectSoundAudioPlayer(self, source, player)
+
+    def get_listener(self):
+        assert self._ds_driver is not None
+        assert self._ds_listener is not None
+        return self._listener
+
+    def delete(self):
+        if self._ds_listener is None:
+            assert _debug("DirectSoundDriver.delete() on deleted driver, ignoring")
+            return
+
+        assert _debug("Deleting DirectSoundDriver")
+        self.worker.stop()
+        # Destroy listener before destroying driver
+        self._ds_listener.delete()
+        self._ds_listener = None
+        self._ds_driver.delete()
+        self._ds_driver = None
+        assert _debug("DirectSoundDriver deleted.")
+
+
+class DirectSoundListener(AbstractListener):
+    def __init__(self, ds_listener, ds_primary_buffer):
+        self._ds_listener = ds_listener
+        self._ds_primary_buffer = ds_primary_buffer
+
+    def _set_volume(self, volume):
+        self._volume = volume
+        self._ds_primary_buffer.volume = _gain2db(volume)
+
+    def _set_position(self, position):
+        self._position = position
+        self._ds_listener.position = _convert_coordinates(position)
+
+    def _set_forward_orientation(self, orientation):
+        self._forward_orientation = orientation
+        self._set_orientation()
+
+    def _set_up_orientation(self, orientation):
+        self._up_orientation = orientation
+        self._set_orientation()
+
+    def _set_orientation(self):
+        self._ds_listener.orientation = (_convert_coordinates(self._forward_orientation)
+                                         + _convert_coordinates(self._up_orientation))
+
+
 class DirectSoundAudioPlayer(AbstractAudioPlayer):
-    # Need to cache these because pyglet API allows update separately, but
-    # DSound requires both to be set at once.
-    _cone_inner_angle = 360
-    _cone_outer_angle = 360
-
-    min_buffer_size = 9600
-
-    def __init__(self, driver, ds_driver, source, player):
-        super(DirectSoundAudioPlayer, self).__init__(source, player)
+    def __init__(self, driver, source, player):
+        super().__init__(source, player)
 
         # We keep here a strong reference because the AudioDriver is anyway
         # a singleton object which will only be deleted when the application
         # shuts down. The AudioDriver does not keep a ref to the AudioPlayer.
         self.driver = driver
-        self._ds_driver = ds_driver
 
-        # Desired play state (may be actually paused due to underrun -- not
-        # implemented yet).
+        # Desired play state. As the DS Buffer is just a circular buffer, it is
+        # not possible to have it stop at an exact position if the source
+        # should lag behind and cause it to underrun.
         self._playing = False
 
-        # Up to one audio data may be buffered if too much data was received
-        # from the source that could not be written immediately into the
-        # buffer.  See _refill().
-        self._audiodata_buffer = None
+        # Need to cache these because pyglet API allows update separately, but
+        # DSound requires both to be set at once.
+        self._cone_inner_angle = 360
+        self._cone_outer_angle = 360
+
+        # Actual cursors for the circular DSBuffer. Will never exceed
+        # `self._buffer_size`.
+        self._play_cursor_ring = 0
+        self._write_cursor_ring = 0
 
         # Theoretical write and play cursors for an infinite buffer.  play
         # cursor is always <= write cursor (when equal, underrun is
@@ -65,50 +125,36 @@ class DirectSoundAudioPlayer(AbstractAudioPlayer):
         self._write_cursor = 0
         self._play_cursor = 0
 
-        # Cursor position of end of data.  Silence is written after
-        # eos for one buffer size.
+        # Cursor position of where the source ran out.
+        # We are done once the play cursor crosses it.
         self._eos_cursor = None
+
+        # Always set to just after the most recently written audio data; so
+        # either undefined data or silence. The eos cursor is set to it once
+        # the source is confirmed to have run out.
+        self._possible_eos_cursor = 0
 
         # Whether the source has hit its end; protect against duplicate
         # dispatch of on_eos events.
         self._has_underrun = False
 
-        # Indexes into DSound circular buffer.  Complications ensue wrt each
-        # other to avoid writing over the play cursor.  See _get_write_size and
-        # write().
-        self._play_cursor_ring = 0
-        self._write_cursor_ring = 0
-
-        # List of (play_cursor, MediaEvent), in sort order
-        self._events = []
-
-        # List of (cursor, timestamp), in sort order (cursor gives expiry
-        # place of the timestamp)
-        self._timestamps = []
-
-        audio_format = source.audio_format
-
         # DSound buffer
-        self._ds_buffer = self._ds_driver.create_buffer(audio_format)
-        self._buffer_size = self._ds_buffer.buffer_size
-
+        self._buffer_size = self._singlebuffer_ideal_size
+        self._ds_buffer = self.driver._ds_driver.create_buffer(source.audio_format, self._buffer_size)
         self._ds_buffer.current_position = 0
 
-        self._refill(self._buffer_size)
-
-    def __del__(self):
-        # We decrease the IDirectSound refcount
-        self.driver._ds_driver._native_dsound.Release()
+        assert self._ds_buffer.buffer_size == self._buffer_size
 
     def delete(self):
-        self.driver.worker.remove(self)
+        if self.driver._ds_driver is not None:
+            self.driver.worker.remove(self)
+            self._ds_buffer.delete()
 
     def play(self):
         assert _debug('DirectSound play')
 
         if not self._playing:
             self._playing = True
-            self._get_audiodata()  # prebuffer if needed
             self._ds_buffer.play()
 
         self.driver.worker.add(self)
@@ -126,179 +172,119 @@ class DirectSoundAudioPlayer(AbstractAudioPlayer):
 
     def clear(self):
         assert _debug('DirectSound clear')
-        super(DirectSoundAudioPlayer, self).clear()
+        super().clear()
         self._ds_buffer.current_position = 0
         self._play_cursor_ring = self._write_cursor_ring = 0
-        self._play_cursor = self._write_cursor
+        self._play_cursor = self._write_cursor = 0
         self._eos_cursor = None
-        self._audiodata_buffer = None
+        self._possible_eos_cursor = 0
         self._has_underrun = False
-        del self._events[:]
-        del self._timestamps[:]
 
-    def refill_buffer(self):
-        write_size = self._get_write_size()
-        if write_size > self.min_buffer_size:
-            self._refill(write_size)
-            return True
-        return False
+    def get_play_cursor(self):
+        return self._play_cursor
 
-    def _refill(self, write_size):
-        while write_size > 0:
-            assert _debug(f'_refill, write_size = {write_size}')
-            audio_data = self._get_audiodata()
+    def work(self):
+        assert self._playing
 
-            if audio_data is not None:
-                assert _debug(f'write {audio_data.length}')
-                length = min(write_size, audio_data.length)
-                self.write(audio_data, length)
-                write_size -= length
-            else:
-                assert _debug('write silence')
-                self.write(None, write_size)
-                write_size = 0
+        self._update_play_cursor()
+        self.dispatch_media_events(self._play_cursor)
 
-    def _dispatch_new_event(self, event_name):
-        MediaEvent(event_name).sync_dispatch_to_player(self.player)
+        if self._eos_cursor is None:
+            self._maybe_fill()
+            return
 
-    def _get_audiodata(self):
-        if self._audiodata_buffer is None or self._audiodata_buffer.length == 0:
-            self._get_new_audiodata()
+        # Source exhausted, check whether we hit the end
+        if not self._has_underrun and self._play_cursor > self._eos_cursor:
+            self._has_underrun = True
+            assert _debug('DirectSoundAudioPlayer: Dispatching eos')
+            MediaEvent('on_eos').sync_dispatch_to_player(self.player)
 
-        return self._audiodata_buffer
+        # While we are still playing / waiting for the on_eos to be dispatched for
+        # the player to stop, the buffer continues playing. Ensure that silence is
+        # filled.
+        if (used := self._get_used_buffer_space()) < self._buffered_data_comfortable_limit:
+            self._write(None, self._buffer_size - used)
 
-    def _get_new_audiodata(self):
-        assert _debug('Getting new audio data buffer.')
-        # Pass a reference of ourself to allow the audio decoding to get time
-        # information for synchronization.
-        compensation_time = self.get_audio_time_diff()
-        self._audiodata_buffer = self.source.get_audio_data(self._buffer_size, compensation_time)
+    def _maybe_fill(self):
+        if (used := self._get_used_buffer_space()) < self._buffered_data_comfortable_limit:
+            self._refill(self.source.audio_format.align(self._buffer_size - used))
 
-        if self._audiodata_buffer is not None:
-            assert _debug('New audio data available: {} bytes'.format(self._audiodata_buffer.length))
-
-            if self._eos_cursor is not None:
-                self._move_write_cursor_after_eos()
-
-            self._add_audiodata_events(self._audiodata_buffer)
-            self._add_audiodata_timestamp(self._audiodata_buffer)
-            self._eos_cursor = None
-        elif self._eos_cursor is None:
-            assert _debug('No more audio data.')
-            self._eos_cursor = self._write_cursor
-
-    def _move_write_cursor_after_eos(self):
-        # Set the write cursor back to eos_cursor or play_cursor to prevent gaps
-        if self._play_cursor < self._eos_cursor:
-            cursor_diff = self._write_cursor - self._eos_cursor
-            assert _debug(f'Moving cursor back {cursor_diff}')
-            self._write_cursor = self._eos_cursor
-            self._write_cursor_ring -= cursor_diff
-            self._write_cursor_ring %= self._buffer_size
+    def _refill(self, size):
+        """Refill the next `size` bytes in the buffer using the source.
+        `size` must be aligned.
+        """
+        audio_data = self._get_and_compensate_audio_data(size, self._play_cursor)
+        if audio_data is None:
+            assert _debug('DirectSoundAudioPlayer: Out of audio data')
+            if self._eos_cursor is None:
+                self._eos_cursor = self._possible_eos_cursor
+            self._write(None, size)
 
         else:
-            cursor_diff = self._play_cursor - self._eos_cursor
-            assert _debug(f'Moving cursor back {cursor_diff}')
-            self._write_cursor = self._play_cursor
-            self._write_cursor_ring -= cursor_diff
-            self._write_cursor_ring %= self._buffer_size
+            assert _debug(f'DirectSoundAudioPlayer: Got {audio_data.length} bytes of audio data')
+            self.append_events(self._write_cursor, audio_data.events)
+            self._write(audio_data, size)
 
-    def _add_audiodata_events(self, audio_data):
-        for event in audio_data.events:
-            event_cursor = self._write_cursor + event.timestamp * \
-                           self.source.audio_format.bytes_per_second
-            assert _debug(f'Adding event {event} at {event_cursor}')
-            self._events.append((event_cursor, event))
-
-    def _add_audiodata_timestamp(self, audio_data):
-        ts_cursor = self._write_cursor + audio_data.length
-        self._timestamps.append(
-            (ts_cursor, audio_data.timestamp + audio_data.duration))
-
-    def update_play_cursor(self):
+    def _update_play_cursor(self):
         play_cursor_ring = self._ds_buffer.current_position.play_cursor
         if play_cursor_ring < self._play_cursor_ring:
             # Wrapped around
             self._play_cursor += self._buffer_size - self._play_cursor_ring
-            self._play_cursor_ring = 0
-        self._play_cursor += play_cursor_ring - self._play_cursor_ring
+            self._play_cursor += play_cursor_ring
+        else:
+            self._play_cursor += play_cursor_ring - self._play_cursor_ring
         self._play_cursor_ring = play_cursor_ring
 
-        self._dispatch_pending_events()
-        self._cleanup_timestamps()
-        self._check_underrun()
+    def _get_used_buffer_space(self):
+        return max(self._write_cursor - self._play_cursor, 0)
 
-    def _dispatch_pending_events(self):
-        pending_events = []
-        while self._events and self._events[0][0] <= self._play_cursor:
-            _, event = self._events.pop(0)
-            pending_events.append(event)
-        assert _debug('Dispatching pending events: {}'.format(pending_events))
-        assert _debug('Remaining events: {}'.format(self._events))
+    def _write(self, audio_data, region_size):
+        """Write data into the circular DSBuffer, starting at _write_cursor_ring.
+        May supply None as audio_data to only write silence.
+        If the audio data is not sufficient, will fill silence afterwards.
+        If too much audio data is supplied, will write as much as fits.
+        """
+        if region_size == 0:
+            return
 
-        for event in pending_events:
-            event.sync_dispatch_to_player(self.player)
-
-    def _cleanup_timestamps(self):
-        while self._timestamps and self._timestamps[0][0] < self._play_cursor:
-            del self._timestamps[0]
-
-    def _check_underrun(self):
-        if (
-            not self._has_underrun and
-            self._playing and
-            (self._eos_cursor is not None and self._play_cursor > self._eos_cursor)
-        ):
-            assert _debug('underrun, stopping')
-            self._has_underrun = True
-            self._dispatch_new_event('on_eos')
-
-    def _get_write_size(self):
-        self.update_play_cursor()
-
-        play_cursor = self._play_cursor
-        write_cursor = self._write_cursor
-
-        return self._buffer_size - max(write_cursor - play_cursor, 0)
-
-    def write(self, audio_data, length):
-        # Pass audio_data=None to write silence
-        if length == 0:
-            return 0
-
-        write_ptr = self._ds_buffer.lock(self._write_cursor_ring, length)
-        assert 0 < length <= self._buffer_size
-        assert length == write_ptr.audio_length_1.value + write_ptr.audio_length_2.value
-
-        if audio_data:
-            ctypes.memmove(write_ptr.audio_ptr_1, audio_data.data, write_ptr.audio_length_1.value)
-            audio_data.consume(write_ptr.audio_length_1.value, self.source.audio_format)
-            if write_ptr.audio_length_2.value > 0:
-                ctypes.memmove(write_ptr.audio_ptr_2, audio_data.data, write_ptr.audio_length_2.value)
-                audio_data.consume(write_ptr.audio_length_2.value, self.source.audio_format)
+        if audio_data is None:
+            audio_size = 0
         else:
-            if self.source.audio_format.sample_size == 8:
-                c = 0x80
-            else:
-                c = 0
-            ctypes.memset(write_ptr.audio_ptr_1, c, write_ptr.audio_length_1.value)
-            if write_ptr.audio_length_2.value > 0:
-                ctypes.memset(write_ptr.audio_ptr_2, c, write_ptr.audio_length_2.value)
+            audio_size = min(region_size, audio_data.length)
+            self._possible_eos_cursor = self._write_cursor + audio_size
+            audio_ptr = audio_data.pointer
+
+        assert _debug(f'Writing {region_size}B ({audio_size}B data, {region_size - audio_size}B silence)')
+
+        write_ptr = self._ds_buffer.lock(self._write_cursor_ring, region_size)
+
+        a1_size = write_ptr.audio_length_1.value
+        a2_size = write_ptr.audio_length_2.value
+
+        assert 0 < region_size <= self._buffer_size
+        assert region_size == a1_size + a2_size
+
+        a2_silence = a2_size
+        s = 0x80 if self.source.audio_format.sample_size == 8 else 0
+
+        if audio_size < a1_size:
+            if audio_size > 0:
+                ctypes.memmove(write_ptr.audio_ptr_1, audio_ptr, audio_size)
+            ctypes.memset(write_ptr.audio_ptr_1.value + audio_size, s, a1_size - audio_size)
+        else:
+            if a1_size > 0:
+                ctypes.memmove(write_ptr.audio_ptr_1, audio_ptr, a1_size)
+            if write_ptr.audio_ptr_2 and (a2_audio := (audio_size - a1_size)) > 0:
+                ctypes.memmove(write_ptr.audio_ptr_2, audio_ptr + a1_size, a2_audio)
+                a2_silence -= a2_audio
+        if write_ptr.audio_ptr_2 and a2_silence > 0:
+            ctypes.memset(write_ptr.audio_ptr_2.value + (a2_size - a2_silence), s, a2_silence)
+
         self._ds_buffer.unlock(write_ptr)
 
-        self._write_cursor += length
-        self._write_cursor_ring += length
+        self._write_cursor += region_size
+        self._write_cursor_ring += region_size
         self._write_cursor_ring %= self._buffer_size
-
-    def get_time(self):
-        self.update_play_cursor()
-        if self._timestamps:
-            cursor, ts = self._timestamps[0]
-            result = ts + (self._play_cursor - cursor) / float(self.source.audio_format.bytes_per_second)
-        else:
-            result = None
-
-        return result
 
     def set_volume(self, volume):
         self._ds_buffer.volume = _gain2db(volume)
@@ -344,65 +330,4 @@ class DirectSoundAudioPlayer(AbstractAudioPlayer):
             self._ds_buffer.cone_outside_volume = volume
 
     def prefill_audio(self):
-        write_size = self._get_write_size()
-        self._refill(write_size)
-
-
-class DirectSoundDriver(AbstractAudioDriver):
-    def __init__(self):
-        self._ds_driver = interface.DirectSoundDriver()
-        self._ds_listener = self._ds_driver.create_listener()
-
-        assert self._ds_driver is not None
-        assert self._ds_listener is not None
-
-        self.worker = PlayerWorkerThread()
-        self.worker.start()
-
-    def __del__(self):
-        self.delete()
-
-    def create_audio_player(self, source, player):
-        assert self._ds_driver is not None
-        # We increase IDirectSound refcount for each AudioPlayer instantiated
-        # This makes sure the AudioPlayer still has a valid _native_dsound to
-        # clean-up itself during tear-down.
-        self._ds_driver._native_dsound.AddRef()
-        return DirectSoundAudioPlayer(self, self._ds_driver, source, player)
-
-    def get_listener(self):
-        assert self._ds_driver is not None
-        assert self._ds_listener is not None
-        return DirectSoundListener(self._ds_listener, self._ds_driver.primary_buffer)
-
-    def delete(self):
-        if hasattr(self, 'worker'):
-            self.worker.stop()
-        # Make sure the _ds_listener is deleted before the _ds_driver
-        self._ds_listener = None
-
-
-class DirectSoundListener(AbstractListener):
-    def __init__(self, ds_listener, ds_buffer):
-        self._ds_listener = ds_listener
-        self._ds_buffer = ds_buffer
-
-    def _set_volume(self, volume):
-        self._volume = volume
-        self._ds_buffer.volume = _gain2db(volume)
-
-    def _set_position(self, position):
-        self._position = position
-        self._ds_listener.position = _convert_coordinates(position)
-
-    def _set_forward_orientation(self, orientation):
-        self._forward_orientation = orientation
-        self._set_orientation()
-
-    def _set_up_orientation(self, orientation):
-        self._up_orientation = orientation
-        self._set_orientation()
-
-    def _set_orientation(self):
-        self._ds_listener.orientation = (_convert_coordinates(self._forward_orientation)
-                                         + _convert_coordinates(self._up_orientation))
+        self._maybe_fill()

--- a/pyglet/media/drivers/openal/adaptation.py
+++ b/pyglet/media/drivers/openal/adaptation.py
@@ -2,7 +2,6 @@ from collections import deque
 from typing import TYPE_CHECKING, List, Optional, Tuple
 import weakref
 
-from pyglet.media.codecs.base import AudioData
 from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer, MediaEvent
 from pyglet.media.drivers.listener import AbstractListener
 from pyglet.media.drivers.openal import interface

--- a/pyglet/media/drivers/openal/adaptation.py
+++ b/pyglet/media/drivers/openal/adaptation.py
@@ -1,16 +1,23 @@
+from collections import deque
+from typing import TYPE_CHECKING, List, Optional, Tuple
 import weakref
 
-from . import interface
-from pyglet.util import debug_print
+from pyglet.media.codecs.base import AudioData
 from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer, MediaEvent
-from pyglet.media.mediathreads import PlayerWorkerThread
 from pyglet.media.drivers.listener import AbstractListener
+from pyglet.media.drivers.openal import interface
+from pyglet.media.player_worker_thread import PlayerWorkerThread
+from pyglet.util import debug_print
+
+if TYPE_CHECKING:
+    from pyglet.media import Source, Player
+
 
 _debug = debug_print('debug_media')
 
 
 class OpenALDriver(AbstractAudioDriver):
-    def __init__(self, device_name=None):
+    def __init__(self, device_name: Optional[str] = None) -> None:
         super().__init__()
 
         self.device = interface.OpenALDevice(device_name)
@@ -22,355 +29,229 @@ class OpenALDriver(AbstractAudioDriver):
         self.worker = PlayerWorkerThread()
         self.worker.start()
 
-    def __del__(self):
-        assert _debug("Delete OpenALDriver")
-        self.delete()
-
-    def create_audio_player(self, source, player):
-        assert self.device is not None, "Device was closed"
+    def create_audio_player(self, source: 'Source', player: 'Player') -> 'OpenALAudioPlayer':
+        assert self.device is not None, 'Device was closed'
         return OpenALAudioPlayer(self, source, player)
 
-    def delete(self):
+    def delete(self) -> None:
+        if self.context is None:
+            assert _debug('Duplicate OpenALDriver.delete(), ignoring')
+            return
+
+        assert _debug("Delete OpenALDriver")
         self.worker.stop()
+
+        # A device may only be closed if no more contexts and no more buffers exist on it
+        # A buffer may only be deleted if no source is using it anymore
+        # A context may only be deleted if it is free of sources
+        # Buffers need a context to report errors to when being deleted
+        self.context.delete_sources()
+        self.device.buffer_pool.delete()
+        self.context.delete()
+        self.device.close()
         self.context = None
 
-    def have_version(self, major, minor):
+    def have_version(self, major: int, minor: int) -> bool:
         return (major, minor) <= self.get_version()
 
-    def get_version(self):
+    def get_version(self) -> Tuple[int, int]:
         assert self.device is not None, "Device was closed"
         return self.device.get_version()
 
-    def get_extensions(self):
+    def get_extensions(self) -> List[str]:
         assert self.device is not None, "Device was closed"
         return self.device.get_extensions()
 
-    def have_extension(self, extension):
+    def have_extension(self, extension: str) -> bool:
         return extension in self.get_extensions()
 
-    def get_listener(self):
+    def get_listener(self) -> 'OpenALListener':
         return self._listener
 
 
 class OpenALListener(AbstractListener):
-    def __init__(self, driver):
+    def __init__(self, driver: 'OpenALDriver') -> None:
         self._driver = weakref.proxy(driver)
         self._al_listener = interface.OpenALListener()
 
-    def __del__(self):
-        assert _debug("Delete OpenALListener")
-
-    def _set_volume(self, volume):
+    def _set_volume(self, volume: float) -> None:
         self._al_listener.gain = volume
         self._volume = volume
 
-    def _set_position(self, position):
+    def _set_position(self, position: Tuple[float, float, float]) -> None:
         self._al_listener.position = position
         self._position = position
 
-    def _set_forward_orientation(self, orientation):
+    def _set_forward_orientation(self, orientation: Tuple[float, float, float]) -> None:
         self._al_listener.orientation = orientation + self._up_orientation
         self._forward_orientation = orientation
 
-    def _set_up_orientation(self, orientation):
+    def _set_up_orientation(self, orientation: Tuple[float, float, float]) -> None:
         self._al_listener.orientation = self._forward_orientation + orientation
         self._up_orientation = orientation
 
 
 class OpenALAudioPlayer(AbstractAudioPlayer):
-    #: Minimum size of an OpenAL buffer worth bothering with, in bytes
-    min_buffer_size = 512
-
-    #: Aggregate (desired) buffer size, in seconds
-    _ideal_buffer_size = 1.0
-
-    def __init__(self, driver, source, player):
-        super(OpenALAudioPlayer, self).__init__(source, player)
+    def __init__(self, driver: 'OpenALDriver', source: 'Source', player: 'Player') -> None:
+        super().__init__(source, player)
         self.driver = driver
         self.alsource = driver.context.create_source()
 
         # Cursor positions, like DSound and Pulse drivers, refer to a
         # hypothetical infinite-length buffer.  Cursor units are in bytes.
 
-        # Cursor position of current (head) AL buffer
+        # The following should be true at all times:
+        # buffer <= play <= write; buffer >= 0; play >= 0; write >= 0
+
+        # Start of the current (head) AL buffer
         self._buffer_cursor = 0
 
         # Estimated playback cursor position (last seen)
         self._play_cursor = 0
 
-        # Cursor position of end of queued AL buffer.
+        # Cursor position of end of the last queued AL buffer.
         self._write_cursor = 0
 
-        # Whether the source hit its end; protect against duplicate dispatch
-        # of on_eos events.
+        # Whether the source has been exhausted of all data.
+        # Don't bother trying to refill then and brace for eos.
+        self._pyglet_source_exhausted = False
+
+        # Whether the OpenAL source has played to its end.
+        # Prevent duplicate dispatches of on_eos events.
         self._has_underrun = False
 
-        # List of currently queued buffer sizes (in bytes)
-        self._buffer_sizes = []
+        # Deque of the currently queued buffer's sizes
+        self._queued_buffer_sizes = deque()
 
-        # List of currently queued buffer timestamps
-        self._buffer_timestamps = []
+    def delete(self) -> None:
+        if self.alsource is not None:
+            self.driver.worker.remove(self)
+            self.alsource.delete()
+            self.alsource = None
 
-        # Timestamp at end of last written buffer (timestamp to return in case
-        # of underrun)
-        self._underrun_timestamp = None
-
-        # List of (cursor, MediaEvent)
-        self._events = []
-
-        # Desired play state (True even if stopped due to underrun)
-        self._playing = False
-
-        # When clearing, the play cursor can be incorrect
-        self._clearing = False
-
-        # Up to one audio data may be buffered if too much data was received
-        # from the source that could not be written immediately into the
-        # buffer.  See _refill().
-        self._audiodata_buffer = None
-
-        self._refill(self.ideal_buffer_size)
-
-    def __del__(self):
-        self.delete()
-
-    def delete(self):
-        self.driver.worker.remove(self)
-        self.alsource = None
-
-    @property
-    def ideal_buffer_size(self):
-        return int(self._ideal_buffer_size * self.source.audio_format.bytes_per_second)
-
-    def play(self):
+    def play(self) -> None:
         assert _debug('OpenALAudioPlayer.play()')
-
         assert self.driver is not None
         assert self.alsource is not None
 
         if not self.alsource.is_playing:
             self.alsource.play()
-        self._playing = True
-        self._clearing = False
 
         self.driver.worker.add(self)
 
-    def stop(self):
-        self.driver.worker.remove(self)
+    def stop(self) -> None:
         assert _debug('OpenALAudioPlayer.stop()')
         assert self.driver is not None
         assert self.alsource is not None
+
+        self.driver.worker.remove(self)
         self.alsource.pause()
-        self._playing = False
 
-    def clear(self):
+    def clear(self) -> None:
         assert _debug('OpenALAudioPlayer.clear()')
-
         assert self.driver is not None
         assert self.alsource is not None
 
         super().clear()
         self.alsource.stop()
-        self._handle_processed_buffers()
         self.alsource.clear()
-        self.alsource.byte_offset = 0
-        self._playing = False
-        self._clearing = True
-        self._audiodata_buffer = None
 
         self._buffer_cursor = 0
         self._play_cursor = 0
         self._write_cursor = 0
+        self._pyglet_source_exhausted = False
         self._has_underrun = False
-        del self._events[:]
-        del self._buffer_sizes[:]
-        del self._buffer_timestamps[:]
+        self._queued_buffer_sizes.clear()
 
-    def _update_play_cursor(self):
-        assert self.driver is not None
-        assert self.alsource is not None
+    def _check_processed_buffers(self) -> None:
+        buffers_processed = self.alsource.unqueue_buffers()
+        for _ in range(buffers_processed):
+            # Buffers have been processed (and already been removed from the ALSource);
+            # Adjust buffer cursor.
+            self._buffer_cursor += self._queued_buffer_sizes.popleft()
 
-        self._handle_processed_buffers()
+    def _update_play_cursor(self) -> None:
+        self._play_cursor = self._buffer_cursor + self.alsource.byte_offset
 
-        # Update play cursor using buffer cursor + estimate into current buffer
-        if self._clearing:
-            self._play_cursor = self._buffer_cursor
-        else:
-            self._play_cursor = self._buffer_cursor + self.alsource.byte_offset
-        assert self._check_cursors()
-
-        self._dispatch_events()
-
-    def _handle_processed_buffers(self):
-        processed = self.alsource.unqueue_buffers()
-
-        if processed > 0:
-            if (len(self._buffer_timestamps) == processed
-                    and self._buffer_timestamps[-1] is not None):
-                assert _debug('OpenALAudioPlayer: Underrun')
-                # Underrun, take note of timestamp.
-                # We check that the timestamp is not None, because otherwise
-                # our source could have been cleared.
-                self._underrun_timestamp = self._buffer_timestamps[-1] + \
-                    self._buffer_sizes[-1] / float(self.source.audio_format.bytes_per_second)
-            self._update_buffer_cursor(processed)
-
-        return processed
-
-    def _update_buffer_cursor(self, processed):
-        self._buffer_cursor += sum(self._buffer_sizes[:processed])
-        del self._buffer_sizes[:processed]
-        del self._buffer_timestamps[:processed]
-
-    def _dispatch_events(self):
-        while self._events and self._events[0][0] <= self._play_cursor:
-            _, event = self._events.pop(0)
-            event.sync_dispatch_to_player(self.player)
-
-    def _get_write_size(self):
+    def work(self) -> None:
+        self._check_processed_buffers()
         self._update_play_cursor()
-        buffer_size = int(self._write_cursor - self._play_cursor)
+        self.dispatch_media_events(self._play_cursor)
 
-        # Only write when current buffer size is smaller than ideal
-        write_size = max(self.ideal_buffer_size - buffer_size, 0)
+        if self._pyglet_source_exhausted:
+            if not self._has_underrun and not self.alsource.is_playing:
+                self._has_underrun = True
+                assert _debug('OpenALAudioPlayer: Dispatching eos')
+                MediaEvent('on_eos').sync_dispatch_to_player(self.player)
+            return
 
-        assert _debug("Write size {} bytes".format(write_size))
-        return write_size
+        refilled = self._maybe_refill()
 
-    def refill_buffer(self):
-        write_size = self._get_write_size()
-        if write_size > self.min_buffer_size:
-            self._refill(write_size)
-            return True
-        return False
-
-    def _refill(self, write_size):
-        assert _debug(f'_refill {write_size}')
-
-        while write_size > self.min_buffer_size:
-            audio_data = self._get_audiodata()
-
-            if audio_data is None:
-                break
-
-            length = min(write_size, audio_data.length)
-            if length == 0:
-                assert _debug('Empty AudioData. Discard it.')
-
-            else:
-                assert _debug('Writing {} bytes'.format(length))
-                self._queue_audio_data(audio_data, length)
-                write_size -= length
-
-        # Check for underrun stopping playback
-        if self._playing and not self.alsource.is_playing:
-            assert _debug('underrun')
+        if refilled and not self.alsource.is_playing:
+            # Very unlikely case where the refill was delayed by so much the
+            # source underran and stopped. If it did, restart it.
             self.alsource.play()
 
-    def _get_audiodata(self):
-        if self._audiodata_buffer is None or self._audiodata_buffer.length == 0:
-            self._get_new_audiodata()
-
-        return self._audiodata_buffer
-
-    def _get_new_audiodata(self):
-        assert _debug('Getting new audio data buffer.')
-        compensation_time = self.get_audio_time_diff()
-        self._audiodata_buffer = self.source.get_audio_data(self.ideal_buffer_size, compensation_time)
-
-        if self._audiodata_buffer is not None:
-            assert _debug('New audio data available: {} bytes'.format(self._audiodata_buffer.length))
-            self._queue_events(self._audiodata_buffer)
-        else:
-            assert _debug('No audio data left')
-            if self._has_just_underrun():
-                assert _debug('Freshly underrun')
-                MediaEvent('on_eos').sync_dispatch_to_player(self.player)
-
-    def _queue_audio_data(self, audio_data, length):
-        buf = self.alsource.get_buffer()
-        buf.data(audio_data, self.source.audio_format, length)
-        self.alsource.queue_buffer(buf)
-        self._update_write_cursor(audio_data, length)
-
-    def _update_write_cursor(self, audio_data, length):
-        self._write_cursor += length
-        self._buffer_sizes.append(length)
-        self._buffer_timestamps.append(audio_data.timestamp)
-        audio_data.consume(length, self.source.audio_format)
-        assert self._check_cursors()
-
-    def _queue_events(self, audio_data):
-        for event in audio_data.events:
-            cursor = self._write_cursor + event.timestamp * self.source.audio_format.bytes_per_second
-            self._events.append((cursor, event))
-
-    def _has_just_underrun(self):
-        if self._has_underrun:
+    def _maybe_refill(self) -> bool:
+        if self._pyglet_source_exhausted:
             return False
 
-        if self.alsource.buffers_queued == 0:
-            self._has_underrun = True
+        remaining_bytes = self._write_cursor - self._play_cursor
+        if remaining_bytes >= self._buffered_data_comfortable_limit:
+            return False
 
-        return self._has_underrun
+        missing_bytes = self._singlebuffer_ideal_size - remaining_bytes
+        self._refill(self.source.audio_format.align_ceil(missing_bytes))
+        return True
 
-    def get_time(self):
-        # Update first, might remove buffers
-        self._update_play_cursor()
+    def get_play_cursor(self) -> int:
+        return self._play_cursor
 
-        if not self._buffer_timestamps:
-            timestamp = self._underrun_timestamp
-            assert _debug('OpenALAudioPlayer: Return underrun timestamp')
-        else:
-            timestamp = self._buffer_timestamps[0]
-            assert _debug('OpenALAudioPlayer: Buffer timestamp: {}'.format(timestamp))
+    def _refill(self, refill_size) -> None:
+        audio_data = self._get_and_compensate_audio_data(refill_size, self._play_cursor)
 
-            if timestamp is not None:
-                timestamp += ((self._play_cursor - self._buffer_cursor) /
-                    float(self.source.audio_format.bytes_per_second))
+        if audio_data is None:
+            self._pyglet_source_exhausted = True
+            return
 
-        assert _debug('OpenALAudioPlayer: get_time = {}'.format(timestamp))
+        # We got new audio data; first queue its events
+        self.append_events(self._write_cursor, audio_data.events)
 
-        return timestamp
+        # Get, fill and queue OpenAL buffer using the entire AudioData
+        buf = self.alsource.get_buffer()
+        buf.data(audio_data, self.source.audio_format)
+        self.alsource.queue_buffer(buf)
 
-    def _check_cursors(self):
-        assert self._play_cursor >= 0
-        assert self._buffer_cursor >= 0
-        assert self._write_cursor >= 0
-        assert self._buffer_cursor <= self._play_cursor
-        assert self._play_cursor <= self._write_cursor
-        assert _debug('Buffer[{}], Play[{}], Write[{}]'.format(self._buffer_cursor,
-                                                                     self._play_cursor,
-                                                                     self._write_cursor))
-        return True  # Return true so it can be called in an assert (and optimized out)
+        # Adjust the write cursor and memorize buffer length
+        self._write_cursor += audio_data.length
+        self._queued_buffer_sizes.append(audio_data.length)
 
-    def set_volume(self, volume):
+    def prefill_audio(self) -> None:
+        self._maybe_refill()
+
+    def set_volume(self, volume: float) -> None:
         self.alsource.gain = volume
 
-    def set_position(self, position):
+    def set_position(self, position: Tuple[float, float, float]) -> None:
         self.alsource.position = position
 
-    def set_min_distance(self, min_distance):
+    def set_min_distance(self, min_distance: float) -> None:
         self.alsource.reference_distance = min_distance
 
-    def set_max_distance(self, max_distance):
+    def set_max_distance(self, max_distance: float) -> None:
         self.alsource.max_distance = max_distance
 
-    def set_pitch(self, pitch):
+    def set_pitch(self, pitch: float) -> None:
         self.alsource.pitch = pitch
 
-    def set_cone_orientation(self, cone_orientation):
+    def set_cone_orientation(self, cone_orientation: Tuple[float, float, float]) -> None:
         self.alsource.direction = cone_orientation
 
-    def set_cone_inner_angle(self, cone_inner_angle):
+    def set_cone_inner_angle(self, cone_inner_angle: float) -> None:
         self.alsource.cone_inner_angle = cone_inner_angle
 
-    def set_cone_outer_angle(self, cone_outer_angle):
+    def set_cone_outer_angle(self, cone_outer_angle: float) -> None:
         self.alsource.cone_outer_angle = cone_outer_angle
 
-    def set_cone_outer_gain(self, cone_outer_gain):
+    def set_cone_outer_gain(self, cone_outer_gain: float) -> None:
         self.alsource.cone_outer_gain = cone_outer_gain
-
-    def prefill_audio(self):
-        write_size = self._get_write_size()
-        self._refill(write_size)

--- a/pyglet/media/drivers/openal/interface.py
+++ b/pyglet/media/drivers/openal/interface.py
@@ -38,12 +38,6 @@ class OpenALObject:
                                   error_code=error_code,
                                   error_string=str(error_string.value))
 
-    @classmethod
-    def _raise_error(cls, message):
-        """Raise an exception. Try to check for OpenAL error code too."""
-        cls._check_error(message)
-        raise OpenALException(message)
-
 
 class OpenALDevice(OpenALObject):
     """OpenAL audio device."""
@@ -53,15 +47,14 @@ class OpenALDevice(OpenALObject):
         if self._al_device is None:
             raise OpenALException('No OpenAL devices.')
 
-    def __del__(self):
-        assert _debug("Delete interface.OpenALDevice")
-        self.delete()
+        self.buffer_pool = OpenALBufferPool()
 
-    def delete(self):
-        if self._al_device is not None:
-            if alc.alcCloseDevice(self._al_device) == alc.ALC_FALSE:
-                self._raise_context_error('Failed to close device.')
-            self._al_device = None
+    def close(self):
+        """Close this ALDevice. No more buffers or contexts may exist on it."""
+        assert _debug("Closing interface.OpenALDevice")
+        if alc.alcCloseDevice(self._al_device) == alc.ALC_FALSE:
+            self._raise_context_error('Failed to close device.')
+        self._al_device = None
 
     @property
     def is_ready(self):
@@ -100,7 +93,9 @@ class OpenALDevice(OpenALObject):
                                   error_string=str(error_string.value))
 
     def _raise_context_error(self, message):
-        """Raise an exception. Try to check for OpenAL error code too."""
+        """Try to check for OpenAL error and raise that, and then
+        definitely raise an error with the given message.
+        """
         self.check_context_error(message)
         raise OpenALException(message)
 
@@ -109,20 +104,26 @@ class OpenALContext(OpenALObject):
     def __init__(self, device, al_context):
         self.device = device
         self._al_context = al_context
+        self._sources = set()
         self.make_current()
 
-    def __del__(self):
-        assert _debug("Delete interface.OpenALContext")
-        self.delete()
+    def delete_sources(self):
+        for s in tuple(self._sources):
+            s.delete()
 
     def delete(self):
-        if self._al_context is not None:
-            # TODO: Check if this context is current
+        assert _debug("Delete interface.OpenALContext")
+
+        if (
+            ctypes.cast(alc.alcGetCurrentContext(), ctypes.c_void_p).value ==
+            ctypes.cast(self._al_context, ctypes.c_void_p).value
+        ):
             alc.alcMakeContextCurrent(None)
             self.device.check_context_error('Failed to make context no longer current.')
-            alc.alcDestroyContext(self._al_context)
-            self.device.check_context_error('Failed to destroy context.')
-            self._al_context = None
+
+        alc.alcDestroyContext(self._al_context)
+        self.device.check_context_error('Failed to destroy context.')
+        self._al_context = None
 
     def make_current(self):
         alc.alcMakeContextCurrent(self._al_context)
@@ -130,34 +131,42 @@ class OpenALContext(OpenALObject):
 
     def create_source(self):
         self.make_current()
-        return OpenALSource(self)
+        new_source = OpenALSource(self)
+        self._sources.add(new_source)
+        return new_source
+
+    def source_deleted(self, source):
+        self._sources.remove(source)
 
 
 class OpenALSource(OpenALObject):
     def __init__(self, context):
-        self.context = weakref.ref(context)
-        self.buffer_pool = OpenALBufferPool(self.context)
+        self.context = context
 
         self._al_source = al.ALuint()
         al.alGenSources(1, self._al_source)
         self._check_error('Failed to create source.')
+
+        self.buffer_pool = context.device.buffer_pool
 
         self._state = None
         self._get_state()
 
         self._owned_buffers = {}
 
-    def __del__(self):
-        assert _debug("Delete interface.OpenALSource")
-        self.delete()
-
     def delete(self):
-        if self.context() and self._al_source is not None:
-            # Only delete source if the context still exists
-            al.alDeleteSources(1, self._al_source)
-            self._check_error('Failed to delete source.')
-            self.buffer_pool.clear()
-            self._al_source = None
+        if self.context is None:
+            assert _debug("Delete interface.OpenAlSource on deleted source, ignoring")
+            return
+
+        assert _debug("Delete interface.OpenALSource")
+        al.alDeleteSources(1, self._al_source)
+        self._check_error('Failed to delete source.')
+        self.context.source_deleted(self)
+
+        self.buffer_pool = None  # Reference breakup
+        self.context = None
+        self._al_source = None
 
     @property
     def is_initial(self):
@@ -207,8 +216,8 @@ class OpenALSource(OpenALObject):
     cone_outer_angle = _float_source_property(al.AL_CONE_OUTER_ANGLE)
     cone_outer_gain = _float_source_property(al.AL_CONE_OUTER_GAIN)
     sec_offset = _float_source_property(al.AL_SEC_OFFSET)
-    sample_offset = _float_source_property(al.AL_SAMPLE_OFFSET)
-    byte_offset = _float_source_property(al.AL_BYTE_OFFSET)
+    sample_offset = _int_source_property(al.AL_SAMPLE_OFFSET)
+    byte_offset = _int_source_property(al.AL_BYTE_OFFSET)
 
     del _int_source_property
     del _float_source_property
@@ -228,18 +237,17 @@ class OpenALSource(OpenALObject):
 
     def clear(self):
         self._set_int(al.AL_BUFFER, al.AL_NONE)
-        while self._owned_buffers:
-            buf_name, buf = self._owned_buffers.popitem()
-            self.buffer_pool.unqueue_buffer(buf)
+        self.buffer_pool.return_buffers(self._owned_buffers.values())
+        self._owned_buffers.clear()
 
     def get_buffer(self):
         return self.buffer_pool.get_buffer()
 
     def queue_buffer(self, buf):
         assert buf.is_valid
-        al.alSourceQueueBuffers(self._al_source, 1, ctypes.byref(buf.al_buffer))
+        al.alSourceQueueBuffers(self._al_source, 1, ctypes.byref(buf.al_name))
         self._check_error('Failed to queue buffer.')
-        self._add_buffer(buf)
+        self._owned_buffers[buf.name] = buf
 
     def unqueue_buffers(self):
         processed = self.buffers_processed
@@ -248,8 +256,7 @@ class OpenALSource(OpenALObject):
             buffers = (al.ALuint * processed)()
             al.alSourceUnqueueBuffers(self._al_source, len(buffers), buffers)
             self._check_error('Failed to unqueue buffers from source.')
-            for buf in buffers:
-                self.buffer_pool.unqueue_buffer(self._pop_buffer(buf))
+            self.buffer_pool.return_buffers([self._owned_buffers.pop(bn) for bn in buffers])
         return processed
 
     def _get_state(self):
@@ -294,14 +301,6 @@ class OpenALSource(OpenALObject):
         x, y, z = map(float, values)
         al.alSource3f(self._al_source, key, x, y, z)
         self._check_error('Failed to set value.')
-
-    def _add_buffer(self, buf):
-        self._owned_buffers[buf.name] = buf
-
-    def _pop_buffer(self, al_buffer):
-        buf = self._owned_buffers.pop(al_buffer, None)
-        assert buf is not None
-        return buf
 
 
 OpenALOrientation = namedtuple("OpenALOrientation", ['at', 'up'])
@@ -392,55 +391,41 @@ class OpenALBuffer(OpenALObject):
         (2, 16): al.AL_FORMAT_STEREO16,
     }
 
-    def __init__(self, al_buffer, context):
-        self._al_buffer = al_buffer
-        self.context = context
-        assert self.is_valid
+    def __init__(self, al_name):
+        self.al_name = al_name
+        self.name = al_name.value
 
-    def __del__(self):
-        assert _debug("Delete interface.OpenALBuffer")
-        self.delete()
+        assert self.is_valid
 
     @property
     def is_valid(self):
         self._check_error('Before validate buffer.')
-        if self._al_buffer is None:
+        if self.al_name is None:
             return False
-        valid = bool(al.alIsBuffer(self._al_buffer))
+        valid = bool(al.alIsBuffer(self.al_name))
         if not valid:
             # Clear possible error due to invalid buffer
             al.alGetError()
         return valid
 
-    @property
-    def al_buffer(self):
-        assert self.is_valid
-        return self._al_buffer
-
-    @property
-    def name(self):
-        assert self.is_valid
-        return self._al_buffer.value
-
     def delete(self):
-        if self._al_buffer is not None and self.context() and self.is_valid:
-            al.alDeleteBuffers(1, ctypes.byref(self._al_buffer))
+        if self.al_name is not None and self.is_valid:
+            al.alDeleteBuffers(1, ctypes.byref(self.al_name))
             self._check_error('Error deleting buffer.')
-            self._al_buffer = None
+            self.al_name = None
 
-    def data(self, audio_data, audio_format, length=None):
+    def data(self, audio_data, audio_format):
         assert self.is_valid
-        length = length or audio_data.length
 
         try:
             al_format = self._format_map[(audio_format.channels, audio_format.sample_size)]
         except KeyError:
             raise MediaException(f"OpenAL does not support '{audio_format.sample_size}bit' audio.")
 
-        al.alBufferData(self._al_buffer,
+        al.alBufferData(self.al_name,
                         al_format,
-                        audio_data.data,
-                        length,
+                        audio_data.pointer,
+                        audio_data.length,
                         audio_format.sample_rate)
         self._check_error('Failed to add data to buffer.')
 
@@ -449,18 +434,15 @@ class OpenALBufferPool(OpenALObject):
     """At least Mac OS X doesn't free buffers when a source is deleted; it just
     detaches them from the source.  So keep our own recycled queue.
     """
-    def __init__(self, context):
-        self.context = context
-        self._buffers = []  # list of free buffer names
-
-    def __del__(self):
-        assert _debug("Delete interface.OpenALBufferPool")
-        self.clear()
+    def __init__(self):
+        self._buffers = []
+        """List of free buffer names"""
 
     def __len__(self):
         return len(self._buffers)
 
-    def clear(self):
+    def delete(self):
+        assert _debug("Delete interface.OpenALBufferPool")
         while self._buffers:
             self._buffers.pop().delete()
 
@@ -473,28 +455,25 @@ class OpenALBufferPool(OpenALObject):
         not be modified in any way, and may get changed by subsequent calls to
         get_buffers.
         """
-        buffers = []
-        while number > 0:
-            if self._buffers:
-                b = self._buffers.pop()
-            else:
-                b = self._create_buffer()
+        ret_buffers = []
+        while self._buffers and len(ret_buffers) < number:
+            b = self._buffers.pop()
             if b.is_valid:
-                # Protect against implementations that DO free buffers
-                # when they delete a source - carry on.
-                buffers.append(b)
-                number -= 1
+                ret_buffers.append(b)
+            # Otherwise the buffer doesn't exist on the OpenAL side
+            # anymore, forget about it
 
-        return buffers
+        # If we didn't get enough, create more buffers
+        if (missing := number - len(ret_buffers)) > 0:
+            names = (al.ALuint * missing)()
+            al.alGenBuffers(missing, names)
+            self._check_error('Error generating buffers.')
+            ret_buffers.extend(OpenALBuffer(al.ALuint(name)) for name in names)
 
-    def unqueue_buffer(self, buf):
-        """A buffer has finished playing, free it."""
-        if buf.is_valid:
-            self._buffers.append(buf)
+        return ret_buffers
 
-    def _create_buffer(self):
-        """Create a new buffer."""
-        al_buffer = al.ALuint()
-        al.alGenBuffers(1, al_buffer)
-        self._check_error('Error allocating buffer.')
-        return OpenALBuffer(al_buffer, self.context)
+    def return_buffers(self, buffers):
+        """Throw buffers not used anymore back into the pool."""
+        for buf in buffers:
+            if buf.is_valid:
+                self._buffers.append(buf)

--- a/pyglet/media/drivers/pulse/adaptation.py
+++ b/pyglet/media/drivers/pulse/adaptation.py
@@ -1,40 +1,47 @@
+from collections import deque
+import ctypes
+import threading
+from typing import Deque, Optional, TYPE_CHECKING
 import weakref
 
 from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer, MediaEvent
 from pyglet.media.drivers.listener import AbstractListener
+from pyglet.media.player_worker_thread import PlayerWorkerThread
 from pyglet.util import debug_print
 
 from . import lib_pulseaudio as pa
-from .interface import PulseAudioMainLoop
+from .interface import PulseAudioMainloop
+
+if TYPE_CHECKING:
+    from pyglet.media.codecs import AudioData, AudioFormat, Source
+    from pyglet.media.player import Player
 
 
 _debug = debug_print('debug_media')
 
 
 class PulseAudioDriver(AbstractAudioDriver):
-    def __init__(self):
-        self.mainloop = PulseAudioMainLoop()
+    def __init__(self) -> None:
+        self.mainloop = PulseAudioMainloop()
         self.mainloop.start()
-        self.lock = self.mainloop
         self.context = None
 
+        self.worker = PlayerWorkerThread()
+        self.worker.start()
         self._players = weakref.WeakSet()
         self._listener = PulseAudioListener(self)
 
-    def __del__(self):
-        self.delete()
-
-    def create_audio_player(self, source, player):
+    def create_audio_player(self, source: 'Source', player: 'Player') -> 'PulseAudioPlayer':
         assert self.context is not None
         player = PulseAudioPlayer(source, player, self)
         self._players.add(player)
         return player
 
-    def connect(self, server=None):
+    def connect(self, server: Optional[bytes] = None) -> None:
         """Connect to pulseaudio server.
 
         :Parameters:
-            `server` : str
+            `server` : bytes
                 Server to connect to, or ``None`` for the default local
                 server (which may be spawned as a daemon if no server is
                 found).
@@ -52,29 +59,30 @@ class PulseAudioDriver(AbstractAudioDriver):
         print('Server protocol:', self.context.server_protocol_version)
         print('Local context:  ', self.context.is_local and 'Yes' or 'No')
 
-    def delete(self):
+    def delete(self) -> None:
         """Completely shut down pulseaudio client."""
-        if self.mainloop is not None:
+        if self.mainloop is None:
+            return
 
-            with self.mainloop:
-                if self.context is not None:
-                    self.context.delete()
-                    self.context = None
+        self.worker.stop()
 
-        if self.mainloop is not None:
-            self.mainloop.delete()
-            self.mainloop = None
-            self.lock = None
+        with self.mainloop.lock:
+            if self.context is not None:
+                self.context.delete()
+                self.context = None
 
-    def get_listener(self):
+        self.mainloop.delete()
+        self.mainloop = None
+
+    def get_listener(self) -> 'PulseAudioListener':
         return self._listener
 
 
 class PulseAudioListener(AbstractListener):
-    def __init__(self, driver):
+    def __init__(self, driver: 'PulseAudioDriver') -> None:
         self.driver = weakref.proxy(driver)
 
-    def _set_volume(self, volume):
+    def _set_volume(self, volume: float) -> None:
         self._volume = volume
         for player in self.driver._players:
             player.set_volume(player._volume)
@@ -89,298 +97,270 @@ class PulseAudioListener(AbstractListener):
         self._up_orientation = orientation
 
 
+class _AudioDataBuffer:
+    def __init__(self, ideal_size: int, comfortable_limit: int) -> None:
+        self.available = 0
+        self.virtual_write_index = 0
+        self._ideal_size = ideal_size
+        self._comfortable_limit = comfortable_limit
+        self._data: Deque['AudioData'] = deque()
+        self._first_read_offset = 0
+
+    def clear(self) -> None:
+        self.available = 0
+        self.virtual_write_index = 0
+        self._data.clear()
+        self._first_read_offset = 0
+
+    def get_ideal_refill_size(self, virtual_required: int = 0) -> int:
+        virtual_available = self.available - virtual_required
+        if virtual_available < self._comfortable_limit:
+            return self._ideal_size - virtual_available
+        return 0
+
+    def add_data(self, d: 'AudioData') -> None:
+        self._data.append(d)
+        self.available += d.length
+        self.virtual_write_index += d.length
+
+    def memmove(self, target_pointer: int, num_bytes: int) -> int:
+        bytes_written = 0
+        bytes_remaining = num_bytes
+        while bytes_remaining > 0 and self._data:
+            cur_audio_data = self._data[0]
+            cur_len = cur_audio_data.length - self._first_read_offset
+            packet_used = cur_len <= bytes_remaining
+            cur_write = min(bytes_remaining, cur_len)
+            ctypes.memmove(target_pointer + bytes_written,
+                           cur_audio_data.pointer + self._first_read_offset,
+                           cur_write)
+            bytes_written += cur_write
+            bytes_remaining -= cur_write
+            if packet_used:
+                self._data.popleft()
+                self._first_read_offset = 0
+            else:
+                self._first_read_offset += cur_write
+
+        self.available -= bytes_written
+
+        return bytes_written
+
+
 class PulseAudioPlayer(AbstractAudioPlayer):
-    _volume = 1.0
+    def __init__(self, source: 'Source', player: 'Player', driver: 'PulseAudioDriver') -> None:
+        super().__init__(source, player)
+        self.driver = driver
 
-    def __init__(self, source, player, driver):
-        super(PulseAudioPlayer, self).__init__(source, player)
-        self.driver = weakref.ref(driver)
-
-        self._events = []
-        self._timestamps = []  # List of (ref_time, timestamp)
-        self._write_index = 0  # Current write index (tracked manually)
-        self._read_index_valid = False # True only if buffer has non-stale data
-
-        self._clear_write = False
-        self._buffered_audio_data = None
-        self._playing = False
-
-        self._current_audio_data = None
-
-        self._time_sync_operation = None
+        self._volume = 1.0
 
         audio_format = source.audio_format
         assert audio_format
 
-        with driver.mainloop:
+        self._latest_timing_info = None
+        self._last_clear_read_index = 0
+
+        self._pyglet_source_exhausted = False
+        self._pending_bytes = 0
+        self._audio_data_buffer = _AudioDataBuffer(self._singlebuffer_ideal_size,
+                                                   self._buffered_data_comfortable_limit)
+
+        # A lock that should be held whenever the audio data buffer is accessed, or
+        # any variables really, if they are shared between PA callbacks and the rest of
+        # implemented methods.
+        # Should prevent The PA callback from interfering with the work method.
+        # Don't ever acquire the PA mainloop lock when this is held, might risk a deadlock
+        # if a callback runs at an unfortunate time.
+        self._audio_data_lock = threading.Lock()
+
+        self._clear_write = False
+        self._has_underrun = False
+
+        with driver.mainloop.lock:
             self.stream = driver.context.create_stream(audio_format)
-            self.stream.push_handlers(self)
+            self.stream.set_write_callback(self._write_callback)
+            self.stream.set_underflow_callback(self._underflow_callback)
             self.stream.connect_playback()
             assert self.stream.is_ready
 
         assert _debug('PulseAudioPlayer: __init__ finished')
 
-    def on_write_needed(self, nbytes, underflow):
-        if underflow:
-            self._handle_underflow()
-        else:
-            self._write_to_stream(nbytes)
+    def _write_callback(self, _stream, nbytes: int, _userdata) -> None:
+        # Called from within PA thread
+        assert _debug(f'PulseAudioPlayer: Write requested, {nbytes}B')
+        assert self.source.audio_format.align(nbytes) == nbytes
 
-        # Asynchronously update time
-        if self._events:
-            if self._time_sync_operation is not None and self._time_sync_operation.is_done:
-                self._time_sync_operation.delete()
-                self._time_sync_operation = None
-            if self._time_sync_operation is None:
-                assert _debug('PulseAudioPlayer: trigger timing info update')
-                self._time_sync_operation = self.stream.update_timing_info(self._process_events)
-
-    def _get_audio_data(self, nbytes=None):
-        if self._current_audio_data is None and self.source is not None:
-            # Always try to buffer at least 1 second of audio data
-            min_bytes = 1 * self.source.audio_format.bytes_per_second
-            if nbytes is None:
-                nbytes = min_bytes
+        with self._audio_data_lock:
+            if self._audio_data_buffer.available > 0:
+                written = self._write_to_stream(nbytes)
+                if (unfulfilled := nbytes - written) > 0:
+                    self._pending_bytes = unfulfilled
             else:
-                nbytes = min(min_bytes, nbytes)
-            assert _debug('PulseAudioPlayer: Try to get {} bytes of audio data'.format(nbytes))
-            compensation_time = self.get_audio_time_diff()
-            self._current_audio_data = self.source.get_audio_data(nbytes, compensation_time)
-            self._schedule_events()
-        if self._current_audio_data is None:
-            assert _debug('PulseAudioPlayer: No audio data available')
+                self._pending_bytes = nbytes
+
+        self.stream.mainloop.signal()
+
+    def _underflow_callback(self, _stream, _userdata) -> None:
+        # Called from within PA thread
+        assert _debug('PulseAudioPlayer: underflow')
+        with self._audio_data_lock:
+            if self._pyglet_source_exhausted and self._audio_data_buffer.available == 0:
+                MediaEvent('on_eos').sync_dispatch_to_player(self.player)
+            self._has_underrun = True
+        self.stream.mainloop.signal()
+
+    def _maybe_fill_audio_data_buffer(self) -> None:
+        # PA as opposed to the other backends works on requests which are relatively small (or on a
+        # polling model not used here which also requires the client to adjust to an ideal remaining
+        # space), so this chops up AudioData in an attempt of not hitting source.get_audio_data too
+        # often.
+        # Hold the audio_data_lock when calling this.
+        if self._pyglet_source_exhausted:
+            return
+
+        refill_size = self._audio_data_buffer.get_ideal_refill_size(self._pending_bytes)
+        if refill_size == 0:
+            return
+
+        self._audio_data_lock.release()
+
+        refill_size = self.source.audio_format.align(refill_size)
+        assert _debug(f'PulseAudioPlayer: Getting {refill_size}B of audio data')
+        new_data = self._get_and_compensate_audio_data(refill_size, self._get_read_index())
+
+        self._audio_data_lock.acquire()
+
+        if new_data is None:
+            self._pyglet_source_exhausted = True
+            if self._has_underrun:
+                MediaEvent('on_eos').sync_dispatch_to_player(self.player)
         else:
-            assert _debug('PulseAudioPlayer: Got {} bytes of audio data'.format(
-                           self._current_audio_data.length))
-        return self._current_audio_data
+            self._audio_data_buffer.add_data(new_data)
+            self.append_events(self._audio_data_buffer.virtual_write_index, new_data.events)
 
-    def _has_audio_data(self):
-        return self._get_audio_data() is not None
+    def _write_to_stream(self, nbytes: int) -> int:
+        data_ptr, bytes_accepted = self.stream.begin_write(nbytes)
 
-    def _consume_audio_data(self, nbytes):
-        if self._current_audio_data is not None:
-            if nbytes == self._current_audio_data.length:
-                self._current_audio_data = None
-            else:
-                self._current_audio_data.consume(nbytes, self.source.audio_format)
+        seek_mode = pa.PA_SEEK_RELATIVE_ON_READ if self._clear_write else pa.PA_SEEK_RELATIVE
 
-    def _schedule_events(self):
-        if self._current_audio_data is not None:
-            for event in self._current_audio_data.events:
-                event_index = self._write_index + event.timestamp * \
-                    self.source.audio_format.bytes_per_second
-                assert _debug('PulseAudioPlayer: Schedule event at index {}'.format(event_index))
-                self._events.append((event_index, event))
+        bytes_written = self._audio_data_buffer.memmove(data_ptr.value, bytes_accepted)
 
-    def _write_to_stream(self, nbytes=None):
-        if nbytes is None:
-            nbytes = self.stream.writable_size
-        assert _debug(f'PulseAudioPlayer: Requested to write {nbytes} bytes to stream')
-
-        seek_mode = pa.PA_SEEK_RELATIVE
-        if self._clear_write:
-            # When seeking, the stream.writable_size will be 0.
-            # So we force at least 4096 bytes to overwrite the Buffer
-            # starting at read index
-            nbytes = max(4096, nbytes)
-            seek_mode = pa.PA_SEEK_RELATIVE_ON_READ
+        if bytes_written == 0:
+            self.stream.cancel_write()
+        else: # elif bytes_written <= bytes_accepted:
+            self.stream.write(data_ptr, bytes_written, seek_mode)
             self._clear_write = False
-            assert _debug('PulseAudioPlayer: Clear buffer')
 
-        while self._has_audio_data() and nbytes > 0:
-            audio_data = self._get_audio_data()
+        assert _debug(f'PulseAudioPlayer: Wrote {bytes_written}/{nbytes}')
+        return bytes_written
 
-            write_length = min(nbytes, audio_data.length)
-            consumption = self.stream.write(audio_data, write_length, seek_mode)
+    def _update_and_get_timing_info(self) -> Optional[pa.pa_timing_info]:
+        self.stream.update_timing_info().wait().delete()
+        return self.stream.get_timing_info()
 
-            seek_mode = pa.PA_SEEK_RELATIVE
-            self._read_index_valid = True
-            self._timestamps.append((self._write_index, audio_data.timestamp))
-            self._write_index += consumption
+    def _maybe_write_pending(self) -> None:
+        with self._audio_data_lock:
+            if self._pending_bytes > 0 and self._audio_data_buffer.available > 0:
+                written = self._write_to_stream(self._pending_bytes)
+                self._pending_bytes -= written
+                # If the stream underran before, trigger it for immediate playback.
+                # Unsure whether this call is really needed, but it shouldn't break anything.
+                if self._has_underrun:
+                    self.stream.trigger().wait().delete()
+                    self._has_underrun = False
 
-            assert _debug('PulseAudioPlayer: Actually wrote {} bytes '
-                          'to stream'.format(consumption))
-            self._consume_audio_data(consumption)
+    def work(self) -> None:
+        with self.driver.mainloop.lock:
+            self._maybe_write_pending()
+            self._latest_timing_info = self._update_and_get_timing_info()
 
-            nbytes -= consumption
+        self.dispatch_media_events(self._get_read_index())
+        with self._audio_data_lock:
+            self._maybe_fill_audio_data_buffer()
+        with self.driver.mainloop.lock:
+            self._maybe_write_pending()
 
-        if not self._has_audio_data():
-            # In case the source group wasn't long enough to prebuffer stream
-            # to PA's satisfaction, trigger immediate playback (has no effect
-            # if stream is already playing).
-            if self._playing:
-                op = self.stream.trigger()
-                op.delete()  # Explicit delete to prevent locking
+    def delete(self) -> None:
+        assert _debug('PulseAudioPlayer.delete')
+        self.driver.worker.remove(self)
 
-    def _handle_underflow(self):
-        assert _debug('Player: underflow')
-        if self._has_audio_data():
-            self._write_to_stream()
+        if self.driver.mainloop is None:
+            assert _debug('PulseAudioPlayer.delete: PulseAudioDriver already deleted.')
+            # This is fine otherwise. If the mainloop's gone, the context is gone too,
+            # having cleaned up all its streams.
         else:
-            self._add_event_at_write_index('on_eos')
+            with self.driver.mainloop.lock:
+                self.stream.delete()
+                self.stream = None
 
-    def _process_events(self):
-        assert _debug('PulseAudioPlayer: Process events')
-        if not self._events:
-            assert _debug('PulseAudioPlayer: No events')
-            return
-
-        # Assume this is called after time sync
-        timing_info = self.stream.get_timing_info()
-        if not timing_info:
-            assert _debug('PulseAudioPlayer: No timing info to process events')
-            return
-
-        read_index = timing_info.read_index
-        assert _debug('PulseAudioPlayer: Dispatch events at index {}'.format(read_index))
-
-        while self._events and self._events[0][0] <= read_index:
-            _, event = self._events.pop(0)
-            assert _debug(f'PulseAudioPlayer: Dispatch event {event}')
-            event.sync_dispatch_to_player(self.player)
-
-    def _add_event_at_write_index(self, event_name):
-        assert _debug('PulseAudioPlayer: Add event at index {}'.format(self._write_index))
-        self._events.append((self._write_index, MediaEvent(event_name)))
-
-    def delete(self):
-        assert _debug('Delete PulseAudioPlayer')
-
-        self.stream.pop_handlers()
-        driver = self.driver()
-        if driver is None:
-            assert _debug('PulseAudioDriver has been garbage collected.')
-            self.stream = None
-            return
-
-        if driver.mainloop is None:
-            assert _debug('PulseAudioDriver already deleted. '
-                      'PulseAudioPlayer could not clean up properly.')
-            return
-
-        if self._time_sync_operation is not None:
-            with self._time_sync_operation:
-                self._time_sync_operation.delete()
-            self._time_sync_operation = None
-
-        self.stream.delete()
-        self.stream = None
-
-    def clear(self):
+    def clear(self) -> None:
         assert _debug('PulseAudioPlayer.clear')
-        super(PulseAudioPlayer, self).clear()
+        super().clear()
+
         self._clear_write = True
-        self._write_index = self._get_read_index()
-        self._timestamps = []
-        self._events = []
+        # self._pending_bytes = 0
+        # Do not reset pending_bytes. This indicates how much PA would like to
+        # have in this stream.
+        # After playing again, no write requests will be issued, with PA expecting data to be
+        # placed in the buffer as usual, so keep pending_bytes around.
+        # _clear_write will cause the data to be written at the read index, making it play
+        # asap.
+        self._pyglet_source_exhausted = False
+        self._audio_data_buffer.clear()
+        self._has_underrun = False
 
-        with self.stream:
-            self._read_index_valid = False
-            self.stream.prebuf().wait()
+        with self.stream.mainloop.lock:
+            # Just hope that the read index is frozen while we're paused.
+            ti = self._update_and_get_timing_info()
+            assert not ti.read_index_corrupt
+            self._last_clear_read_index = ti.read_index
+            self.stream.prebuf().wait().delete()
 
-    def play(self):
+    def play(self) -> None:
         assert _debug('PulseAudioPlayer.play')
 
-        with self.stream:
-            if self.stream.is_corked:
+        with self.stream.mainloop.lock:
+            if self.stream.is_corked():
                 self.stream.resume().wait().delete()
-                assert _debug('PulseAudioPlayer: Resumed playback')
-            if self.stream.underflow:
-                self._write_to_stream()
-            if not self._has_audio_data():
-                self.stream.trigger().wait().delete()
-                assert _debug('PulseAudioPlayer: Triggered stream for immediate playback')
-            assert not self.stream.is_corked
+            assert not self.stream.is_corked()
 
-        self._playing = True
+        self.driver.worker.add(self)
 
-    def stop(self):
+    def stop(self) -> None:
         assert _debug('PulseAudioPlayer.stop')
+        self.driver.worker.remove(self)
 
-        with self.stream:
-            if not self.stream.is_corked:
-                self.stream.pause().wait().delete()
+        with self.stream.mainloop.lock:
+            self.stream.pause().wait().delete()
 
-        self._playing = False
+    def get_play_cursor(self) -> int:
+        return self._get_read_index()
 
-    def _get_read_index(self):
-        with self.stream:
-            self.stream.update_timing_info().wait().delete()
-
-        timing_info = self.stream.get_timing_info()
-        if timing_info:
-            read_index = timing_info.read_index
-        else:
-            read_index = 0
-
-        assert _debug(f'_get_read_index -> {read_index}')
-        return read_index
-
-    def _get_write_index(self):
-        timing_info = self.stream.get_timing_info()
-        if timing_info:
-            write_index = timing_info.write_index
-        else:
-            write_index = 0
-
-        assert _debug(f'_get_write_index -> {write_index}')
-        return write_index
-
-    def _get_timing_info(self):
-        with self.stream:
-            self.stream.update_timing_info().wait().delete()
-
-        timing_info = self.stream.get_timing_info()
-        return timing_info
-
-    def get_time(self):
-        if not self._read_index_valid:
-            assert _debug('get_time <_read_index_valid = False> -> 0')
+    def _get_read_index(self) -> int:
+        if (t_info := self._latest_timing_info) is None:
             return 0
 
-        t_info = self._get_timing_info()
-        read_index = t_info.read_index
-        transport_usec = t_info.transport_usec
-        sink_usec = t_info.sink_usec
+        read_idx = t_info.read_index - self._last_clear_read_index
+        # bps = self.source.audio_format.bytes_per_second
+        # (t_info.transport_usec / 1000000.0) * bps -
+        # (t_info.sink_usec / 1000000.0) * bps
 
-        write_index = 0
-        timestamp = 0.0
+        assert _debug(f'_get_read_index -> {read_idx}')
+        return read_idx
 
-        try:
-            write_index, timestamp = self._timestamps[0]
-            write_index, timestamp = self._timestamps[1]
-            while read_index >= write_index:
-                del self._timestamps[0]
-                write_index, timestamp = self._timestamps[1]
-        except IndexError:
-            pass
-
-        bytes_per_second = self.source.audio_format.bytes_per_second
-        dt = (read_index - write_index) / float(bytes_per_second) * 1000000
-        # We add 2x the transport time because we didn't take it into account
-        # when we wrote the write index the first time. See _write_to_stream
-        dt += t_info.transport_usec * 2
-        dt -= t_info.sink_usec
-        # We convert back to seconds
-        dt /= 1000000
-        time = timestamp + dt
-
-        assert _debug('get_time -> {time}')
-        return time
-
-    def set_volume(self, volume):
+    def set_volume(self, volume: float) -> None:
         self._volume = volume
 
         if self.stream:
-            driver = self.driver()
+            driver = self.driver
             volume *= driver._listener._volume
-            with driver.context:
-                driver.context.set_input_volume(self.stream, volume).wait()
+            with driver.context.mainloop.lock:
+                driver.context.set_input_volume(self.stream, volume).wait().delete()
 
     def set_pitch(self, pitch):
-        sample_rate = self.stream.audio_format.rate
-        with self.stream:
-            self.stream.update_sample_rate(int(pitch * sample_rate)).wait()
+        with self.stream.mainloop.lock:
+            sample_rate = self.stream.get_sample_spec().rate
+            self.stream.update_sample_rate(int(pitch * sample_rate)).wait().delete()
 
     def prefill_audio(self):
-        self._write_to_stream(nbytes=None)
+        self.work()

--- a/pyglet/media/drivers/pulse/interface.py
+++ b/pyglet/media/drivers/pulse/interface.py
@@ -1,22 +1,38 @@
+import ctypes
 import sys
+from typing import Any, Callable, Dict, Optional, Tuple, TYPE_CHECKING, TypeVar, Union
 import weakref
 
-from . import lib_pulseaudio as pa
+from pyglet.media.drivers.pulse import lib_pulseaudio as pa
 from pyglet.media.exceptions import MediaException
 from pyglet.util import debug_print
 
-import pyglet
+if TYPE_CHECKING:
+    from pyglet.media.codecs import AudioData, AudioFormat
+
+T = TypeVar('T')
+PulseAudioStreamSuccessCallback = Callable[[ctypes.POINTER(pa.pa_stream), int, Any], Any]
+PulseAudioStreamRequestCallback = Callable[[ctypes.POINTER(pa.pa_stream), int, Any], Any]
+PulseAudioStreamNotifyCallback = Callable[[ctypes.POINTER(pa.pa_stream), Any], Any]
+PulseAudioContextSuccessCallback = Callable[[ctypes.POINTER(pa.pa_context), int, Any], Any]
+
+
 _debug = debug_print('debug_media')
 
 
-def get_uint32_or_none(value):
-    # Check for max uint32
-    if value is None or value == 4294967295:
+_UINT32_MAX = 0xFFFFFFFF
+_SIZE_T_MAX = sys.maxsize*2 + 1
+PA_INVALID_INDEX = _UINT32_MAX
+PA_INVALID_WRITABLE_SIZE = _SIZE_T_MAX
+
+
+def get_uint32_or_none(value: Optional[int]) -> Optional[int]:
+    if value is None or value == _UINT32_MAX:
         return None
     return value
 
 
-def get_bool_or_none(value):
+def get_bool_or_none(value: Optional[int]) -> Optional[bool]:
     if value < 0:
         return None
     elif value == 1:
@@ -25,136 +41,130 @@ def get_bool_or_none(value):
         return False
 
 
-def get_ascii_str_or_none(value):
+def get_ascii_str_or_none(value: Optional[bytes]) -> Optional[str]:
     if value is not None:
         return value.decode('ascii')
     return None
 
 
+class Proplist:
+    def __init__(self, ini_data: Optional[Dict[str, Union[bytes, str]]] = None) -> None:
+        self._pl = pa.pa_proplist_new()
+        if not self._pl:
+            raise PulseAudioException(0, 'Failed creating proplist.')
+        if ini_data is not None:
+            for k, v in ini_data:
+                self[k] = v
+
+    def __setitem__(self, k, v):
+        if isinstance(v, bytes):
+            r = pa.pa_proplist_set(self._pl, k.encode("utf-8"), v, len(v))
+        else:
+            r = pa.pa_proplist_sets(self._pl, k.encode("utf-8"), v.encode("utf-8"))
+        if r != 0:
+            raise PulseAudioException(0, 'Error setting proplist entry.')
+
+    def __delitem__(self, k):
+        if pa.pa_proplist_unset(k) != 0:
+            raise PulseAudioException(0, 'Error unsetting proplist entry.')
+
+    def delete(self) -> None:
+        pa.pa_proplist_free(self._pl)
+        self._pl = None
+
+
 class PulseAudioException(MediaException):
-    def __init__(self, error_code, message):
-        super(PulseAudioException, self).__init__(message)
+    def __init__(self, error_code: int, message: str) -> None:
+        super().__init__(message)
         self.error_code = error_code
         self.message = message
 
     def __str__(self):
-        return '{}: [{}] {}'.format(self.__class__.__name__, self.error_code, self.message)
+        return f'{self.__class__.__name__}: [{self.error_code}] {self.message}'
 
     __repr__ = __str__
 
 
-class PulseAudioMainLoop:
-    def __init__(self):
+class _MainloopLock:
+    def __init__(self, mainloop: 'PulseAudioMainloop') -> None:
+        self.mainloop = mainloop
+
+    def __enter__(self):
+        self.mainloop.lock_()
+
+    def __exit__(self, _exc_type, _ecx_value, _tb):
+        self.mainloop.unlock()
+
+
+class PulseAudioMainloop:
+    def __init__(self) -> None:
         self._pa_threaded_mainloop = pa.pa_threaded_mainloop_new()
-        self._pa_mainloop = pa.pa_threaded_mainloop_get_api(self._pa_threaded_mainloop)
-        self._lock_count = 0
+        self._pa_mainloop_vtab = pa.pa_threaded_mainloop_get_api(self._pa_threaded_mainloop)
+        self.lock = _MainloopLock(self)
 
-    def __del__(self):
-        self.delete()
-
-    def start(self):
+    def start(self) -> None:
         """Start running the mainloop."""
-        with self:
-            result = pa.pa_threaded_mainloop_start(self._pa_threaded_mainloop)
-            if result < 0:
-                raise PulseAudioException(0, "Failed to start PulseAudio mainloop")
-        assert _debug('PulseAudioMainLoop: Started')
+        result = pa.pa_threaded_mainloop_start(self._pa_threaded_mainloop)
+        if result < 0:
+            raise PulseAudioException(0, "Failed to start PulseAudio mainloop")
+        assert _debug('PulseAudioMainloop: Started')
 
-    def delete(self):
+    def delete(self) -> None:
         """Clean up the mainloop."""
         if self._pa_threaded_mainloop is not None:
-            assert _debug("Delete PulseAudioMainLoop")
+            assert _debug("Delete PulseAudioMainloop")
             pa.pa_threaded_mainloop_stop(self._pa_threaded_mainloop)
             pa.pa_threaded_mainloop_free(self._pa_threaded_mainloop)
             self._pa_threaded_mainloop = None
-            self._pa_mainloop = None
+            self._pa_mainloop_vtab = None
 
-    def lock(self):
+    def lock_(self) -> None:
         """Lock the threaded mainloop against events.  Required for all
         calls into PA."""
         assert self._pa_threaded_mainloop is not None
         pa.pa_threaded_mainloop_lock(self._pa_threaded_mainloop)
-        self._lock_count += 1
 
-    def unlock(self):
+    def unlock(self) -> None:
         """Unlock the mainloop thread."""
         assert self._pa_threaded_mainloop is not None
-        # TODO: This is not completely safe. Unlock might be called without lock.
-        assert self._lock_count > 0
-        self._lock_count -= 1
         pa.pa_threaded_mainloop_unlock(self._pa_threaded_mainloop)
 
-    def signal(self):
+    def signal(self) -> None:
         """Signal the mainloop thread to break from a wait."""
         assert self._pa_threaded_mainloop is not None
         pa.pa_threaded_mainloop_signal(self._pa_threaded_mainloop, 0)
 
-    def wait(self):
-        """Wait for a signal."""
+    def wait(self) -> None:
+        """Unlock and then Wait for a signal from the locked mainloop.
+        It's important to note that the PA mainloop lock is reentrant, yet this method only
+        releases one lock.
+        Before returning, the lock is reacquired.
+        """
         assert self._pa_threaded_mainloop is not None
-        # Although lock and unlock can be called reentrantly, the wait call only releases one lock.
-        assert self._lock_count > 0
-        original_lock_count = self._lock_count
-        while self._lock_count > 1:
-            self.unlock()
         pa.pa_threaded_mainloop_wait(self._pa_threaded_mainloop)
-        while self._lock_count < original_lock_count:
-            self.lock()
 
-    def create_context(self):
-        return PulseAudioContext(self, self._context_new())
+    def create_context(self) -> 'PulseAudioContext':
+        """Construct and return a new context in this mainloop.
+        Will grab the lock.
+        """
+        assert self._pa_mainloop_vtab is not None
+        app_name = self._get_app_name().encode("utf-8")
+        with self.lock:
+            return PulseAudioContext(self, app_name)
 
-    def _context_new(self):
-        """Construct a new context in this mainloop."""
-        assert self._pa_mainloop is not None
-        app_name = self._get_app_name()
-        context = pa.pa_context_new(self._pa_mainloop,
-                                    app_name.encode('ASCII')
-                                    )
-        return context
-
-    def _get_app_name(self):
+    def _get_app_name(self) -> str:
         """Get the application name as advertised to the pulseaudio server."""
         # TODO move app name into pyglet.app (also useful for OS X menu bar?).
         return sys.argv[0]
 
-    def __enter__(self):
-        self.lock()
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.unlock()
-
-
-class PulseAudioLockable:
-    def __init__(self, mainloop):
+class PulseAudioMainloopChild:
+    def __init__(self, mainloop: PulseAudioMainloop):
         assert mainloop is not None
-        self.mainloop = weakref.ref(mainloop)
-
-    def lock(self):
-        """Lock the threaded mainloop against events.  Required for all
-        calls into PA."""
-        self.mainloop().lock()
-
-    def unlock(self):
-        """Unlock the mainloop thread."""
-        self.mainloop().unlock()
-
-    def signal(self):
-        """Signal the mainloop thread to break from a wait."""
-        self.mainloop().signal()
-
-    def wait(self):
-        """Wait for a signal."""
-        self.mainloop().wait()
-
-    def __enter__(self):
-        self.lock()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.unlock()
+        self.mainloop = mainloop
 
 
-class PulseAudioContext(PulseAudioLockable):
+class PulseAudioContext(PulseAudioMainloopChild):
     """Basic object for a connection to a PulseAudio server."""
     _state_name = {pa.PA_CONTEXT_UNCONNECTED: 'Unconnected',
                    pa.PA_CONTEXT_CONNECTING: 'Connecting',
@@ -164,71 +174,77 @@ class PulseAudioContext(PulseAudioLockable):
                    pa.PA_CONTEXT_FAILED: 'Failed',
                    pa.PA_CONTEXT_TERMINATED: 'Terminated'}
 
-    def __init__(self, mainloop, pa_context):
-        super(PulseAudioContext, self).__init__(mainloop)
-        self._pa_context = pa_context
+    def __init__(self, mainloop: PulseAudioMainloop, name: bytes) -> None:
+        super().__init__(mainloop)
+
+        # TODO: Filling in stuff like language, IDs and icons is possible here
+        # but gateways to get them down here don't really exist.
+        # pl = Proplist({}); pl.delete()
+        ctx = pa.pa_context_new_with_proplist(mainloop._pa_mainloop_vtab, name, None)
+        self.check_ptr_not_null(ctx)
+
+        self._pa_context = ctx
         self.state = None
 
-        self._connect_callbacks()
+        self._set_state_callback(self._state_callback)
 
-    def __del__(self):
+    def delete(self) -> None:
+        """Completely shut down pulseaudio client. Will lock."""
         if self._pa_context is not None:
-            with self:
-                self.delete()
+            with self.mainloop.lock:
+                assert _debug("PulseAudioContext.delete")
+                if self.is_ready:
+                    pa.pa_context_disconnect(self._pa_context)
 
-    def delete(self):
-        """Completely shut down pulseaudio client."""
-        if self._pa_context is not None:
-            assert _debug("PulseAudioContext.delete")
-            if self.is_ready:
-                pa.pa_context_disconnect(self._pa_context)
+                    while self.state is not None and not self.is_terminated:
+                        self.mainloop.wait()
 
-                while self.state is not None and not self.is_terminated:
-                    self.wait()
+                self._set_state_callback(0)
+                pa.pa_context_unref(self._pa_context)
 
-            self._disconnect_callbacks()
-            pa.pa_context_unref(self._pa_context)
             self._pa_context = None
 
     @property
-    def is_ready(self):
+    def is_ready(self) -> bool:
         return self.state == pa.PA_CONTEXT_READY
 
     @property
-    def is_failed(self):
+    def is_failed(self) -> bool:
         return self.state == pa.PA_CONTEXT_FAILED
 
     @property
-    def is_terminated(self):
+    def is_terminated(self) -> bool:
         return self.state == pa.PA_CONTEXT_TERMINATED
 
     @property
-    def server(self):
+    def server(self) -> Optional[str]:
         if self.is_ready:
             return get_ascii_str_or_none(pa.pa_context_get_server(self._pa_context))
         else:
             return None
 
     @property
-    def protocol_version(self):
+    def protocol_version(self) -> Optional[str]:
         if self._pa_context is not None:
             return get_uint32_or_none(pa.pa_context_get_protocol_version(self._pa_context))
 
     @property
-    def server_protocol_version(self):
+    def server_protocol_version(self) -> Optional[str]:
         if self._pa_context is not None:
             return get_uint32_or_none(pa.pa_context_get_server_protocol_version(self._pa_context))
 
     @property
-    def is_local(self):
+    def is_local(self) -> Optional[bool]:
         if self._pa_context is not None:
             return get_bool_or_none(pa.pa_context_is_local(self._pa_context))
 
-    def connect(self, server=None):
+    def connect(self, server: Optional[bytes] = None) -> None:
         """Connect the context to a PulseAudio server.
 
+        Will grab the mainloop lock.
+
         :Parameters:
-            `server` : str
+            `server` : bytes
                 Server to connect to, or ``None`` for the default local
                 server (which may be spawned as a daemon if no server is
                 found).
@@ -236,120 +252,84 @@ class PulseAudioContext(PulseAudioLockable):
         assert self._pa_context is not None
         self.state = None
 
-        with self:
+        with self.mainloop.lock:
             self.check(
                 pa.pa_context_connect(self._pa_context, server, 0, None)
             )
             while not self.is_failed and not self.is_ready:
-                self.wait()
+                self.mainloop.wait()
 
-        if self.is_failed:
-            self.raise_error()
+            if self.is_failed:
+                self.raise_error()
 
-    def create_stream(self, audio_format):
+    def create_stream(self, audio_format: 'AudioFormat') -> 'PulseAudioStream':
         """
         Create a new audio stream.
         """
-        mainloop = self.mainloop()
-        assert mainloop is not None
         assert self.is_ready
 
-        sample_spec = self.create_sample_spec(audio_format)
-        channel_map = None
+        return PulseAudioStream(self, audio_format)
 
-        # TODO It is now recommended to use pa_stream_new_with_proplist()
-        stream = pa.pa_stream_new(self._pa_context,
-                                  str(id(self)).encode('ASCII'),
-                                  sample_spec,
-                                  channel_map)
-        self.check_not_null(stream)
-        return PulseAudioStream(mainloop, self, stream)
-
-    def create_sample_spec(self, audio_format):
-        """
-        Create a PulseAudio sample spec from pyglet audio format.
-        """
-        sample_spec = pa.pa_sample_spec()
-        if audio_format.sample_size == 8:
-            sample_spec.format = pa.PA_SAMPLE_U8
-        elif audio_format.sample_size == 16:
-            if sys.byteorder == 'little':
-                sample_spec.format = pa.PA_SAMPLE_S16LE
-            else:
-                sample_spec.format = pa.PA_SAMPLE_S16BE
-        elif audio_format.sample_size == 24:
-            if sys.byteorder == 'little':
-                sample_spec.format = pa.PA_SAMPLE_S24LE
-            else:
-                sample_spec.format = pa.PA_SAMPLE_S24BE
-        else:
-            raise MediaException('Unsupported sample size')
-        sample_spec.rate = audio_format.sample_rate
-        sample_spec.channels = audio_format.channels
-        return sample_spec
-
-    def set_input_volume(self, stream, volume):
+    def set_input_volume(self, stream: 'PulseAudioStream', volume: float) -> 'PulseAudioOperation':
         """
         Set the volume for a stream.
         """
         cvolume = self._get_cvolume_from_linear(stream, volume)
-        idx = stream.index
-        op = PulseAudioOperation(self, succes_cb_t=pa.pa_context_success_cb_t)
-        op.execute(
-                pa.pa_context_set_sink_input_volume(self._pa_context,
-                                                    idx,
-                                                    cvolume,
-                                                    op.pa_callback,
-                                                    None)
-                  )
-        return op
 
-    def _get_cvolume_from_linear(self, stream, volume):
+        clump = PulseAudioContextSuccessCallbackLump(self)
+        return PulseAudioOperation(
+            clump,
+            pa.pa_context_set_sink_input_volume(
+                self._pa_context,
+                stream.index,
+                cvolume,
+                clump.pa_callback,
+                None,
+            ),
+        )
+
+    def _get_cvolume_from_linear(self, stream: 'PulseAudioStream', volume: float) -> pa.pa_cvolume:
         cvolume = pa.pa_cvolume()
         volume = pa.pa_sw_volume_from_linear(volume)
-        pa.pa_cvolume_set(cvolume,
-                          stream.audio_format.channels,
-                          volume)
+        pa.pa_cvolume_set(cvolume, stream.get_sample_spec().channels, volume)
         return cvolume
 
-    def _connect_callbacks(self):
-        self._state_cb_func = pa.pa_context_notify_cb_t(self._state_callback)
-        pa.pa_context_set_state_callback(self._pa_context,
-                                         self._state_cb_func, None)
+    def _set_state_callback(
+        self,
+        py_callback: Optional[Callable[['PulseAudioContext', Any], Any]]
+    ) -> None:
+        if py_callback is None:
+            self._pa_state_change_callback = None
+        else:
+            self._pa_state_change_callback = pa.pa_context_notify_cb_t(py_callback)
+        pa.pa_context_set_state_callback(self._pa_context, self._pa_state_change_callback, None)
 
-    def _disconnect_callbacks(self):
-        self._state_cb_func = None
-        pa.pa_context_set_state_callback(self._pa_context,
-                                         pa.pa_context_notify_cb_t(0),
-                                         None)
-
-    def _state_callback(self, context, userdata):
+    def _state_callback(self, context: 'PulseAudioContext', _userdata) -> None:
         self.state = pa.pa_context_get_state(self._pa_context)
-        assert _debug('PulseAudioContext: state changed to {}'.format(
-                self._state_name[self.state]))
-        self.signal()
+        assert _debug(f'PulseAudioContext: state changed to {self._state_name[self.state]}')
+        self.mainloop.signal()
 
-    def check(self, result):
+    def check(self, result: T) -> T:
         if result < 0:
             self.raise_error()
         return result
 
-    def check_not_null(self, value):
+    def check_not_null(self, value: T) -> T:
         if value is None:
             self.raise_error()
         return value
 
-    def check_ptr_not_null(self, value):
+    def check_ptr_not_null(self, value: T) -> T:
         if not value:
             self.raise_error()
         return value
 
-    def raise_error(self):
+    def raise_error(self) -> None:
         error = pa.pa_context_errno(self._pa_context)
         raise PulseAudioException(error, get_ascii_str_or_none(pa.pa_strerror(error)))
 
 
-class PulseAudioStream(PulseAudioLockable, pyglet.event.EventDispatcher):
+class PulseAudioStream(PulseAudioMainloopChild):
     """PulseAudio audio stream."""
 
     _state_name = {pa.PA_STREAM_UNCONNECTED: 'Unconnected',
@@ -358,22 +338,59 @@ class PulseAudioStream(PulseAudioLockable, pyglet.event.EventDispatcher):
                    pa.PA_STREAM_FAILED: 'Failed',
                    pa.PA_STREAM_TERMINATED: 'Terminated'}
 
-    def __init__(self, mainloop, context, pa_stream):
-        PulseAudioLockable.__init__(self, mainloop)
-        self._pa_stream = pa_stream
-        self.context = weakref.ref(context)
-        self.state = None
-        self.underflow = False
+    def __init__(self, context: PulseAudioContext, audio_format: 'AudioFormat') -> None:
+        super().__init__(context.mainloop)
 
-        pa.pa_stream_ref(self._pa_stream)
-        self._connect_callbacks()
+        self.state = None
+        """The stream's state."""
+
+        self.index = None
+        """The stream's sink index."""
+
+        self.context = weakref.ref(context)
+
+        self._cb_write = pa.pa_stream_request_cb_t(0)
+        self._cb_underflow = pa.pa_stream_notify_cb_t(0)
+        self._cb_state = pa.pa_stream_notify_cb_t(self._state_callback)
+        self._cb_moved = pa.pa_stream_notify_cb_t(self._moved_callback)
+
+        self._pa_stream = pa.pa_stream_new_with_proplist(
+            context._pa_context,
+            f'{id(self):X}'.encode("utf-8"),
+            self.create_sample_spec(audio_format),
+            None,  # Default channel map
+            None,  # No proplist to supply
+        )
+        context.check_not_null(self._pa_stream)
+
+        pa.pa_stream_set_state_callback(self._pa_stream, self._cb_state, None)
+        pa.pa_stream_set_moved_callback(self._pa_stream, self._cb_moved, None)
         self._refresh_state()
 
-    def __del__(self):
-        if self._pa_stream is not None:
-            self.delete()
+    def create_sample_spec(self, audio_format: 'AudioFormat') -> pa.pa_sample_spec:
+        """
+        Create a PulseAudio sample spec from pyglet audio format.
+        """
+        _FORMATS = {
+            ('little', 8):  pa.PA_SAMPLE_U8,
+            ('big', 8):     pa.PA_SAMPLE_U8,
+            ('little', 16): pa.PA_SAMPLE_S16LE,
+            ('big', 16):    pa.PA_SAMPLE_S16BE,
+            ('little', 24): pa.PA_SAMPLE_S24LE,
+            ('big', 24):    pa.PA_SAMPLE_S24BE,
+        }
+        fmt = (sys.byteorder, audio_format.sample_size) 
+        if fmt not in _FORMATS:
+            raise MediaException(f'Unsupported sample size/format: {fmt}')
 
-    def delete(self):
+        sample_spec = pa.pa_sample_spec()
+        sample_spec.format = _FORMATS[fmt]
+        sample_spec.rate = audio_format.sample_rate
+        sample_spec.channels = audio_format.channels
+        return sample_spec
+
+    def delete(self) -> None:
+        """If connected, disconnect, and delete the stream."""
         context = self.context()
         if context is None:
             assert _debug("No active context anymore. Cannot disconnect the stream")
@@ -388,67 +405,75 @@ class PulseAudioStream(PulseAudioLockable, pyglet.event.EventDispatcher):
         if not self.is_unconnected:
             assert _debug("PulseAudioStream: disconnecting")
 
-            with self:
-                context.check(
-                    pa.pa_stream_disconnect(self._pa_stream)
-                    )
-                while not (self.is_terminated or self.is_failed):
-                    self.wait()
+            context.check(
+                pa.pa_stream_disconnect(self._pa_stream)
+            )
+            while not (self.is_terminated or self.is_failed):
+                self.mainloop.wait()
 
         self._disconnect_callbacks()
         pa.pa_stream_unref(self._pa_stream)
         self._pa_stream = None
 
     @property
-    def is_unconnected(self):
+    def is_unconnected(self) -> bool:
         return self.state == pa.PA_STREAM_UNCONNECTED
 
     @property
-    def is_creating(self):
+    def is_creating(self) -> bool:
         return self.state == pa.PA_STREAM_CREATING
 
     @property
-    def is_ready(self):
+    def is_ready(self) -> bool:
         return self.state == pa.PA_STREAM_READY
 
     @property
-    def is_failed(self):
+    def is_failed(self) -> bool:
         return self.state == pa.PA_STREAM_FAILED
 
     @property
-    def is_terminated(self):
+    def is_terminated(self) -> bool:
         return self.state == pa.PA_STREAM_TERMINATED
 
-    @property
-    def writable_size(self):
+    def get_writable_size(self) -> int:
         assert self._pa_stream is not None
-        return pa.pa_stream_writable_size(self._pa_stream)
 
-    @property
-    def index(self):
+        r = pa.pa_stream_writable_size(self._pa_stream)
+        if r == PA_INVALID_WRITABLE_SIZE:
+            self.context().raise_error()
+        return r
+
+    def is_corked(self) -> bool:
         assert self._pa_stream is not None
-        return pa.pa_stream_get_index(self._pa_stream)
 
-    @property
-    def is_corked(self):
-        assert self._pa_stream is not None
-        return get_bool_or_none(pa.pa_stream_is_corked(self._pa_stream))
+        r = pa.pa_stream_is_corked(self._pa_stream)
+        self.context().check(r)
+        return bool(r)
 
-    @property
-    def audio_format(self):
+    def get_sample_spec(self) -> pa.pa_sample_spec:
         assert self._pa_stream is not None
         return pa.pa_stream_get_sample_spec(self._pa_stream)[0]
 
-    def connect_playback(self):
+    def connect_playback(self) -> None:
         context = self.context()
         assert self._pa_stream is not None
         assert context is not None
+
         device = None
-        buffer_attr = None
+
+        buffer_attr = pa.pa_buffer_attr()
+        buffer_attr.fragsize = _UINT32_MAX  # Irrelevant for playback
+        buffer_attr.maxlength = _UINT32_MAX
+        buffer_attr.tlength = _UINT32_MAX
+        buffer_attr.prebuf = _UINT32_MAX
+        buffer_attr.minreq = _UINT32_MAX
+
         flags = (pa.PA_STREAM_START_CORKED |
                  pa.PA_STREAM_INTERPOLATE_TIMING |
                  pa.PA_STREAM_VARIABLE_RATE)
+
         volume = None
+
         sync_stream = None  # TODO use this
 
         context.check(
@@ -461,240 +486,273 @@ class PulseAudioStream(PulseAudioLockable, pyglet.event.EventDispatcher):
         )
 
         while not self.is_ready and not self.is_failed:
-            self.wait()
+            self.mainloop.wait()
         if not self.is_ready:
             context.raise_error()
+
+        self._refresh_sink_index()
+        # ba = pa.pa_stream_get_buffer_attr(self._pa_stream).contents
+        # print(f"{ba.maxlength=}, {ba.tlength=}, {ba.prebuf=}, {ba.minreq=}, {ba.fragsize=}")
+
         assert _debug('PulseAudioStream: Playback connected')
 
-    def write(self, audio_data, length=None, seek_mode=pa.PA_SEEK_RELATIVE):
+    def begin_write(self, nbytes: Optional[int] = None) -> Tuple[ctypes.c_void_p, int]:
+        context = self.context()
+        assert context is not None
+
+        addr = ctypes.c_void_p()
+        nbytes_st = ctypes.c_size_t(_SIZE_T_MAX if nbytes is None else nbytes)
+
+        context.check(
+            pa.pa_stream_begin_write(self._pa_stream, ctypes.byref(addr), ctypes.byref(nbytes_st))
+        )
+        context.check_ptr_not_null(addr)
+
+        assert _debug(f"PulseAudioStream: begin_write nbytes={nbytes} nbytes_n={nbytes_st.value}")
+
+        return addr, nbytes_st.value
+
+    def cancel_write(self) -> None:
+        self.context().check(pa.pa_stream_cancel_write(self._pa_stream))
+
+    def write(self, data, length: int, seek_mode=pa.PA_SEEK_RELATIVE) -> int:
         context = self.context()
         assert context is not None
         assert self._pa_stream is not None
         assert self.is_ready
-        if length is None:
-            length = min(audio_data.length, self.writable_size)
-        assert _debug('PulseAudioStream: writing {} bytes'.format(length))
-        assert _debug('PulseAudioStream: writable size before write {} bytes'.format(self.writable_size))
+        assert _debug(f'PulseAudioStream: writing {length} bytes')
+
         context.check(
-                pa.pa_stream_write(self._pa_stream,
-                                   audio_data.data,
-                                   length,
-                                   pa.pa_free_cb_t(0),  # Data is copied
-                                   0,
-                                   seek_mode)
-                )
-        assert _debug('PulseAudioStream: writable size after write {} bytes'.format(self.writable_size))
-        self.underflow = False
+            pa.pa_stream_write(self._pa_stream, data, length, pa.pa_free_cb_t(0), 0, seek_mode)
+        )
         return length
 
-    def update_timing_info(self, callback=None):
+    def update_timing_info(
+        self,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> 'PulseAudioOperation':
         context = self.context()
         assert context is not None
         assert self._pa_stream is not None
-        op = PulseAudioOperation(context, callback)
-        op.execute(
-                pa.pa_stream_update_timing_info(self._pa_stream,
-                                                op.pa_callback,
-                                                None)
-                )
-        return op
 
-    def get_timing_info(self):
+        clump = PulseAudioStreamSuccessCallbackLump(context, callback)
+        return PulseAudioOperation(
+            clump,
+            pa.pa_stream_update_timing_info(self._pa_stream, clump.pa_callback, None),
+        )
+
+    def get_timing_info(self) -> Optional[pa.pa_timing_info]:
+        """
+        Retrieves the stream's timing_info struct,
+        or None if it does not exist.
+        Note that ctypes creates a copy of the struct, meaning it will
+        be safe to use with an unlocked mainloop.
+        """
         context = self.context()
         assert context is not None
         assert self._pa_stream is not None
-        timing_info = context.check_ptr_not_null(
-                pa.pa_stream_get_timing_info(self._pa_stream)
-                )
-        return timing_info.contents
+        timing_info = pa.pa_stream_get_timing_info(self._pa_stream)
+        return timing_info.contents if timing_info else None
 
-    def trigger(self, callback=None):
+    def trigger(
+        self,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> 'PulseAudioOperation':
         context = self.context()
         assert context is not None
         assert self._pa_stream is not None
-        op = PulseAudioOperation(context)
-        op.execute(
-                pa.pa_stream_trigger(self._pa_stream,
-                                     op.pa_callback,
-                                     None)
-                )
-        return op
 
-    def prebuf(self, callback=None):
+        clump = PulseAudioStreamSuccessCallbackLump(context, callback)
+        return PulseAudioOperation(
+            clump,
+            pa.pa_stream_trigger(self._pa_stream, clump.pa_callback, None),
+        )
+
+    def prebuf(
+        self,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> 'PulseAudioOperation':
         context = self.context()
         assert context is not None
         assert self._pa_stream is not None
-        op = PulseAudioOperation(context)
-        op.execute(
-                pa.pa_stream_prebuf(self._pa_stream,
-                                    op.pa_callback,
-                                    None)
-                )
-        return op
 
-    def resume(self, callback=None):
+        clump = PulseAudioStreamSuccessCallbackLump(context, callback)
+        return PulseAudioOperation(
+            clump,
+            pa.pa_stream_prebuf(self._pa_stream, clump.pa_callback, None),
+        )
+
+    def resume(
+        self,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> 'PulseAudioOperation':
         return self._cork(False, callback)
 
-    def pause(self, callback=None):
+    def pause(
+        self,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> 'PulseAudioOperation':
         return self._cork(True, callback)
 
-    def update_sample_rate(self, sample_rate, callback=None):
+    def _cork(
+        self,
+        pause: Union[int, bool],
+        callback: PulseAudioContextSuccessCallback,
+    ) -> 'PulseAudioOperation':
         context = self.context()
         assert context is not None
         assert self._pa_stream is not None
-        op = PulseAudioOperation(context)
-        op.execute(
-                pa.pa_stream_update_sample_rate(self._pa_stream,
-                                                int(sample_rate),
-                                                op.pa_callback,
-                                                None)
-                )
-        return op
 
-    def _cork(self, pause, callback):
+        clump = PulseAudioStreamSuccessCallbackLump(context, callback)
+        return PulseAudioOperation(
+            clump,
+            pa.pa_stream_cork(self._pa_stream, pause, clump.pa_callback, None),
+        )
+
+    def update_sample_rate(
+        self,
+        sample_rate: int,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> 'PulseAudioOperation':
         context = self.context()
         assert context is not None
         assert self._pa_stream is not None
-        op = PulseAudioOperation(context)
-        op.execute(
-            pa.pa_stream_cork(self._pa_stream,
-                              1 if pause else 0,
-                              op.pa_callback,
-                              None)
-            )
-        return op
 
-    def _connect_callbacks(self):
-        self._cb_underflow = pa.pa_stream_notify_cb_t(self._underflow_callback)
-        self._cb_write = pa.pa_stream_request_cb_t(self._write_callback)
-        self._cb_state = pa.pa_stream_notify_cb_t(self._state_callback)
+        clump = PulseAudioStreamSuccessCallbackLump(context, callback)
+        return PulseAudioOperation(
+            clump,
+            pa.pa_stream_update_sample_rate(
+                self._pa_stream, sample_rate, clump.pa_callback, None
+            ),
+        )
 
-        pa.pa_stream_set_underflow_callback(self._pa_stream, self._cb_underflow, None)
+    def set_write_callback(self, f: PulseAudioStreamRequestCallback) -> None:
+        self._cb_write = pa.pa_stream_request_cb_t(f)
         pa.pa_stream_set_write_callback(self._pa_stream, self._cb_write, None)
-        pa.pa_stream_set_state_callback(self._pa_stream, self._cb_state, None)
 
-    def _disconnect_callbacks(self):
-        self._cb_underflow = None
-        self._cb_write = None
-        self._cb_state = None
+    def set_underflow_callback(self, f: PulseAudioStreamNotifyCallback) -> None:
+        self._cb_underflow = pa.pa_stream_notify_cb_t(f)
+        pa.pa_stream_set_underflow_callback(self._pa_stream, self._cb_underflow, None)
 
-        pa.pa_stream_set_underflow_callback(self._pa_stream,
-                                            pa.pa_stream_notify_cb_t(0),
-                                            None)
-        pa.pa_stream_set_write_callback(self._pa_stream,
-                                        pa.pa_stream_request_cb_t(0),
-                                        None)
-        pa.pa_stream_set_state_callback(self._pa_stream,
-                                        pa.pa_stream_notify_cb_t(0),
-                                        None)
+    def _connect_callbacks(self) -> None:
+        s = self._pa_stream
+        pa.pa_stream_set_underflow_callback(s, self._cb_underflow, None)
+        pa.pa_stream_set_write_callback(s, self._cb_write, None)
+        pa.pa_stream_set_state_callback(s, self._cb_state, None)
+        pa.pa_stream_set_moved_callback(s, self._cb_moved, None)
 
-    def _underflow_callback(self, stream, userdata):
-        assert _debug("PulseAudioStream: underflow")
-        self.underflow = True
-        self._write_needed()
-        self.signal()
+    def _disconnect_callbacks(self) -> None:
+        s = self._pa_stream
+        pa.pa_stream_set_underflow_callback(s, pa.pa_stream_notify_cb_t(0), None)
+        pa.pa_stream_set_write_callback(s, pa.pa_stream_request_cb_t(0), None)
+        pa.pa_stream_set_state_callback(s, pa.pa_stream_notify_cb_t(0), None)
+        pa.pa_stream_set_moved_callback(s, pa.pa_stream_notify_cb_t(0), None)
 
-    def _write_callback(self, stream, nbytes, userdata):
-        assert _debug("PulseAudioStream: write requested")
-        self._write_needed(nbytes)
-        self.signal()
-
-    def _state_callback(self, stream, userdata):
+    def _state_callback(self, _stream, _userdata) -> None:
         self._refresh_state()
-        assert _debug("PulseAudioStream: state changed to {}".format(self._state_name[self.state]))
-        self.signal()
+        assert _debug(f"PulseAudioStream: state changed to {self._state_name[self.state]}")
+        self.mainloop.signal()
 
-    def _refresh_state(self):
-        if self._pa_stream is not None:
-            self.state = pa.pa_stream_get_state(self._pa_stream)
+    def _moved_callback(self, _stream, _userdata) -> None:
+        self._refresh_sink_index()
+        assert _debug(f"PulseAudioStream: moved to new index {self.index}")
 
-    def _write_needed(self, nbytes=None):
-        if nbytes is None:
-            nbytes = self.writable_size
-        # This dispatch call is made from the threaded mainloop thread!
-        pyglet.app.platform_event_loop.post_event(
-            self, 'on_write_needed', nbytes, self.underflow)
+    def _refresh_sink_index(self) -> None:
+        self.index = pa.pa_stream_get_index(self._pa_stream)
+        if self.index == PA_INVALID_INDEX:
+            self.context().raise_error()
 
-    def on_write_needed(self, nbytes, underflow):
-        """A write is requested from PulseAudio.
-        Called from the PulseAudio mainloop, so no locking required.
-
-        :event:
-        """
-
-PulseAudioStream.register_event_type('on_write_needed')
+    def _refresh_state(self) -> None:
+        self.state = pa.pa_stream_get_state(self._pa_stream)
 
 
-class PulseAudioOperation(PulseAudioLockable):
-    """Asynchronous PulseAudio operation"""
+class PulseAudioOperation(PulseAudioMainloopChild):
+    """An asynchronous PulseAudio operation.
+    Can be waited for, where it will run until completion or cancellation.
+    Remember to `delete()` it with the mainloop lock held, otherwise
+    it will be leaked.
+    """
 
     _state_name = {pa.PA_OPERATION_RUNNING: 'Running',
                    pa.PA_OPERATION_DONE: 'Done',
                    pa.PA_OPERATION_CANCELLED: 'Cancelled'}
 
-    def __init__(self, context, callback=None, pa_operation=None,
-                 succes_cb_t=pa.pa_stream_success_cb_t):
-        mainloop = context.mainloop()
-        assert mainloop is not None
-        PulseAudioLockable.__init__(self, mainloop)
-        self.context = weakref.ref(context)
-        self._callback = callback
-        self.pa_callback = succes_cb_t(self._success_callback)
-        if pa_operation is not None:
-            self.execute(pa_operation)
-        else:
-            self._pa_operation = None
+    def __init__(self, callback_lump, pa_operation: pa.pa_operation) -> None:
+        context = callback_lump.context
 
-    def __del__(self):
-        if self._pa_operation is not None:
-            with self:
-                self.delete()
+        assert context.mainloop is not None
+        assert pa_operation is not None
+        context.check_ptr_not_null(pa_operation)
 
-    def delete(self):
+        super().__init__(context.mainloop)
+
+        self.callback_lump = callback_lump
+        self._pa_operation = pa_operation
+
+    def _get_state(self) -> None:
+        assert self._pa_operation is not None
+        return pa.pa_operation_get_state(self._pa_operation)
+
+    def delete(self) -> None:
+        """Unref and delete the operation."""
         if self._pa_operation is not None:
-            assert _debug("PulseAudioOperation.delete({})".format(id(self)))
             pa.pa_operation_unref(self._pa_operation)
             self._pa_operation = None
-
-    def execute(self, pa_operation):
-        context = self.context()
-        assert context is not None
-        context.check_ptr_not_null(pa_operation)
-        assert _debug("PulseAudioOperation.execute({})".format(id(self)))
-        self._pa_operation = pa_operation
-        self._get_state()
-        return self
+            self.callback_lump = None
+            self.context = None
 
     def cancel(self):
+        """Cancel the operation."""
         assert self._pa_operation is not None
         pa.pa_operation_cancel(self._pa_operation)
         return self
 
+    def wait(self):
+        """Wait until the operation is either done or cancelled."""
+        while self.is_running:
+            self.mainloop.wait()
+        return self
+
     @property
-    def is_running(self):
+    def is_running(self) -> bool:
         return self._get_state() == pa.PA_OPERATION_RUNNING
 
     @property
-    def is_done(self):
+    def is_done(self) -> bool:
         return self._get_state() == pa.PA_OPERATION_DONE
 
     @property
-    def is_cancelled(self):
+    def is_cancelled(self) -> bool:
         return self._get_state() == pa.PA_OPERATION_CANCELLED
 
-    def wait(self):
-        """Wait until operation is either done or cancelled."""
-        while self.is_running:
-            super(PulseAudioOperation, self).wait()
-        return self
 
-    def _get_state(self):
-        assert self._pa_operation is not None
-        return pa.pa_operation_get_state(self._pa_operation)
+class PulseAudioContextSuccessCallbackLump:
+    def __init__(
+        self,
+        context: PulseAudioContext,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> None:
+        self.pa_callback = pa.pa_context_success_cb_t(self._success_callback)
+        self.py_callback = callback
+        self.context = context
+
+    def _success_callback(self, context, success, userdata):
+        if self.py_callback is not None:
+            self.py_callback(context, success, userdata)
+        self.context.mainloop.signal()
+
+
+class PulseAudioStreamSuccessCallbackLump:
+    def __init__(
+        self,
+        context: PulseAudioContext,
+        callback: Optional[PulseAudioContextSuccessCallback] = None,
+    ) -> None:
+        self.pa_callback = pa.pa_stream_success_cb_t(self._success_callback)
+        self.py_callback = callback
+        self.context = context
 
     def _success_callback(self, stream, success, userdata):
-        if self._callback:
-            self._callback()
-        self.pa_callback = None  # Clean up callback, not called anymore
-        self.signal()
-
+        if self.py_callback is not None:
+            self.py_callback(stream, success, userdata)
+        self.context.mainloop.signal()

--- a/pyglet/media/drivers/pulse/interface.py
+++ b/pyglet/media/drivers/pulse/interface.py
@@ -26,13 +26,13 @@ PA_INVALID_INDEX = _UINT32_MAX
 PA_INVALID_WRITABLE_SIZE = _SIZE_T_MAX
 
 
-def get_uint32_or_none(value: Optional[int]) -> Optional[int]:
-    if value is None or value == _UINT32_MAX:
+def get_uint32_or_none(value: int) -> Optional[int]:
+    if value == _UINT32_MAX:
         return None
     return value
 
 
-def get_bool_or_none(value: Optional[int]) -> Optional[bool]:
+def get_bool_or_none(value: int) -> Optional[bool]:
     if value < 0:
         return None
     elif value == 1:
@@ -220,23 +220,25 @@ class PulseAudioContext(PulseAudioMainloopChild):
     def server(self) -> Optional[str]:
         if self.is_ready:
             return get_ascii_str_or_none(pa.pa_context_get_server(self._pa_context))
-        else:
-            return None
+        return None
 
     @property
     def protocol_version(self) -> Optional[str]:
         if self._pa_context is not None:
             return get_uint32_or_none(pa.pa_context_get_protocol_version(self._pa_context))
+        return None
 
     @property
     def server_protocol_version(self) -> Optional[str]:
         if self._pa_context is not None:
             return get_uint32_or_none(pa.pa_context_get_server_protocol_version(self._pa_context))
+        return None
 
     @property
     def is_local(self) -> Optional[bool]:
         if self._pa_context is not None:
             return get_bool_or_none(pa.pa_context_is_local(self._pa_context))
+        return None
 
     def connect(self, server: Optional[bytes] = None) -> None:
         """Connect the context to a PulseAudio server.

--- a/pyglet/media/drivers/pulse/lib_pulseaudio.py
+++ b/pyglet/media/drivers/pulse/lib_pulseaudio.py
@@ -812,7 +812,7 @@ enum_pa_update_mode = c_int
 PA_UPDATE_SET = 0
 PA_UPDATE_MERGE = 1
 PA_UPDATE_REPLACE = 2
-pa_update_mode_t = enum_pa_update_mode 	# /usr/include/pulse/proplist.h:345
+pa_update_mode_t = enum_pa_update_mode  # /usr/include/pulse/proplist.h:345
 # /usr/include/pulse/proplist.h:355
 pa_proplist_update = _lib.pa_proplist_update
 pa_proplist_update.restype = None
@@ -982,11 +982,6 @@ pa_context_get_server_protocol_version = _lib.pa_context_get_server_protocol_ver
 pa_context_get_server_protocol_version.restype = c_uint32
 pa_context_get_server_protocol_version.argtypes = [POINTER(pa_context)]
 
-enum_pa_update_mode = c_int
-PA_UPDATE_SET = 0
-PA_UPDATE_MERGE = 1
-PA_UPDATE_REPLACE = 2
-pa_update_mode_t = enum_pa_update_mode  # /usr/include/pulse/proplist.h:337
 # /usr/include/pulse/context.h:248
 pa_context_proplist_update = _lib.pa_context_proplist_update
 pa_context_proplist_update.restype = POINTER(pa_operation)
@@ -2948,12 +2943,12 @@ __all__ = ['pa_get_library_version', 'PA_API_VERSION', 'PA_PROTOCOL_VERSION',
            # Begin manually transferred proplist definitions #
            'pa_proplist', 'pa_proplist_new', 'pa_proplist_free', 'pa_proplist_key_valid',
            'pa_proplist_sets', 'pa_proplist_setp', 'pa_proplist_set', 'pa_proplist_gets',
-           'pa_proplist_get', 'pa_update_mode_t', 'PA_UPDATE_SET', 'PA_UPDATE_MERGE',
-           'PA_UPDATE_REPLACE', 'pa_proplist_update', 'pa_proplist_unset',
-           'pa_proplist_unset_many', 'pa_proplist_iterate', 'pa_proplist_to_string',
-           'pa_proplist_to_string_sep', 'pa_proplist_from_string',
-           'pa_proplist_contains', 'pa_proplist_clear', 'pa_proplist_copy',
-           'pa_proplist_size', 'pa_proplist_isempty', 'pa_proplist_equal',
+           'pa_proplist_get', 'pa_update_mode_t', 'pa_proplist_update',
+           'pa_proplist_unset', 'pa_proplist_unset_many', 'pa_proplist_iterate',
+           'pa_proplist_to_string', 'pa_proplist_to_string_sep',
+           'pa_proplist_from_string', 'pa_proplist_contains', 'pa_proplist_clear',
+           'pa_proplist_copy', 'pa_proplist_size', 'pa_proplist_isempty',
+           'pa_proplist_equal',
            # End manually transferred proplist definitions #
            'pa_context_event_cb_t', 'pa_context_new',
            'pa_context_new_with_proplist', 'pa_context_unref', 'pa_context_ref',

--- a/pyglet/media/drivers/pulse/lib_pulseaudio.py
+++ b/pyglet/media/drivers/pulse/lib_pulseaudio.py
@@ -5,8 +5,17 @@ tools/genwrappers.py pulseaudio
 
 Do not modify this file.
 
-IMPORTANT: struct_timeval is incorrectly parsed by tools/genwrappers.py and
-was manually edited in this file.
+!!! IMPORTANT !!!
+
+Despite the warning up there, this file has been manually modified:
+- struct_timeval, stemming from <sys/time.h>, is incorrectly parsed by
+  tools/genwrappers.py and was manually edited and shifted to the top.
+- All `pa_proplist_*` function definitions and the definition of an
+  associated enum have been copypasted over from a different run of this
+  script on a (likely) later version of PulseAudio's headers.
+  - This includes modifiction of `__all__` at the very end of the file.
+- All definitions of opaque structs (_opaque_struct dummy member) were
+  duplicated. Those duplicates have been manually removed.
 """
 
 import ctypes
@@ -32,6 +41,11 @@ class c_void(Structure):
     # POINTER(None) == c_void_p is actually written as
     # POINTER(c_void), so it can be treated as a real pointer.
     _fields_ = [('dummy', c_int)]
+
+
+class struct_timeval(Structure):
+    _fields_ = [("tv_sec", c_long),
+                ("tv_usec", c_long)]
 
 
 # /usr/include/pulse/version.h:40
@@ -338,11 +352,6 @@ class struct_pa_timing_info(Structure):
     ]
 
 
-class struct_timeval(Structure):
-    _fields_ = [("tv_sec", c_long),
-                ("tv_usec", c_long)]
-
-
 struct_pa_timing_info._fields_ = [
     ('timestamp', struct_timeval),
     ('synchronized_clocks', c_int),
@@ -440,15 +449,6 @@ struct_pa_mainloop_api._fields_ = [
 ]
 
 
-class struct_pa_mainloop_api(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_mainloop_api._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_mainloop_api = struct_pa_mainloop_api  # /usr/include/pulse/mainloop-api.h:47
 enum_pa_io_event_flags = c_int
 PA_IO_EVENT_NULL = 0
@@ -469,15 +469,6 @@ struct_pa_io_event._fields_ = [
 ]
 
 
-class struct_pa_io_event(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_io_event._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_io_event = struct_pa_io_event  # /usr/include/pulse/mainloop-api.h:59
 pa_io_event_cb_t = CFUNCTYPE(None, POINTER(pa_mainloop_api), POINTER(pa_io_event), c_int, pa_io_event_flags_t,
                              POINTER(None))  # /usr/include/pulse/mainloop-api.h:61
@@ -494,15 +485,6 @@ struct_pa_time_event._fields_ = [
     ('_opaque_struct', c_int)
 ]
 
-
-class struct_pa_time_event(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_time_event._fields_ = [
-    ('_opaque_struct', c_int)
-]
 
 pa_time_event = struct_pa_time_event  # /usr/include/pulse/mainloop-api.h:66
 
@@ -521,15 +503,6 @@ struct_pa_defer_event._fields_ = [
     ('_opaque_struct', c_int)
 ]
 
-
-class struct_pa_defer_event(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_defer_event._fields_ = [
-    ('_opaque_struct', c_int)
-]
 
 pa_defer_event = struct_pa_defer_event  # /usr/include/pulse/mainloop-api.h:73
 pa_defer_event_cb_t = CFUNCTYPE(None, POINTER(pa_mainloop_api), POINTER(pa_defer_event),
@@ -738,15 +711,6 @@ struct_pa_operation._fields_ = [
 ]
 
 
-class struct_pa_operation(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_operation._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_operation = struct_pa_operation  # /usr/include/pulse/operation.h:33
 pa_operation_notify_cb_t = CFUNCTYPE(None, POINTER(pa_operation), POINTER(None))  # /usr/include/pulse/operation.h:36
 # /usr/include/pulse/operation.h:39
@@ -785,15 +749,6 @@ struct_pa_context._fields_ = [
 ]
 
 
-class struct_pa_context(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_context._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_context = struct_pa_context  # /usr/include/pulse/context.h:154
 pa_context_notify_cb_t = CFUNCTYPE(None, POINTER(pa_context), POINTER(None))  # /usr/include/pulse/context.h:157
 pa_context_success_cb_t = CFUNCTYPE(None, POINTER(pa_context), c_int, POINTER(None))  # /usr/include/pulse/context.h:160
@@ -809,16 +764,122 @@ struct_pa_proplist._fields_ = [
 ]
 
 
-class struct_pa_proplist(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_proplist._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_proplist = struct_pa_proplist  # /usr/include/pulse/proplist.h:272
+
+# Begin manually transferred pa_proplist definitions #
+
+# /usr/include/pulse/proplist.h:281
+pa_proplist_new = _lib.pa_proplist_new
+pa_proplist_new.restype = POINTER(pa_proplist)
+pa_proplist_new.argtypes = []
+
+# /usr/include/pulse/proplist.h:284
+pa_proplist_free = _lib.pa_proplist_free
+pa_proplist_free.restype = None
+pa_proplist_free.argtypes = [POINTER(pa_proplist)]
+
+# /usr/include/pulse/proplist.h:287
+pa_proplist_key_valid = _lib.pa_proplist_key_valid
+pa_proplist_key_valid.restype = c_int
+pa_proplist_key_valid.argtypes = [c_char_p]
+
+# /usr/include/pulse/proplist.h:293
+pa_proplist_sets = _lib.pa_proplist_sets
+pa_proplist_sets.restype = c_int
+pa_proplist_sets.argtypes = [POINTER(pa_proplist), c_char_p, c_char_p]
+
+# /usr/include/pulse/proplist.h:301
+pa_proplist_setp = _lib.pa_proplist_setp
+pa_proplist_setp.restype = c_int
+pa_proplist_setp.argtypes = [POINTER(pa_proplist), c_char_p]
+
+# /usr/include/pulse/proplist.h:314
+pa_proplist_set = _lib.pa_proplist_set
+pa_proplist_set.restype = c_int
+pa_proplist_set.argtypes = [POINTER(pa_proplist), c_char_p, POINTER(None), c_size_t]
+
+# /usr/include/pulse/proplist.h:320
+pa_proplist_gets = _lib.pa_proplist_gets
+pa_proplist_gets.restype = c_char_p
+pa_proplist_gets.argtypes = [POINTER(pa_proplist), c_char_p]
+
+# /usr/include/pulse/proplist.h:328
+pa_proplist_get = _lib.pa_proplist_get
+pa_proplist_get.restype = c_int
+pa_proplist_get.argtypes = [POINTER(pa_proplist), c_char_p, POINTER(POINTER(None)), POINTER(c_size_t)]
+
+enum_pa_update_mode = c_int
+PA_UPDATE_SET = 0
+PA_UPDATE_MERGE = 1
+PA_UPDATE_REPLACE = 2
+pa_update_mode_t = enum_pa_update_mode 	# /usr/include/pulse/proplist.h:345
+# /usr/include/pulse/proplist.h:355
+pa_proplist_update = _lib.pa_proplist_update
+pa_proplist_update.restype = None
+pa_proplist_update.argtypes = [POINTER(pa_proplist), pa_update_mode_t, POINTER(pa_proplist)]
+
+# /usr/include/pulse/proplist.h:360
+pa_proplist_unset = _lib.pa_proplist_unset
+pa_proplist_unset.restype = c_int
+pa_proplist_unset.argtypes = [POINTER(pa_proplist), c_char_p]
+
+# /usr/include/pulse/proplist.h:367
+pa_proplist_unset_many = _lib.pa_proplist_unset_many
+pa_proplist_unset_many.restype = c_int
+pa_proplist_unset_many.argtypes = [POINTER(pa_proplist), POINTER(c_char_p)]
+
+# /usr/include/pulse/proplist.h:378
+pa_proplist_iterate = _lib.pa_proplist_iterate
+pa_proplist_iterate.restype = c_char_p
+pa_proplist_iterate.argtypes = [POINTER(pa_proplist), POINTER(POINTER(None))]
+
+# /usr/include/pulse/proplist.h:384
+pa_proplist_to_string = _lib.pa_proplist_to_string
+pa_proplist_to_string.restype = c_char_p
+pa_proplist_to_string.argtypes = [POINTER(pa_proplist)]
+
+# /usr/include/pulse/proplist.h:389
+pa_proplist_to_string_sep = _lib.pa_proplist_to_string_sep
+pa_proplist_to_string_sep.restype = c_char_p
+pa_proplist_to_string_sep.argtypes = [POINTER(pa_proplist), c_char_p]
+
+# /usr/include/pulse/proplist.h:393
+pa_proplist_from_string = _lib.pa_proplist_from_string
+pa_proplist_from_string.restype = POINTER(pa_proplist)
+pa_proplist_from_string.argtypes = [c_char_p]
+
+# /usr/include/pulse/proplist.h:397
+pa_proplist_contains = _lib.pa_proplist_contains
+pa_proplist_contains.restype = c_int
+pa_proplist_contains.argtypes = [POINTER(pa_proplist), c_char_p]
+
+# /usr/include/pulse/proplist.h:400
+pa_proplist_clear = _lib.pa_proplist_clear
+pa_proplist_clear.restype = None
+pa_proplist_clear.argtypes = [POINTER(pa_proplist)]
+
+# /usr/include/pulse/proplist.h:404
+pa_proplist_copy = _lib.pa_proplist_copy
+pa_proplist_copy.restype = POINTER(pa_proplist)
+pa_proplist_copy.argtypes = [POINTER(pa_proplist)]
+
+# /usr/include/pulse/proplist.h:407
+pa_proplist_size = _lib.pa_proplist_size
+pa_proplist_size.restype = c_uint
+pa_proplist_size.argtypes = [POINTER(pa_proplist)]
+
+# /usr/include/pulse/proplist.h:410
+pa_proplist_isempty = _lib.pa_proplist_isempty
+pa_proplist_isempty.restype = c_int
+pa_proplist_isempty.argtypes = [POINTER(pa_proplist)]
+
+# /usr/include/pulse/proplist.h:414
+pa_proplist_equal = _lib.pa_proplist_equal
+pa_proplist_equal.restype = c_int
+pa_proplist_equal.argtypes = [POINTER(pa_proplist), POINTER(pa_proplist)]
+
+# End of manually transferred pa_proplist definitions #
+
 pa_context_event_cb_t = CFUNCTYPE(None, POINTER(pa_context), c_char_p, POINTER(pa_proplist),
                                   POINTER(None))  # /usr/include/pulse/context.h:167
 # /usr/include/pulse/context.h:172
@@ -1204,15 +1265,6 @@ struct_pa_stream._fields_ = [
     ('_opaque_struct', c_int)
 ]
 
-
-class struct_pa_stream(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_stream._fields_ = [
-    ('_opaque_struct', c_int)
-]
 
 pa_stream = struct_pa_stream  # /usr/include/pulse/stream.h:335
 pa_stream_success_cb_t = CFUNCTYPE(None, POINTER(pa_stream), c_int, POINTER(None))  # /usr/include/pulse/stream.h:338
@@ -2500,15 +2552,6 @@ struct_pa_threaded_mainloop._fields_ = [
 ]
 
 
-class struct_pa_threaded_mainloop(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_threaded_mainloop._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_threaded_mainloop = struct_pa_threaded_mainloop  # /usr/include/pulse/thread-mainloop.h:246
 # /usr/include/pulse/thread-mainloop.h:251
 pa_threaded_mainloop_new = _lib.pa_threaded_mainloop_new
@@ -2586,15 +2629,6 @@ struct_pa_mainloop._fields_ = [
 ]
 
 
-class struct_pa_mainloop(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_mainloop._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_mainloop = struct_pa_mainloop  # /usr/include/pulse/mainloop.h:78
 # /usr/include/pulse/mainloop.h:81
 pa_mainloop_new = _lib.pa_mainloop_new
@@ -2662,15 +2696,6 @@ struct_pollfd._fields_ = [
 ]
 
 
-class struct_pollfd(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pollfd._fields_ = [
-    ('_opaque_struct', c_int)
-]
-
 pa_poll_func = CFUNCTYPE(c_int, POINTER(struct_pollfd), c_ulong, c_int,
                          POINTER(None))  # /usr/include/pulse/mainloop.h:124
 # /usr/include/pulse/mainloop.h:127
@@ -2688,15 +2713,6 @@ struct_pa_signal_event._fields_ = [
     ('_opaque_struct', c_int)
 ]
 
-
-class struct_pa_signal_event(Structure):
-    __slots__ = [
-    ]
-
-
-struct_pa_signal_event._fields_ = [
-    ('_opaque_struct', c_int)
-]
 
 pa_signal_event = struct_pa_signal_event  # /usr/include/pulse/mainloop-signal.h:39
 pa_signal_cb_t = CFUNCTYPE(None, POINTER(pa_mainloop_api), POINTER(pa_signal_event), c_int,
@@ -2928,7 +2944,18 @@ __all__ = ['pa_get_library_version', 'PA_API_VERSION', 'PA_PROTOCOL_VERSION',
            'pa_operation_notify_cb_t', 'pa_operation_ref', 'pa_operation_unref',
            'pa_operation_cancel', 'pa_operation_get_state',
            'pa_operation_set_state_callback', 'pa_context', 'pa_context_notify_cb_t',
-           'pa_context_success_cb_t', 'pa_context_event_cb_t', 'pa_context_new',
+           'pa_context_success_cb_t',
+           # Begin manually transferred proplist definitions #
+           'pa_proplist', 'pa_proplist_new', 'pa_proplist_free', 'pa_proplist_key_valid',
+           'pa_proplist_sets', 'pa_proplist_setp', 'pa_proplist_set', 'pa_proplist_gets',
+           'pa_proplist_get', 'pa_update_mode_t', 'PA_UPDATE_SET', 'PA_UPDATE_MERGE',
+           'PA_UPDATE_REPLACE', 'pa_proplist_update', 'pa_proplist_unset',
+           'pa_proplist_unset_many', 'pa_proplist_iterate', 'pa_proplist_to_string',
+           'pa_proplist_to_string_sep', 'pa_proplist_from_string',
+           'pa_proplist_contains', 'pa_proplist_clear', 'pa_proplist_copy',
+           'pa_proplist_size', 'pa_proplist_isempty', 'pa_proplist_equal',
+           # End manually transferred proplist definitions #
+           'pa_context_event_cb_t', 'pa_context_new',
            'pa_context_new_with_proplist', 'pa_context_unref', 'pa_context_ref',
            'pa_context_set_state_callback', 'pa_context_set_event_callback',
            'pa_context_errno', 'pa_context_is_pending', 'pa_context_get_state',

--- a/pyglet/media/drivers/silent/adaptation.py
+++ b/pyglet/media/drivers/silent/adaptation.py
@@ -1,26 +1,118 @@
-from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer
+from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer, MediaEvent
 from pyglet.media.drivers.listener import AbstractListener
+from pyglet.media.player_worker_thread import PlayerWorkerThread
+
+
+class SilentDriver(AbstractAudioDriver):
+    def __init__(self) -> None:
+        super().__init__()
+        self.worker = PlayerWorkerThread()
+        self.worker.start()
+
+    def create_audio_player(self, source, player):
+        return SilentAudioPlayer(self, source, player)
+
+    def get_listener(self):
+        return SilentListener()
+
+    def delete(self):
+        if self.worker is not None:
+            self.worker.stop()
+            self.worker = None
+
+
+class SilentListener(AbstractListener):
+
+    def _set_volume(self, volume):
+        pass
+
+    def _set_position(self, position):
+        pass
+
+    def _set_forward_orientation(self, orientation):
+        pass
+
+    def _set_up_orientation(self, orientation):
+        pass
+
+    def _set_orientation(self):
+        pass
 
 
 class SilentAudioPlayer(AbstractAudioPlayer):
+    def __init__(self, driver, source, player):
+        super().__init__(source, player)
+
+        self.driver = driver
+
+        self._pseudo_play_cursor = 0
+        self._pseudo_write_cursor = 0
+
+        self._exhausted = False
+        self._dispatched_on_eos = False
 
     def delete(self):
-        pass
+        if self.driver.worker is not None:
+            self.driver.worker.remove(self)
 
     def play(self):
-        pass
+        self.driver.worker.add(self)
 
     def stop(self):
-        pass
+        self.driver.worker.remove(self)
+
+    def prefill_audio(self):
+        self.work()
+
+    def _update_play_cursor(self):
+        corrected_time = self.player.time - self.player.last_seek_time
+        pc = self.source.audio_format.timestamp_to_bytes_aligned(corrected_time)
+        assert pc >= self._pseudo_play_cursor
+        self._pseudo_play_cursor = min(self._pseudo_write_cursor, pc)
+
+    def work(self):
+        self._update_play_cursor()
+        self.dispatch_media_events(self._pseudo_play_cursor)
+
+        if not self._exhausted:
+            remaining = max(0, self._pseudo_write_cursor - self._pseudo_play_cursor)
+            if remaining > self._buffered_data_comfortable_limit:
+                return
+
+            data = self._get_and_compensate_audio_data(
+                self.source.audio_format.align(self._singlebuffer_ideal_size - remaining),
+                self._pseudo_play_cursor)
+
+            if data is None:
+                self._exhausted = True
+                self._update_play_cursor()
+            else:
+                self.append_events(self._pseudo_write_cursor, data.events)
+
+                # The silent player always cheats itself to be 100% accurate, compensation is
+                # effectless and actually throws off audio syncing as well as accurate
+                # on_eos dispatching. Undo it here.
+                self._pseudo_write_cursor += data.length - self._compensated_bytes
+                self._compensated_bytes = 0
+                return
+
+        if (
+            self._pseudo_play_cursor >= self._pseudo_write_cursor and
+            self._exhausted and
+            not self._dispatched_on_eos
+        ):
+            self._dispatched_on_eos = True
+            MediaEvent('on_eos').sync_dispatch_to_player(self.player)
 
     def clear(self):
-        pass
+        super().clear()
+        self._pseudo_play_cursor = 0
+        self._pseudo_write_cursor = 0
+        self._exhausted = False
+        self._dispatched_on_eos = False
 
-    def write(self, audio_data, length):
-        pass
-
-    def get_time(self):
-        return 0
+    def get_play_cursor(self):
+        return self._pseudo_play_cursor
 
     def set_volume(self, volume):
         pass
@@ -47,37 +139,4 @@ class SilentAudioPlayer(AbstractAudioPlayer):
         pass
 
     def set_cone_outer_gain(self, cone_outer_gain):
-        pass
-
-    def prefill_audio(self):
-        pass
-
-
-class SilentDriver(AbstractAudioDriver):
-
-    def create_audio_player(self, source, player):
-        return SilentAudioPlayer(source, player)
-
-    def get_listener(self):
-        return SilentListener()
-
-    def delete(self):
-        pass
-
-
-class SilentListener(AbstractListener):
-
-    def _set_volume(self, volume):
-        pass
-
-    def _set_position(self, position):
-        pass
-
-    def _set_forward_orientation(self, orientation):
-        pass
-
-    def _set_up_orientation(self, orientation):
-        pass
-
-    def _set_orientation(self):
         pass

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -1,45 +1,99 @@
+from collections import deque
+from enum import IntEnum
 import math
+import threading
+from typing import Deque, Tuple, TYPE_CHECKING
 
-import pyglet
 from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer, MediaEvent
+from pyglet.media.player_worker_thread import PlayerWorkerThread
 from pyglet.media.drivers.listener import AbstractListener
 from pyglet.util import debug_print
 from . import interface
 
+if TYPE_CHECKING:
+    from pyglet.media.codecs import AudioData, AudioFormat, Source
+    from pyglet.media.player import Player
+
+
 _debug = debug_print('debug_media')
 
 
-def _convert_coordinates(coordinates):
+def _convert_coordinates(coordinates: Tuple[float, float, float]) -> Tuple[float, float, float]:
     x, y, z = coordinates
     return x, y, -z
 
 
+class XAudio2Driver(AbstractAudioDriver):
+    def __init__(self) -> None:
+        self._xa2_driver = interface.XAudio2Driver()
+        self._xa2_listener = self._xa2_driver.create_listener()
+        self._listener = XAudio2Listener(self._xa2_listener, self._xa2_driver)
+
+        self.worker = PlayerWorkerThread()
+        self.worker.start()
+
+    def get_performance(self) -> interface.lib.XAUDIO2_PERFORMANCE_DATA:
+        assert self._xa2_driver is not None
+        return self._xa2_driver.get_performance()
+
+    def create_audio_player(self, source: 'Source', player: 'Player') -> 'XAudio2AudioPlayer':
+        assert self._xa2_driver is not None
+        return XAudio2AudioPlayer(self, source, player)
+
+    def get_listener(self) -> 'XAudio2Listener':
+        return self._listener
+
+    def delete(self) -> None:
+        if self._xa2_driver is not None:
+            self.worker.stop()
+            self.worker = None
+            self._xa2_driver._delete_driver()
+            self._xa2_driver = None
+            self._xa2_listener = None
+
+
+class XAudio2Listener(AbstractListener):
+    def __init__(self, xa2_listener, xa2_driver) -> None:
+        self._xa2_listener = xa2_listener
+        self._xa2_driver = xa2_driver
+
+    def _set_volume(self, volume: float) -> None:
+        self._volume = volume
+        self._xa2_driver.volume = volume
+
+    def _set_position(self, position: Tuple[float, float, float]) -> None:
+        self._position = position
+        self._xa2_listener.position = _convert_coordinates(position)
+
+    def _set_forward_orientation(self, orientation: Tuple[float, float, float]) -> None:
+        self._forward_orientation = orientation
+        self._set_orientation()
+
+    def _set_up_orientation(self, orientation: Tuple[float, float, float]) -> None:
+        self._up_orientation = orientation
+        self._set_orientation()
+
+    def _set_orientation(self) -> None:
+        self._xa2_listener.orientation = (
+            _convert_coordinates(self._forward_orientation) +
+            _convert_coordinates(self._up_orientation))
+
+
 class XAudio2AudioPlayer(AbstractAudioPlayer):
-    # Need to cache these because pyglet API allows update separately, but
-    # DSound requires both to be set at once.
-    _cone_inner_angle = 360
-    _cone_outer_angle = 360
-
-    min_buffer_size = 9600
-
-    max_buffer_count = 3  # Max in queue at once, increasing may impact performance depending on buffer size.
-
-    def __init__(self, driver, xa2_driver, source, player):
-        super(XAudio2AudioPlayer, self).__init__(source, player)
+    def __init__(self, driver: 'XAudio2Driver', source: 'Source', player: 'Player') -> None:
+        super().__init__(source, player)
         # We keep here a strong reference because the AudioDriver is anyway
         # a singleton object which will only be deleted when the application
         # shuts down. The AudioDriver does not keep a ref to the AudioPlayer.
         self.driver = driver
-        self._xa2_driver = xa2_driver
 
-        # If cleared, we need to check when it's done clearing.
-        self._flushing = False
+        # Need to cache these because pyglet API allows update separately, but
+        # XAudio2 requires both to be set at once.
+        self._cone_inner_angle = 360
+        self._cone_outer_angle = 360
 
-        # If deleted, we need to make sure it's done deleting.
-        self._deleted = False
-
-        # Desired play state (may be actually paused due to underrun -- not
-        # implemented yet).
+        # Desired play state. (`True` doesn't necessarily mean the player is playing.
+        # It may be silent due to either underrun or because a flush is in progress.)
         self._playing = False
 
         # Theoretical write and play cursors for an infinite buffer.  play
@@ -48,302 +102,199 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
         self._write_cursor = 0
         self._play_cursor = 0
 
-        # List of (play_cursor, MediaEvent), in sort order
-        self._events = []
+        self._audio_data_in_use: Deque['AudioData'] = deque()
+        self._pyglet_source_exhausted = False
 
-        # List of (cursor, timestamp), in sort order (cursor gives expiry
-        # place of the timestamp)
-        self._timestamps = []
+        # A lock to be held whenever modifying things relating to the in-use audio data.
+        # Ensures that the XAudio2 callbacks will not interfere with the
+        # player operations.
+        self._audio_data_lock = threading.Lock()
 
-        # This will be True if the last buffer has already been submitted.
-        self.buffer_end_submitted = False
+        self._xa2_source_voice = self.driver._xa2_driver.get_source_voice(source.audio_format, self)
 
-        self._buffers = []  # Current buffers in queue waiting to be played.
-
-        self._xa2_source_voice = self._xa2_driver.get_source_voice(source, self)
-
-        self._buffer_size = int(source.audio_format.sample_rate * 2)
-
-    def on_driver_destroy(self):
+    def on_driver_destroy(self) -> None:
         self.stop()
         self._xa2_source_voice = None
 
-    def on_driver_reset(self):
-        self._xa2_source_voice = self._xa2_driver.get_source_voice(self.source, self)
+    def on_driver_reset(self) -> None:
+        self._xa2_source_voice = self.driver._xa2_driver.get_source_voice(self.source.audio_format, self)
 
-        # Queue up any buffers that are still in queue but weren't deleted. This does not pickup where the last sample
-        # played, only where the last buffer was submitted. As such it's possible for audio to be replayed if buffer is
-        # large enough.
-        for cx2_buffer in self._buffers:
-            self._xa2_source_voice.submit_buffer(cx2_buffer)
+        # Queue up any buffers that are still in queue but weren't deleted. This does not
+        # pickup where the last sample played, only where the last buffer was submitted.
+        # As such, audio will be replayed.
+        # TODO: Make best effort by using XAUDIO2_BUFFER.PlayBegin in conjunction
+        # with last playback sample
+        for audio_data in self._audio_data_in_use:
+            xa2_buffer = interface.create_xa2_buffer(audio_data)
+            self._xa2_source_voice.submit_buffer(xa2_buffer)
 
-    def __del__(self):
-        if self._xa2_source_voice:
+    def delete(self) -> None:
+        if self.driver._xa2_driver is None:
+            assert _debug("Xaudio2: Player deleted, driver is gone")
+            # Driver was deleted, voice is gone; just break up some references and return
+            self.driver = None
             self._xa2_source_voice = None
+            self._audio_data_in_use.clear()
+            return
 
-    def delete(self):
-        """Called from Player. Docs says to cleanup resources, but other drivers wait for GC to do it?"""
-        if self._xa2_source_voice:
-            self._deleted = True
+        assert _debug("XAudio2: Player deleted, returning voice")
 
-            if not self._buffers:
-                self._xa2_driver.return_voice(self._xa2_source_voice)
+        self.stop()
+        self.driver._xa2_driver.return_voice(self._xa2_source_voice, self._audio_data_in_use)
+        self.driver = None
+        self._xa2_source_voice = None
 
-    def play(self):
-        assert _debug('XAudio2 play')
+    def play(self) -> None:
+        assert _debug(f'XAudio2 play: {self._playing=}')
 
         if not self._playing:
             self._playing = True
-            if not self._flushing:
-                self._xa2_source_voice.play()
+            self._xa2_source_voice.play()
+            self.driver.worker.add(self)
 
         assert _debug('return XAudio2 play')
 
-    def stop(self):
+    def stop(self) -> None:
         assert _debug('XAudio2 stop')
 
         if self._playing:
+            self.driver.worker.remove(self)
+            # no callback could possibly be running after this lock is released.
+            with self.driver._xa2_driver.lock:
+                self._xa2_source_voice.stop()
             self._playing = False
-            self.buffer_end_submitted = False
-            self._xa2_source_voice.stop()
 
         assert _debug('return XAudio2 stop')
 
-    def clear(self):
+    def clear(self) -> None:
         assert _debug('XAudio2 clear')
-        super(XAudio2AudioPlayer, self).clear()
+        super().clear()
         self._play_cursor = 0
         self._write_cursor = 0
-        self.buffer_end_submitted = False
-        self._deleted = False
+        self._pyglet_source_exhausted = False
+        self.driver._xa2_driver.return_voice(self._xa2_source_voice, self._audio_data_in_use)
+        self._audio_data_in_use = deque()
+        self._xa2_source_voice = self.driver._xa2_driver.get_source_voice(self.source.audio_format, self)
 
-        if self._buffers:
-            self._flushing = True
+    def on_buffer_end(self, buffer_context_ptr: int) -> None:
+        # Called from the XAudio2 thread.
+        # A buffer stopped being played by the voice, it should by all means be the first one
+        with self._audio_data_lock:
+            assert self._audio_data_in_use
+            self._audio_data_in_use.popleft()
+            # This should cause the AudioData to lose all its references and be gc'd
 
-        self._xa2_source_voice.flush()
-        self._buffers.clear()
-        del self._events[:]
-        del self._timestamps[:]
+            if self._audio_data_in_use:
+                assert _debug(f"Buffer ended, others remain: {len(self._audio_data_in_use)=}")
+                return
 
-    def _restart(self, dt):
-        """Prefill audio and attempt to replay audio."""
-        if self._playing and self._xa2_source_voice:
-            self.refill_source_player()
-            self._xa2_source_voice.play()
+            assert self._xa2_source_voice.buffers_queued == 0
 
-    def refill_source_player(self):
-        """Obtains audio data from the source, puts it into a buffer to submit to the voice.
-        Unlike the other drivers this does not carve pieces of audio from the buffer and slowly
-        consume it. This submits the buffer retrieved from the decoder in it's entirety.
+            # Last buffer ran out naturally, out of AudioData; voice will now fall silent
+            if self._pyglet_source_exhausted:
+                assert _debug("Last buffer ended normally, dispatching eos")
+                MediaEvent('on_eos').sync_dispatch_to_player(self.player)
+            else:
+                assert _debug("Last buffer ended normally, source is lagging behind")
+                # Shouldn't have ran out; supplier is running behind
+                # All we can do is wait; as long as voices are not stopped via `Stop`, they will
+                # immediately continue playing the new buffer once it arrives
+                pass
+
+    def _refill(self, refill_size: int) -> None:
+        """Get one piece of AudioData and submit it to the voice.
+        This method will release the lock around the call to `get_audio_data`,
+        so make sure it's held upon calling.
         """
-        if not self._xa2_source_voice:
+        assert _debug(f"XAudio2: Retrieving new buffer of {refill_size}B")
+
+        self._audio_data_lock.release()
+        audio_data = self._get_and_compensate_audio_data(refill_size, self._play_cursor)
+        self._audio_data_lock.acquire()
+
+        if audio_data is None:
+            assert _debug(f"XAudio2: Source is out of data")
+            self._pyglet_source_exhausted = True
+            if not self._audio_data_in_use:
+                MediaEvent('on_eos').sync_dispatch_to_player(self.player)
             return
 
-        buffers_queued = self._xa2_source_voice.buffers_queued
+        xa2_buffer = interface.create_xa2_buffer(audio_data)
+        self._audio_data_in_use.append(audio_data)
+        self._xa2_source_voice.submit_buffer(xa2_buffer)
+        assert _debug(f"XAudio2: Submitted buffer of size {audio_data.length}B")
 
-        # Free any buffers that have ended.
-        while len(self._buffers) > buffers_queued:
-            # Clean out any buffers that have played.
-            buffer = self._buffers.pop(0)
-            self._play_cursor += buffer.AudioBytes
-            del buffer  # Does this remove AudioData within the buffer? Let GC remove or explicit remove?
+        self.append_events(self._write_cursor, audio_data.events)
+        self._write_cursor += audio_data.length
 
-        # We have to wait for all of the buffers we are flushing to end before we restart next buffer.
-        # When voice reaches 0 buffers, it is available for re-use.
-        if self._flushing:
-            if buffers_queued == 0:
-                self._flushing = False
+    def _update_play_cursor(self) -> None:
+        self._play_cursor = (
+            self._xa2_source_voice.samples_played * self.source.audio_format.bytes_per_frame
+        )
 
-                # This is required because the next call to play will come before all flushes are done.
-                # Restart at next available opportunity.
-                pyglet.clock.schedule_once(self._restart, 0)
-            return
+    def get_play_cursor(self) -> int:
+        return self._play_cursor
 
-        if self._deleted:
-            if buffers_queued == 0:
-                self._deleted = False
-                self._xa2_driver.return_voice(self._xa2_source_voice)
-            return
+    def work(self) -> None:
+        with self._audio_data_lock:
+            self._update_play_cursor()
+            self.dispatch_media_events(self._play_cursor)
+            self._maybe_refill()
 
-        # Wait for the playback to hit 0 buffers before we eos.
-        if self.buffer_end_submitted:
-            if buffers_queued == 0:
-                self._xa2_source_voice.stop()
-                MediaEvent("on_eos").sync_dispatch_to_player(self.player)
-        else:
-            current_buffers = []
-            while buffers_queued < self.max_buffer_count:
-                audio_data = self.source.get_audio_data(self._buffer_size, 0.0)
-                if audio_data:
-                    assert _debug(
-                        'Xaudio2: audio data - length: {}, duration: {}, buffer size: {}'.format(audio_data.length,
-                                                                                                 audio_data.duration,
-                                                                                                 self._buffer_size))
+    def _maybe_refill(self) -> bool:
+        if self._pyglet_source_exhausted:
+            return False
 
-                    if audio_data.length == 0:  # Sometimes audio data has 0 length at the front?
-                        continue
+        remaining_bytes = self._write_cursor - self._play_cursor
+        if remaining_bytes >= self._buffered_data_comfortable_limit:
+            return False
 
-                    x2_buffer = self._xa2_driver.create_buffer(audio_data)
+        missing_bytes = self._singlebuffer_ideal_size - remaining_bytes
+        self._refill(self.source.audio_format.align_ceil(missing_bytes))
+        return True
 
-                    current_buffers.append(x2_buffer)
+    def prefill_audio(self) -> None:
+        with self._audio_data_lock:
+            self._maybe_refill()
 
-                    self._write_cursor += x2_buffer.AudioBytes  # We've pushed this many bytes into the source player.
-
-                    self._add_audiodata_events(audio_data)
-                    self._add_audiodata_timestamp(audio_data)
-
-                    buffers_queued += 1
-                else:
-                    # End of audio data, set last packet as end.
-                    self.buffer_end_submitted = True
-                    break
-
-            # We submit the buffers here, just in-case the end of stream was found.
-            for cx2_buffer in current_buffers:
-                self._xa2_source_voice.submit_buffer(cx2_buffer)
-
-            # Store buffers temporarily, otherwise they get GC'd.
-            self._buffers.extend(current_buffers)
-
-        self._dispatch_pending_events()
-
-    def _dispatch_new_event(self, event_name):
-        MediaEvent(event_name).sync_dispatch_to_player(self.player)
-
-    def _add_audiodata_events(self, audio_data):
-        for event in audio_data.events:
-            event_cursor = self._write_cursor + event.timestamp * self.source.audio_format.bytes_per_second
-            assert _debug(f'Adding event {event} at {event_cursor}')
-            self._events.append((event_cursor, event))
-
-    def _add_audiodata_timestamp(self, audio_data):
-        ts_cursor = self._write_cursor + audio_data.length
-        self._timestamps.append(
-            (ts_cursor, audio_data.timestamp + audio_data.duration))
-
-    def _dispatch_pending_events(self):
-        pending_events = []
-        while self._events and self._events[0][0] <= self._play_cursor:
-            _, event = self._events.pop(0)
-            pending_events.append(event)
-
-        assert _debug('Dispatching pending events: {}'.format(pending_events))
-        assert _debug('Remaining events: {}'.format(self._events))
-
-        for event in pending_events:
-            event.sync_dispatch_to_player(self.player)
-
-    def _cleanup_timestamps(self):
-        while self._timestamps and self._timestamps[0][0] < self._play_cursor:
-            del self._timestamps[0]
-
-    def get_time(self):
-        self.update_play_cursor()
-        if self._timestamps:
-            cursor, ts = self._timestamps[0]
-            result = ts + (self._play_cursor - cursor) / float(self.source.audio_format.bytes_per_second)
-        else:
-            result = None
-
-        return result
-
-    def set_volume(self, volume):
+    def set_volume(self, volume: float) -> None:
         self._xa2_source_voice.volume = volume
 
-    def set_position(self, position):
+    def set_position(self, position: Tuple[float, float, float]) -> None:
         if self._xa2_source_voice.is_emitter:
             self._xa2_source_voice.position = _convert_coordinates(position)
 
-    def set_min_distance(self, min_distance):
+    def set_min_distance(self, min_distance: float) -> None:
         """Not a true min distance, but similar effect. Changes CurveDistanceScaler default is 1."""
         if self._xa2_source_voice.is_emitter:
             self._xa2_source_voice.distance_scaler = min_distance
 
-    def set_max_distance(self, max_distance):
+    def set_max_distance(self, max_distance: float) -> None:
         """No such thing built into xaudio2"""
         return
 
-    def set_pitch(self, pitch):
+    def set_pitch(self, pitch: float) -> None:
         self._xa2_source_voice.frequency = pitch
 
-    def set_cone_orientation(self, cone_orientation):
+    def set_cone_orientation(self, cone_orientation: Tuple[float, float, float]) -> None:
         if self._xa2_source_voice.is_emitter:
             self._xa2_source_voice.cone_orientation = _convert_coordinates(cone_orientation)
 
-    def set_cone_inner_angle(self, cone_inner_angle):
+    def set_cone_inner_angle(self, cone_inner_angle: float) -> None:
         if self._xa2_source_voice.is_emitter:
             self._cone_inner_angle = int(cone_inner_angle)
             self._set_cone_angles()
 
-    def set_cone_outer_angle(self, cone_outer_angle):
+    def set_cone_outer_angle(self, cone_outer_angle: float) -> None:
         if self._xa2_source_voice.is_emitter:
             self._cone_outer_angle = int(cone_outer_angle)
             self._set_cone_angles()
 
-    def _set_cone_angles(self):
+    def _set_cone_angles(self) -> None:
         inner = min(self._cone_inner_angle, self._cone_outer_angle)
         outer = max(self._cone_inner_angle, self._cone_outer_angle)
         self._xa2_source_voice.set_cone_angles(math.radians(inner), math.radians(outer))
 
-    def set_cone_outer_gain(self, cone_outer_gain):
+    def set_cone_outer_gain(self, cone_outer_gain: float) -> None:
         if self._xa2_source_voice.is_emitter:
             self._xa2_source_voice.cone_outside_volume = cone_outer_gain
-
-    def prefill_audio(self):
-        # Cannot refill during a flush. Schedule will handle it.
-        if not self._flushing:
-            self.refill_source_player()
-
-
-class XAudio2Driver(AbstractAudioDriver):
-    def __init__(self):
-        self._xa2_driver = interface.XAudio2Driver()
-        self._xa2_listener = self._xa2_driver.create_listener()
-
-        assert self._xa2_driver is not None
-        assert self._xa2_listener is not None
-
-    def __del__(self):
-        self.delete()
-
-    def get_performance(self):
-        assert self._xa2_driver is not None
-        return self._xa2_driver.get_performance()
-
-    def create_audio_player(self, source, player):
-        assert self._xa2_driver is not None
-        return XAudio2AudioPlayer(self, self._xa2_driver, source, player)
-
-    def get_listener(self):
-        assert self._xa2_driver is not None
-        assert self._xa2_listener is not None
-        return XAudio2Listener(self._xa2_listener, self._xa2_driver)
-
-    def delete(self):
-        self._xa2_listener = None
-
-
-class XAudio2Listener(AbstractListener):
-    def __init__(self, xa2_listener, xa2_driver):
-        self._xa2_listener = xa2_listener
-        self._xa2_driver = xa2_driver
-
-    def _set_volume(self, volume):
-        self._volume = volume
-        self._xa2_driver.volume = volume
-
-    def _set_position(self, position):
-        self._position = position
-        self._xa2_listener.position = _convert_coordinates(position)
-
-    def _set_forward_orientation(self, orientation):
-        self._forward_orientation = orientation
-        self._set_orientation()
-
-    def _set_up_orientation(self, orientation):
-        self._up_orientation = orientation
-        self._set_orientation()
-
-    def _set_orientation(self):
-        self._xa2_listener.orientation = _convert_coordinates(self._forward_orientation) + _convert_coordinates(
-            self._up_orientation)

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -189,16 +189,15 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
 
             assert self._xa2_source_voice.buffers_queued == 0
 
-            # Last buffer ran out naturally, out of AudioData; voice will now fall silent
             if self._pyglet_source_exhausted:
+                # Last buffer ran out naturally, out of AudioData; voice will now fall silent
                 assert _debug("Last buffer ended normally, dispatching eos")
                 MediaEvent('on_eos').sync_dispatch_to_player(self.player)
             else:
-                assert _debug("Last buffer ended normally, source is lagging behind")
                 # Shouldn't have ran out; supplier is running behind
                 # All we can do is wait; as long as voices are not stopped via `Stop`, they will
                 # immediately continue playing the new buffer once it arrives
-                pass
+                assert _debug("Last buffer ended normally, source is lagging behind")
 
     def _refill(self, refill_size: int) -> None:
         """Get one piece of AudioData and submit it to the voice.

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -226,8 +226,10 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
         self._write_cursor += audio_data.length
 
     def _update_play_cursor(self) -> None:
+        voice = self._xa2_source_voice
         self._play_cursor = (
-            self._xa2_source_voice.samples_played * self.source.audio_format.bytes_per_frame
+            (voice.samples_played - voice.samples_played_at_last_recycle) *
+            self.source.audio_format.bytes_per_frame
         )
 
     def get_play_cursor(self) -> int:

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -1,5 +1,4 @@
 from collections import deque
-from enum import IntEnum
 import math
 import threading
 from typing import Deque, Tuple, TYPE_CHECKING

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -1,5 +1,6 @@
-import weakref
 from collections import namedtuple, defaultdict
+import threading
+import weakref
 
 from pyglet.media.devices.base import DeviceFlow
 
@@ -10,6 +11,128 @@ from pyglet.media.devices import get_audio_device_manager
 from . import lib_xaudio2 as lib
 
 _debug = debug_print('debug_media')
+
+
+def create_xa2_buffer(audio_data):
+    """Creates a XAUDIO2_BUFFER to be used with a source voice.
+        Audio data cannot be purged until the source voice has played it; doing so will cause glitches."""
+    buff = lib.XAUDIO2_BUFFER()
+    buff.AudioBytes = audio_data.length
+    buff.pAudioData = ctypes.cast(audio_data.pointer, ctypes.POINTER(ctypes.c_char))
+    return buff
+
+
+def create_xa2_waveformat(audio_format):
+    wfx = lib.WAVEFORMATEX()
+    wfx.wFormatTag = lib.WAVE_FORMAT_PCM
+    wfx.nChannels = audio_format.channels
+    wfx.nSamplesPerSec = audio_format.sample_rate
+    wfx.wBitsPerSample = audio_format.sample_size
+    wfx.nBlockAlign = wfx.wBitsPerSample * wfx.nChannels // 8
+    wfx.nAvgBytesPerSec = wfx.nSamplesPerSec * wfx.nBlockAlign
+    return wfx
+
+
+class _VoiceResetter:
+    """Manage a voice during its reset period.
+    This process is convoluted, but the only thing capable of resetting a
+    voice's reported `SamplesPlayed` to zero.
+    """
+
+    def __init__(self, driver, voice, voice_key, remaining_data) -> None:
+        self.driver = driver
+        self.voice = voice
+        self.voice_key = voice_key
+        l, p = driver._get_silence_frame(voice)
+        self.silence_len = l
+        self.silence_ptr = p
+        self.remaining_data = remaining_data
+
+    def run(self):
+        if self.voice.buffers_queued != 0:
+            self.voice._callback.on_buffer_end = self.flush_on_buffer_end
+            self.voice.flush()
+        else:
+            self._initiate_reset()
+
+    def destroy(self):
+        pyglet.clock.unschedule(self._initiate_reset)
+        self.driver = None
+        self.voice = None
+        self.remaining_data.clear()
+
+    def _initiate_reset(self, *_):
+        self.voice._callback.on_buffer_end = self.reset_on_buffer_end
+
+        buff = lib.XAUDIO2_BUFFER()
+        buff.Flags = lib.XAUDIO2_END_OF_STREAM
+        buff.AudioBytes = self.silence_len
+        buff.pAudioData = ctypes.cast(self.silence_ptr, ctypes.POINTER(ctypes.c_char))
+
+        self.voice.play()
+        self.voice.submit_buffer(buff)
+
+    def flush_on_buffer_end(self, *_):
+        if self.voice.buffers_queued == 0:
+            self.remaining_data.clear()
+
+            # Unfortunately we need to schedule this as things go sideways when submitting more
+            # buffers inside of an on_buffer_end call issued through flush
+            pyglet.clock.schedule_once(self._initiate_reset, 0)
+
+    def reset_on_buffer_end(self, *_):
+        # This feels risky.
+        # SamplesPlayed is not 0 at this point; though that typically has changed by itself
+        # as soon as the voice is circled back into use.
+
+        self.voice._callback.on_buffer_end = None
+        self.voice.stop()
+        self.driver._return_reset_voice(self.voice, self.voice_key)
+
+
+class XA2EngineCallback(com.COMObject):
+    _interfaces_ = [lib.IXAudio2EngineCallback]
+
+    def __init__(self, lock):
+        self._lock = lock
+
+    def OnProcessingPassStart(self):
+        self._lock.acquire()
+
+    def OnProcessingPassEnd(self):
+        self._lock.release()
+
+    def OnCriticalError(self, hresult):
+        # This is a textbook bad example, yes.
+        # It's probably safe though: assuming that XA2 has ceased to operate if we ever end up
+        # here, nothing can release the lock inbetween.
+        if self._lock.locked():
+            self._lock.release()
+        raise Exception("Critical Error:", hresult)
+
+
+class XAudio2VoiceCallback(com.COMObject):
+    """Callback class used to trigger when buffers or streams end.
+           WARNING: Whenever a callback is running, XAudio2 cannot generate audio.
+           Make sure these functions run as fast as possible and do not block/delay more than a few milliseconds.
+           MS Recommendation:
+           At a minimum, callback functions must not do the following:
+                - Access the hard disk or other permanent storage
+                - Make expensive or blocking API calls
+                - Synchronize with other parts of client code
+                - Require significant CPU usage
+    """
+    _interfaces_ = [lib.IXAudio2VoiceCallback]
+
+    def __init__(self):
+        super().__init__()
+        self.on_buffer_end = None
+
+    def OnBufferEnd(self, pBufferContext):
+        self.on_buffer_end(pBufferContext)
+
+    def OnVoiceError(self, pBufferContext, hresult):
+        raise Exception(f"Error occurred during audio playback: {hresult}")
 
 
 class XAudio2Driver:
@@ -38,11 +161,26 @@ class XAudio2Driver:
         self._xaudio2 = None
         self._dead = False
 
+        self.lock = threading.Lock()
+        # A lock that will prevent XAudio2 from running any callbacks (processing audio at all)
+        # while it is held. Must be acquired by audio players in certain situations in order to
+        # ensure that the following, very unlikely, sequence of events does not happen:
+        # - an on_buffer_end callback is made
+        # - this causes python to create a dummy thread to run its code
+        # - very early on, before it could acquire any protective locks, the thread is deactivated
+        #   and the main thread runs
+        # - the main thread runs a critical operation on the player such as `delete` to completion
+        # - the callback is resumed and breaks as the audio player is deleted.
+        self._engine_callback = XA2EngineCallback(self._lock)
+
         self._emitting_voices = []  # Contains all of the emitting source voices.
         self._voice_pool = defaultdict(list)
-        self._in_use = []  # All voices currently in use.
+        self._in_use = {}  # All voices currently in use, mapped to their audio player.
 
-        self._players = []  # Only used for resetting/restoring xaudio2. Store players to callback.
+        self._resetting_voices = {}  # All resetting voices, mapped to their resetter.
+        self._silence = {}  # Map audio formats to silence for voice resetting ritual
+
+        self._players = []  # Used for resetting/restoring xaudio2. Stores high-level players to callback.
 
         self._create_xa2()
 
@@ -101,6 +239,8 @@ class XAudio2Driver:
 
             self._xaudio2.SetDebugConfiguration(ctypes.byref(debug), None)
 
+        self._xaudio2.RegisterForCallbacks(self._engine_callback)
+
         self._master_voice = lib.IXAudio2MasteringVoice()
         self._xaudio2.CreateMasteringVoice(byref(self._master_voice),
                                            lib.XAUDIO2_DEFAULT_CHANNELS,
@@ -112,30 +252,22 @@ class XAudio2Driver:
 
     @property
     def active_voices(self):
-        return self._in_use
+        return self._in_use.keys()
 
-    @property
-    def pooled_voices(self):
-        return [voice for voices in self._voice_pool.values() for voice in voices]
+    def _destroy_voices(self):
+        """Destroy and clear all voice pools."""
+        for list_ in self._voice_pool.values():
+            for voice in list_:
+                voice.destroy()
+            list_.clear()
 
-    @property
-    def all_voices(self):
-        """All pooled and active voices."""
-        return self.active_voices + self.all_voices
-
-    def clear_pool(self):
-        """Destroy and then clear the pool of voices"""
-        for voice in self.pooled_voices:
+        for voice, resetter in self._resetting_voices.items():
             voice.destroy()
+            resetter.destroy()
+        self._resetting_voices.clear()
 
-        for voice_key in self._voice_pool:
-            self._voice_pool[voice_key].clear()
-
-    def clear_active(self):
-        """Destroy and then clear all active voices"""
-        for voice in self._in_use:
+        for voice in self.active_voices:
             voice.destroy()
-
         self._in_use.clear()
 
     def set_device(self, device):
@@ -143,7 +275,7 @@ class XAudio2Driver:
         self._shutdown_xaudio2()
         self._create_xa2(device.id)
 
-        # Notify all active players it's reset..
+        # Notify all active players it's reset.
         for player in self._players:
             player.dispatch_event('on_driver_reset')
 
@@ -151,22 +283,23 @@ class XAudio2Driver:
 
     def _shutdown_xaudio2(self):
         """Stops and destroys all active voices, then destroys XA2 instance."""
-        for voice in self.active_voices:
-            voice.player.on_driver_destroy()
-            self._players.append(voice.player.player)
+        for player in self._in_use.values():
+            player.on_driver_destroy()
+            self._players.append(player.player)
 
         self._delete_driver()
 
     def _delete_driver(self):
         if self._xaudio2:
+            assert _debug("XAudio2Driver: Deleting")
             # Stop 3d
             if self.allow_3d:
                 pyglet.clock.unschedule(self._calculate_3d_sources)
 
             # Destroy all pooled voices as master will change.
-            self.clear_pool()
-            self.clear_active()
+            self._destroy_voices()
 
+            self._xaudio2.UnregisterForCallbacks(self._engine_callback)
             self._xaudio2.StopEngine()
             self._xaudio2.Release()
             self._xaudio2 = None
@@ -206,7 +339,7 @@ class XAudio2Driver:
         for source_voice in self._emitting_voices:
             self.apply3d(source_voice)
 
-        self._xaudio2.CommitChanges(0)
+        # self._xaudio2.CommitChanges(0)
 
     def _calculate3d(self, listener, emitter):
         lib.X3DAudioCalculate(
@@ -214,7 +347,7 @@ class XAudio2Driver:
             listener,
             emitter,
             lib.default_dsp_calculation,
-            self._dsp_settings
+            self._dsp_settings,
         )
 
     def _apply3d(self, voice, commit):
@@ -233,13 +366,9 @@ class XAudio2Driver:
         self._calculate3d(self._listener.listener, source_voice._emitter)
         self._apply3d(source_voice._voice, commit)
 
-    def __del__(self):
-        try:
-            self._delete_driver()
-            pyglet.clock.unschedule(self._check_state)
-        except AttributeError:
-            # Usually gets unloaded by default on app exit, but be safe.
-            pass
+    def delete(self):
+        self._delete_driver()
+        pyglet.clock.unschedule(self._check_state)
 
     def get_performance(self):
         """Retrieve some basic XAudio2 performance data such as memory usage and source counts."""
@@ -252,93 +381,111 @@ class XAudio2Driver:
         self._listener = XAudio2Listener(self)
         return self._listener
 
-    def get_source_voice(self, source, player):
-        """ Get a source voice from the pool. Source voice creation can be slow to create/destroy. So pooling is
-            recommended. We pool based on audio channels as channels must be the same as well as frequency.
-            Source voice handles all of the audio playing and state for a single source."""
-        voice_key = (source.audio_format.channels, source.audio_format.sample_size, source.audio_format.sample_rate)
-        if len(self._voice_pool[voice_key]) > 0:
-            source_voice = self._voice_pool[voice_key].pop(0)
-            source_voice.acquired(player)
+    def return_voice(self, voice, remaining_data):
+        """Reset a voice and eventually return it to the pool. The voice must be stopped.
+        `remaining_data` should contain the data this voice's remaining
+        buffers point to.
+        It will be `.clear()`ed shortly after as soon as the flush initiated
+        by the driver completes in order to not have theoretical dangling
+        pointers.
+        """
+        if voice.is_emitter:
+            self._emitting_voices.remove(voice)
+
+        self._in_use.pop(voice)
+
+        assert _debug(f"XA2AudioDriver: Resetting {voice}...")
+        voice_key = (voice.channel_count, voice.sample_size)
+        resetter = _VoiceResetter(self, voice, voice_key, remaining_data)
+        self._resetting_voices[voice] = resetter
+        resetter.run()
+
+    def _return_reset_voice(self, voice, voice_key):
+        self._resetting_voices.pop(voice).destroy()
+        self._voice_pool[voice_key].append(voice)
+        assert _debug(f"XA2AudioDriver: {voice} back in pool")
+
+    def get_source_voice(self, audio_format, player):
+        """Get a source voice from the pool. Source voice creation can be slow to create/destroy.
+        So pooling is recommended. We pool based on audio channels.
+        A source voice handles all of the audio playing and state for a single source."""
+
+        voice_key = (audio_format.channels, audio_format.sample_size)
+        if not self._voice_pool[voice_key]:
+            voice = self._create_new_voice(audio_format)
+            # Create a 2nd one for good measure, multiple players might be needing it soon,
+            # and a clear command will probably complete more quickly when swapping out for a
+            # pooled voice
+            self._voice_pool[voice_key].append(self._create_new_voice(audio_format))
         else:
-            source_voice = self._get_voice(source, player)
+            voice = self._voice_pool[voice_key].pop()
 
-        if source_voice.is_emitter:
-            self._emitting_voices.append(source_voice)
+        assert voice.buffers_queued == 0
+        assert voice.samples_played == 0
 
-        self._in_use.append(source_voice)
-        return source_voice
+        voice.acquired(player.on_buffer_end, audio_format.sample_rate)
+        if voice.is_emitter:
+            self._emitting_voices.append(voice)
 
-    def _create_new_voice(self, source, player):
-        """Has the driver create a new source voice for the source."""
+        self._in_use[voice] = player
+
+        return voice
+
+    def _create_new_voice(self, audio_format):
+        """Has the driver create a new source voice for the given audio format."""
         voice = lib.IXAudio2SourceVoice()
 
-        wfx_format = self.create_wave_format(source.audio_format)
+        wfx_format = create_xa2_waveformat(audio_format)
 
-        callback = lib.XA2SourceCallback(player)
+        callback = lib.XAudio2VoiceCallback()
         self._xaudio2.CreateSourceVoice(ctypes.byref(voice),
                                         ctypes.byref(wfx_format),
                                         0,
                                         self.max_frequency_ratio,
                                         callback,
-                                        None, None)
-        return voice, callback
+                                        None,
+                                        None)
+        return XA2SourceVoice(voice, callback, audio_format.channels, audio_format.sample_size)
 
-    def _get_voice(self, source, player):
-        """Creates a new source voice and puts it into XA2SourceVoice high level wrap."""
-        voice, callback = self._create_new_voice(source, player)
-        return XA2SourceVoice(voice, callback, source.audio_format)
+    def _get_silence_frame(self, voice):
+        """Return the length of a single audio frame of silence and a pointer
+        to the frame for the given voice.
+        """
+        channel_count = voice.channel_count * 4096
+        sample_size = voice.sample_size
+        if (key := (sample_size, channel_count)) not in self._silence:
+            # Just guessing the type based on directsound
+            if sample_size == 8:
+                dtype = ctypes.c_ubyte
+            elif sample_size == 16:
+                dtype = ctypes.c_short
+            else:
+                raise ValueError("Bad sample size")
+            silence = (dtype * channel_count)(*([0] * channel_count))
+            self._silence[key] = (silence, ctypes.addressof(silence))
 
-    def return_voice(self, voice):
-        """Reset a voice and return it to the pool."""
-        voice.reset()
-        voice_key = (voice.audio_format.channels, voice.audio_format.sample_size, voice.audio_format.sample_rate)
-        self._voice_pool[voice_key].append(voice)
+        sil_tup = self._silence[key]
+        size = (sample_size // 8) * channel_count
 
-        if voice.is_emitter:
-            self._emitting_voices.remove(voice)
+        assert ctypes.sizeof(sil_tup[0]) == size
 
-    @staticmethod
-    def create_buffer(audio_data):
-        """Creates a XAUDIO2_BUFFER to be used with a source voice.
-            Audio data cannot be purged until the source voice has played it; doing so will cause glitches.
-            Furthermore, if the data is not in a string buffer, such as pure bytes, it must be converted."""
-        if type(audio_data.data) == bytes:
-            data = (ctypes.c_char * audio_data.length)()
-            ctypes.memmove(data, audio_data.data, audio_data.length)
-        else:
-            data = audio_data.data
-
-        buff = lib.XAUDIO2_BUFFER()
-        buff.AudioBytes = audio_data.length
-        buff.pAudioData = data
-        return buff
-
-    @staticmethod
-    def create_wave_format(audio_format):
-        wfx = lib.WAVEFORMATEX()
-        wfx.wFormatTag = lib.WAVE_FORMAT_PCM
-        wfx.nChannels = audio_format.channels
-        wfx.nSamplesPerSec = audio_format.sample_rate
-        wfx.wBitsPerSample = audio_format.sample_size
-        wfx.nBlockAlign = wfx.wBitsPerSample * wfx.nChannels // 8
-        wfx.nAvgBytesPerSec = wfx.nSamplesPerSec * wfx.nBlockAlign
-        return wfx
+        return (size, sil_tup[1])
 
 
 class XA2SourceVoice:
-
-    def __init__(self, voice, callback, audio_format):
+    def __init__(self, voice, callback, channel_count, sample_size):
         self._voice_state = lib.XAUDIO2_VOICE_STATE()  # Used for buffer state, will be reused constantly.
         self._voice = voice
         self._callback = callback
 
-        self.audio_format = audio_format
+        self.channel_count = channel_count
+        self.sample_size = sample_size
+
         # If it's a mono source, then we can make it an emitter.
         # In the future, non-mono source's can be supported as well.
-        if audio_format is not None and audio_format.channels == 1:
+        if channel_count == 1:
             self._emitter = lib.X3DAUDIO_EMITTER()
-            self._emitter.ChannelCount = audio_format.channels
+            self._emitter.ChannelCount = channel_count
             self._emitter.CurveDistanceScaler = 1.0
 
             # Commented are already set by the Player class.
@@ -354,55 +501,48 @@ class XA2SourceVoice:
         else:
             self._emitter = None
 
-    @property
-    def player(self):
-        """Returns the player class, stored within the callback."""
-        return self._callback.xa2_player
-
     def delete(self):
         self._emitter = None
         self._voice.Stop(0, 0)
         self._voice.FlushSourceBuffers()
         self._voice = None
-        self._callback.xa2_player = None
-
-    def __del__(self):
-        self.destroy()
+        self._callback.on_buffer_end = None
 
     def destroy(self):
         """Completely destroy the voice."""
         self._emitter = None
 
         if self._voice is not None:
-            try:
-                self._voice.Stop(0, 0)
-                self._voice.FlushSourceBuffers()
-                self._voice.DestroyVoice()
-            except TypeError:
-                pass
-
+            self._voice.DestroyVoice()
             self._voice = None
 
         self._callback = None
 
-    def acquired(self, player):
-        """A voice has been reacquired, set the player for callback."""
-        self._callback.xa2_player = player
+    def acquired(self, on_buffer_end_cb, sample_rate):
+        """A voice has been acquired. Set the callback as well as its new sample
+        rate.
+        """
+        self._callback.on_buffer_end = on_buffer_end_cb
+        self._voice.SetSourceSampleRate(sample_rate)
 
     def reset(self):
         """When a voice is returned to the pool, reset position on emitter."""
         if self._emitter is not None:
             self.position = (0, 0, 0)
 
-        self._voice.Stop(0, 0)
-        self._voice.FlushSourceBuffers()
-        self._callback.xa2_player = None
+        self._callback.on_buffer_end = None
 
     @property
     def buffers_queued(self):
         """Get the amount of buffers in the current voice. Adding flag for no samples played is 3x faster."""
         self._voice.GetState(ctypes.byref(self._voice_state), lib.XAUDIO2_VOICE_NOSAMPLESPLAYED)
         return self._voice_state.BuffersQueued
+
+    @property
+    def samples_played(self):
+        """Get the amount of samples played by the voice."""
+        self._voice.GetState(ctypes.byref(self._voice_state), 0)
+        return self._voice_state.SamplesPlayed
 
     @property
     def volume(self):
@@ -549,9 +689,6 @@ class XAudio2Listener:
         self.listener.OrientTop.x = 0
         self.listener.OrientTop.y = 1
         self.listener.OrientTop.z = 0
-
-    def __del__(self):
-        self.delete()
 
     def delete(self):
         self.listener = None

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -94,6 +94,7 @@ class XA2EngineCallback(com.COMObject):
     _interfaces_ = [lib.IXAudio2EngineCallback]
 
     def __init__(self, lock):
+        super().__init__()
         self._lock = lock
 
     def OnProcessingPassStart(self):
@@ -171,7 +172,7 @@ class XAudio2Driver:
         #   and the main thread runs
         # - the main thread runs a critical operation on the player such as `delete` to completion
         # - the callback is resumed and breaks as the audio player is deleted.
-        self._engine_callback = XA2EngineCallback(self._lock)
+        self._engine_callback = XA2EngineCallback(self.lock)
 
         self._emitting_voices = []  # Contains all of the emitting source voices.
         self._voice_pool = defaultdict(list)
@@ -437,7 +438,7 @@ class XAudio2Driver:
 
         wfx_format = create_xa2_waveformat(audio_format)
 
-        callback = lib.XAudio2VoiceCallback()
+        callback = XAudio2VoiceCallback()
         self._xaudio2.CreateSourceVoice(ctypes.byref(voice),
                                         ctypes.byref(wfx_format),
                                         0,

--- a/pyglet/media/drivers/xaudio2/lib_xaudio2.py
+++ b/pyglet/media/drivers/xaudio2/lib_xaudio2.py
@@ -208,34 +208,6 @@ class IXAudio2VoiceCallback(com.Interface):
     ]
 
 
-class XA2SourceCallback(com.COMObject):
-    """Callback class used to trigger when buffers or streams end..
-           WARNING: Whenever a callback is running, XAudio2 cannot generate audio.
-           Make sure these functions run as fast as possible and do not block/delay more than a few milliseconds.
-           MS Recommendation:
-           At a minimum, callback functions must not do the following:
-                - Access the hard disk or other permanent storage
-                - Make expensive or blocking API calls
-                - Synchronize with other parts of client code
-                - Require significant CPU usage
-    """
-    _interfaces_ = [IXAudio2VoiceCallback]
-
-    def __init__(self, xa2_player):
-        super().__init__()
-        self.xa2_player = xa2_player
-
-    def OnBufferEnd(self, pBufferContext):
-        """At the end of playing one buffer, attempt to refill again.
-        Even if the player is out of sources, it needs to be called to purge all buffers.
-        """
-        if self.xa2_player:
-            self.xa2_player.refill_source_player()
-
-    def OnVoiceError(self, pBufferContext, hresult):
-        raise Exception("Error occurred during audio playback.", hresult)
-
-
 class XAUDIO2_EFFECT_DESCRIPTOR(Structure):
     _fields_ = [
         ('pEffect', com.pIUnknown),
@@ -336,7 +308,7 @@ class IXAudio2SourceVoice(IXAudio2Voice):
         ('GetFrequencyRatio',
          com.STDMETHOD(POINTER(c_float))),
         ('SetSourceSampleRate',
-         com.STDMETHOD()),
+         com.STDMETHOD(UINT32)),
     ]
 
 
@@ -356,14 +328,6 @@ class IXAudio2EngineCallback(com.Interface):
         ('OnCriticalError',
          com.VOIDMETHOD(HRESULT)),
     ]
-
-
-class XA2EngineCallback(com.COMObject):
-    _interfaces_ = [IXAudio2EngineCallback]
-
-    def OnCriticalError(self, hresult):
-        raise Exception("Critical Error:", hresult)
-
 
 
 # -------------- 3D Audio Positioning----------

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -184,8 +184,8 @@ class Player(pyglet.event.EventDispatcher):
             if source.audio_format is not None:
                 if self._audio_player is None:
                     self._create_audio_player()
-                if self._audio_player is not None:
-                    self._audio_player.prefill_audio()
+                    if self._audio_player is not None:
+                        self._audio_player.prefill_audio()
 
             if bl.logger is not None:
                 bl.logger.init_wall_time()
@@ -299,6 +299,7 @@ class Player(pyglet.event.EventDispatcher):
             if self._audio_player is not None:
                 if self._source.audio_format == old_source.audio_format:
                     self._audio_player.set_source(self._source)
+                    self._audio_player.prefill_audio()
                 else:
                     self._audio_player.delete()
                     self._audio_player = None
@@ -345,6 +346,7 @@ class Player(pyglet.event.EventDispatcher):
             # XXX: According to docstring in AbstractAudioPlayer this cannot
             # be called when the player is not stopped
             self._audio_player.clear()
+            self._audio_player.prefill_audio()
         if self.source.video_format is not None:
             self.update_texture()
             pyglet.clock.unschedule(self.update_texture)

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -285,28 +285,17 @@ class Player(pyglet.event.EventDispatcher):
             self.delete()
             self.dispatch_event('on_player_eos')
         else:
-            # XXX: Believe it or not, but this coupled with the fact the audio
-            # player only has a weakref to the source somehow causes the
-            # entire thread to hang upon accessing it in `set_source`.
-            # I am 20% sure this might be a python bug. Whatever; push it to a
-            # local to prevent the freeze.
-            __hold_on = self._source
-            old_audio_format = self._source.audio_format
-            old_video_format = self._source.video_format
-            self._set_source(new_source)
-
             if self._audio_player:
-                if old_audio_format == self._source.audio_format:
-                    self._audio_player.clear()
-                    self._audio_player.set_source(self._source)
+                if self._source.audio_format == new_source.audio_format:
+                    self._audio_player.set_source(new_source)
                 else:
                     self._audio_player.delete()
                     self._audio_player = None
-            if old_video_format != self._source.video_format:
+            if self._source.video_format != new_source.video_format:
                 self._texture = None
                 pyglet.clock.unschedule(self.update_texture)
 
-            del __hold_on
+            self._set_source(new_source)
 
             self._set_playing(was_playing)
             self.dispatch_event('on_player_next_source')

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -1,13 +1,14 @@
 """High-level sound and video player."""
 
-import time
 from collections import deque
+import time
+from typing import Iterable, Optional, Union
 
 import pyglet
 from pyglet.gl import GL_TEXTURE_2D
 from pyglet.media import buffered_logger as bl
 from pyglet.media.drivers import get_audio_driver
-from pyglet.media.codecs.base import Source, SourceGroup
+from pyglet.media.codecs.base import PreciseStreamingSource, Source, SourceGroup
 
 _debug = pyglet.options['debug_media']
 
@@ -19,35 +20,33 @@ class PlaybackTimer:
     paused and reset.
     """
 
-    def __init__(self):
-        """Initialize the timer with time 0."""
-        self._time = 0.0
-        self._systime = None
+    def __init__(self) -> None:
+        self._elapsed = 0.0
+        self._started_at = None
 
-    def start(self):
+    def start(self) -> None:
         """Start the timer."""
-        self._systime = time.time()
+        self._started_at = time.perf_counter()
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause the timer."""
-        self._time = self.get_time()
-        self._systime = None
+        self._elapsed = self.get_time()
+        self._started_at = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset the timer to 0."""
-        self._time = 0.0
-        if self._systime is not None:
-            self._systime = time.time()
+        self._elapsed = 0.0
+        if self._started_at is not None:
+            self._started_at = time.perf_counter()
 
-    def get_time(self):
+    def get_time(self) -> float:
         """Get the elapsed time."""
-        if self._systime is None:
-            now = self._time
-        else:
-            now = time.time() - self._systime + self._time
-        return now
+        if self._started_at is None:
+            return self._elapsed
 
-    def set_time(self, value):
+        return time.perf_counter() - self._started_at + self._elapsed
+
+    def set_time(self, value: float) -> None:
         """
         Manually set the elapsed time.
 
@@ -55,7 +54,7 @@ class PlaybackTimer:
             value (float): the new elapsed time value
         """
         self.reset()
-        self._time = value
+        self._elapsed = value
 
 
 class _PlayerProperty:
@@ -71,20 +70,21 @@ class _PlayerProperty:
     """
 
     def __init__(self, attribute, doc=None):
-        self.attribute = attribute
+        self.private_name = '_' + attribute
+        self.setter_name = 'set_' + attribute
         self.__doc__ = doc or ''
 
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
-        if '_' + self.attribute in obj.__dict__:
-            return obj.__dict__['_' + self.attribute]
-        return getattr(objtype, '_' + self.attribute)
+        if self.private_name in obj.__dict__:
+            return obj.__dict__[self.private_name]
+        return getattr(objtype, self.private_name)
 
     def __set__(self, obj, value):
-        obj.__dict__['_' + self.attribute] = value
+        obj.__dict__[self.private_name] = value
         if obj._audio_player:
-            getattr(obj._audio_player, 'set_' + self.attribute)(value)
+            getattr(obj._audio_player, self.setter_name)(value)
 
 
 class Player(pyglet.event.EventDispatcher):
@@ -103,7 +103,7 @@ class Player(pyglet.event.EventDispatcher):
     _cone_outer_angle = 360.
     _cone_outer_gain = 1.
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the Player with a MasterClock."""
         self._source = None
         self._playlists = deque()
@@ -115,6 +115,8 @@ class Player(pyglet.event.EventDispatcher):
         # Desired play state (not an indication of actual state).
         self._playing = False
 
+        self.last_seek_time = 0.0
+
         self._timer = PlaybackTimer()
         #: Loop the current source indefinitely or until
         #: :meth:`~Player.next_source` is called. Defaults to ``False``.
@@ -124,11 +126,11 @@ class Player(pyglet.event.EventDispatcher):
         #: .. versionadded:: 1.4
         self.loop = False
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Release the Player resources."""
         self.delete()
 
-    def queue(self, source):
+    def queue(self, source: Union[Source, Iterable[Source]]) -> None:
         """
         Queue the source on this player.
 
@@ -138,7 +140,7 @@ class Player(pyglet.event.EventDispatcher):
         Args:
             source (Source or Iterable[Source]): The source to queue.
         """
-        if isinstance(source, (Source, SourceGroup)):
+        if isinstance(source, Source):
             source = _one_item_playlist(source)
         else:
             try:
@@ -149,12 +151,28 @@ class Player(pyglet.event.EventDispatcher):
         self._playlists.append(source)
 
         if self.source is None:
-            source = next(self._playlists[0])
-            self._source = source.get_queue_source()
+            self._set_source(next(self._playlists[0]))
 
         self._set_playing(self._playing)
 
-    def _set_playing(self, playing):
+    def _set_source(self, new_source: Source) -> None:
+        if self._source is not None:
+            self._source.seek(0.0)
+            self._source.is_player_source = False
+
+        if new_source is None:
+            self._source = None
+        else:
+            qs = new_source.get_queue_source()
+            # HACK: for 2.0.x, players perform additional PreciseStreamingSource wrapping.
+            # Existing sources might not use `super().get_queue_source()`, leading to an
+            # imprecise source on here, which may not happen.
+            if not isinstance(qs, PreciseStreamingSource) and not qs.is_precise():
+                self._source = PreciseStreamingSource(qs)
+            else:
+                self._source = qs
+
+    def _set_playing(self, playing: bool) -> None:
         # stopping = self._playing and not playing
         # starting = not self._playing and playing
 
@@ -189,7 +207,6 @@ class Player(pyglet.event.EventDispatcher):
             if self._audio_player is None and source.video_format is None:
                 pyglet.clock.schedule_once(lambda dt: self.dispatch_event("on_eos"), source.duration)
 
-
         else:
             if self._audio_player:
                 self._audio_player.stop()
@@ -198,7 +215,7 @@ class Player(pyglet.event.EventDispatcher):
             self._timer.pause()
 
     @property
-    def playing(self):
+    def playing(self) -> bool:
         """
         bool: Read-only. Determine if the player state is playing.
 
@@ -210,34 +227,33 @@ class Player(pyglet.event.EventDispatcher):
         """
         return self._playing
 
-    def play(self):
+    def play(self) -> None:
         """Begin playing the current source.
 
         This has no effect if the player is already playing.
         """
         self._set_playing(True)
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause playback of the current source.
 
         This has no effect if the player is already paused.
         """
         self._set_playing(False)
 
-    def delete(self):
+    def delete(self) -> None:
         """Release the resources acquired by this player.
 
         The internal audio player and the texture will be deleted.
         """
-        if self._source:
-            self.source.is_player_source = False
+        self._set_source(None)
         if self._audio_player:
             self._audio_player.delete()
             self._audio_player = None
         if self._texture:
             self._texture = None
 
-    def next_source(self):
+    def next_source(self) -> None:
         """Move immediately to the next source in the current playlist.
 
         If the playlist is empty, discard it and check if another playlist
@@ -248,13 +264,9 @@ class Player(pyglet.event.EventDispatcher):
         self.pause()
         self._timer.reset()
 
-        if self._source:
-            # Reset source to the beginning
-            self.seek(0.0)
-            self.source.is_player_source = False
-
         playlists = self._playlists
         if not playlists:
+            self._set_source(None)
             return
 
         try:
@@ -268,18 +280,22 @@ class Player(pyglet.event.EventDispatcher):
                 new_source = next(self._playlists[0])
 
         if new_source is None:
-            self._source = None
             self.delete()
             self.dispatch_event('on_player_eos')
         else:
+            # XXX: Believe it or not, but this coupled with the fact the audio
+            # player only has a weakref to the source somehow causes the
+            # entire thread to hang upon accessing it in `set_source`.
+            # I am 20% sure this might be a python bug. Whatever; push it to a
+            # local to prevent the freeze.
+            __hold_on = self._source
             old_audio_format = self._source.audio_format
             old_video_format = self._source.video_format
-            self._source = new_source.get_queue_source()
+            self._set_source(new_source)
 
             if self._audio_player:
                 if old_audio_format == self._source.audio_format:
-                    self._audio_player.clear()
-                    self._audio_player.source = self._source
+                    self._audio_player.set_source(self._source)
                 else:
                     self._audio_player.delete()
                     self._audio_player = None
@@ -287,10 +303,12 @@ class Player(pyglet.event.EventDispatcher):
                 self._texture = None
                 pyglet.clock.unschedule(self.update_texture)
 
+            del __hold_on
+
             self._set_playing(was_playing)
             self.dispatch_event('on_player_next_source')
 
-    def seek(self, timestamp):
+    def seek(self, timestamp: float) -> None:
         """
         Seek for playback to the indicated timestamp on the current source.
 
@@ -298,8 +316,7 @@ class Player(pyglet.event.EventDispatcher):
         duration of the source, it will be clamped to the end.
 
         Args:
-            timestamp (float): The time where to seek in the source, clamped to the
-                beginning and end of the source.
+            timestamp (float): The time where to seek in the source.
         """
         playing = self._playing
         if playing:
@@ -310,10 +327,17 @@ class Player(pyglet.event.EventDispatcher):
         if bl.logger is not None:
             bl.logger.log("p.P.sk", timestamp)
 
-        timestamp = max(timestamp, 0)
+        timestamp = max(timestamp, 0.0)
+        if self._source.duration is not None:
+            # TODO: If the duration is reported as None and the source clamps anyways,
+            # this will have pretty bad effects.
+            # Maybe have seek methods return the timestamp they actually seeked to
+            timestamp = min(timestamp, self._source.duration)
 
         self._timer.set_time(timestamp)
         self._source.seek(timestamp)
+        self.last_seek_time = timestamp
+
         if self._audio_player:
             # XXX: According to docstring in AbstractAudioPlayer this cannot
             # be called when the player is not stopped
@@ -323,7 +347,7 @@ class Player(pyglet.event.EventDispatcher):
             pyglet.clock.unschedule(self.update_texture)
         self._set_playing(playing)
 
-    def _create_audio_player(self):
+    def _create_audio_player(self) -> None:
         assert not self._audio_player
         assert self.source
 
@@ -343,12 +367,12 @@ class Player(pyglet.event.EventDispatcher):
             setattr(self, attr, value)
 
     @property
-    def source(self):
+    def source(self) -> Optional[Source]:
         """Source: Read-only. The current :class:`Source`, or ``None``."""
         return self._source
 
     @property
-    def time(self):
+    def time(self) -> float:
         """
         float: Read-only. Current playback time of the current source.
 
@@ -359,7 +383,7 @@ class Player(pyglet.event.EventDispatcher):
         """
         return self._timer.get_time()
 
-    def _create_texture(self):
+    def _create_texture(self) -> None:
         video_format = self.source.video_format
         self._texture = pyglet.image.Texture.create(video_format.width, video_format.height, GL_TEXTURE_2D)
         self._texture = self._texture.get_transform(flip_y=True)
@@ -369,7 +393,7 @@ class Player(pyglet.event.EventDispatcher):
         return self._texture
 
     @property
-    def texture(self):
+    def texture(self) -> pyglet.image.Texture:
         """
         :class:`pyglet.image.Texture`: Get the texture for the current video frame.
 
@@ -379,7 +403,7 @@ class Player(pyglet.event.EventDispatcher):
         """
         return self._texture
 
-    def get_texture(self):
+    def get_texture(self) -> pyglet.image.Texture:
         """
         Get the texture for the current video frame.
 
@@ -395,17 +419,14 @@ class Player(pyglet.event.EventDispatcher):
         """
         return self.texture
 
-    def refill_buffer(self):
-        raise NotImplemented
-
-    def seek_next_frame(self):
+    def seek_next_frame(self) -> None:
         """Step forwards one video frame in the current source."""
         time = self.source.get_next_video_timestamp()
         if time is None:
             return
         self.seek(time)
 
-    def update_texture(self, dt=None):
+    def update_texture(self, dt: float = None) -> None:
         """Manually update the texture from the current source.
 
         This happens automatically, so you shouldn't need to call this method.
@@ -457,12 +478,10 @@ class Player(pyglet.event.EventDispatcher):
 
         image = source.get_next_video_frame()
         if image is not None:
-
             with self._context:
                 if self._texture is None:
                     self._create_texture()
                 self._texture.blit_into(image, 0, 0, 0)
-
         elif bl.logger is not None:
             bl.logger.log("p.P.ut.1.8")
 
@@ -478,7 +497,7 @@ class Player(pyglet.event.EventDispatcher):
         pyglet.clock.schedule_once(self.update_texture, delay)
         # self.pr.enable()
 
-    def _video_finished(self, dt):
+    def _video_finished(self, _dt) -> None:
         if self._audio_player is None:
             self.dispatch_event("on_eos")
 
@@ -588,8 +607,6 @@ class Player(pyglet.event.EventDispatcher):
             if self.source:
                 # Reset source to the beginning
                 self.seek(0.0)
-            if self._audio_player:
-                self._audio_player.clear()
             self._set_playing(was_playing)
 
         else:
@@ -644,14 +661,15 @@ class PlayerGroup:
     All players in the group must currently not belong to any other group.
 
     Args:
-        players (List[Player]): List of :class:`.Player` s in this group.
+        players (Iterable[Player]): Iterable of :class:`.Player` s in this
+            group.
     """
 
-    def __init__(self, players):
+    def __init__(self, players: Iterable[Player]) -> None:
         """Initialize the PlayerGroup with the players."""
         self.players = list(players)
 
-    def play(self):
+    def play(self) -> None:
         """Begin playing all players in the group simultaneously."""
         audio_players = [p._audio_player
                          for p in self.players if p._audio_player]
@@ -660,7 +678,7 @@ class PlayerGroup:
         for player in self.players:
             player.play()
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause all players in the group simultaneously."""
         audio_players = [p._audio_player
                          for p in self.players if p._audio_player]

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -262,7 +262,9 @@ class Player(pyglet.event.EventDispatcher):
         """
         was_playing = self._playing
         self.pause()
+
         self._timer.reset()
+        self.last_seek_time = 0.0
 
         playlists = self._playlists
         if not playlists:
@@ -295,6 +297,7 @@ class Player(pyglet.event.EventDispatcher):
 
             if self._audio_player:
                 if old_audio_format == self._source.audio_format:
+                    self._audio_player.clear()
                     self._audio_player.set_source(self._source)
                 else:
                     self._audio_player.delete()

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -157,10 +157,6 @@ class Player(pyglet.event.EventDispatcher):
         self._set_playing(self._playing)
 
     def _set_source(self, new_source: Optional[Source]) -> None:
-        # if self._source is not None:
-        #     self._source.seek(0.0)
-        #     self._source.is_player_source = False
-
         if new_source is None:
             self._source = None
         else:
@@ -246,7 +242,6 @@ class Player(pyglet.event.EventDispatcher):
 
         The internal audio player and the texture will be deleted.
         """
-        # self._set_source(None)
         if self._source:
             self.source.is_player_source = False
         if self._audio_player is not None:

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -26,7 +26,8 @@ class PlaybackTimer:
 
     def start(self) -> None:
         """Start the timer."""
-        self._started_at = time.perf_counter()
+        if self._started_at is None:
+            self._started_at = time.perf_counter()
 
     def pause(self) -> None:
         """Pause the timer."""

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -8,7 +8,7 @@ import pyglet
 from pyglet.gl import GL_TEXTURE_2D
 from pyglet.media import buffered_logger as bl
 from pyglet.media.drivers import get_audio_driver
-from pyglet.media.codecs.base import PreciseStreamingSource, Source
+from pyglet.media.codecs.base import PreciseStreamingSource, Source, SourceGroup
 
 _debug = pyglet.options['debug_media']
 
@@ -140,7 +140,7 @@ class Player(pyglet.event.EventDispatcher):
         Args:
             source (Source or Iterable[Source]): The source to queue.
         """
-        if isinstance(source, Source):
+        if isinstance(source, (Source, SourceGroup)):
             source = _one_item_playlist(source)
         else:
             try:

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -8,7 +8,7 @@ import pyglet
 from pyglet.gl import GL_TEXTURE_2D
 from pyglet.media import buffered_logger as bl
 from pyglet.media.drivers import get_audio_driver
-from pyglet.media.codecs.base import PreciseStreamingSource, Source, SourceGroup
+from pyglet.media.codecs.base import PreciseStreamingSource, Source
 
 _debug = pyglet.options['debug_media']
 

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -285,17 +285,22 @@ class Player(pyglet.event.EventDispatcher):
             self.delete()
             self.dispatch_event('on_player_eos')
         else:
+            # Keeping a strong reference to old source directly as `_audio_player` only has
+            # a weakref and still accesses it in `set_source`
+            old_source = self._source
+            self._set_source(new_source)
+
             if self._audio_player:
-                if self._source.audio_format == new_source.audio_format:
-                    self._audio_player.set_source(new_source)
+                if self._source.audio_format == old_source.audio_format:
+                    self._audio_player.set_source(self._source)
                 else:
                     self._audio_player.delete()
                     self._audio_player = None
-            if self._source.video_format != new_source.video_format:
+            if self._source.video_format != old_source.video_format:
                 self._texture = None
                 pyglet.clock.unschedule(self.update_texture)
 
-            self._set_source(new_source)
+            del old_source
 
             self._set_playing(was_playing)
             self.dispatch_event('on_player_next_source')

--- a/pyglet/media/player_worker_thread.py
+++ b/pyglet/media/player_worker_thread.py
@@ -1,10 +1,13 @@
-import time
-import atexit
 import threading
+import time
+from typing import TYPE_CHECKING, Set
 
 import pyglet
 
 from pyglet.util import debug_print
+
+if TYPE_CHECKING:
+    from pyglet.media.drivers.base import AbstractAudioPlayer
 
 
 _debug = debug_print('debug_media')
@@ -15,37 +18,34 @@ class PlayerWorkerThread(threading.Thread):
     provides a notify method to interrupt it as well as a termination method.
     """
 
-    _threads = set()
+    # Run every 20ms; accurate enough for event dispatching while not hogging too much
+    # time updating the players
+    _nap_time = 0.020
 
-    # Time to wait if there are players, but they're all full:
-    _nap_time = 0.05
-
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(daemon=True)
 
         self._rest_event = threading.Event()
         # A lock that should be held as long as consistency of `self.players` is required.
         self._operation_lock = threading.Lock()
         self._stopped = False
-        self.players = set()
+        self.players: Set[AbstractAudioPlayer] = set()
 
-    def run(self):
+    def run(self) -> None:
         if pyglet.options['debug_trace']:
             pyglet._install_trace()
-
-        self._threads.add(self)
 
         sleep_time = None
 
         while True:
             assert _debug(
-                'PlayerWorkerThread: Going to sleep ' +
+                'PlayerWorkerThread.run: Going to sleep ' +
                 ('indefinitely; no active players' if sleep_time is None else f'for {sleep_time}')
             )
             self._rest_event.wait(sleep_time)
             self._rest_event.clear()
 
-            assert _debug(f'PlayerWorkerThread: woke up @{time.time()}')
+            assert _debug(f'PlayerWorkerThread.run: woke up @{time.time()}')
             if self._stopped:
                 break
 
@@ -53,14 +53,14 @@ class PlayerWorkerThread(threading.Thread):
                 if self.players:
                     sleep_time = self._nap_time
                     for player in self.players:
-                        player.refill_buffer()
+                        player.work()
                 else:
                     # sleep until a player is added
                     sleep_time = None
 
-        self._threads.remove(self)
+        assert _debug(f'PlayerWorkerThread.run: exiting')
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the thread and wait for it to terminate.
 
         The `stop` instance variable is set to ``True`` and the rest event
@@ -77,7 +77,7 @@ class PlayerWorkerThread(threading.Thread):
             # Ignore on unclean shutdown
             pass
 
-    def notify(self):
+    def notify(self) -> None:
         """Interrupt the current sleep operation.
 
         If the thread is currently sleeping, it will be woken immediately,
@@ -88,10 +88,10 @@ class PlayerWorkerThread(threading.Thread):
         assert _debug('PlayerWorkerThread.notify()')
         self._rest_event.set()
 
-    def add(self, player):
+    def add(self, player: 'AbstractAudioPlayer') -> None:
         """
         Add a player to the PlayerWorkerThread; which will call
-        `refill_buffer` on it regularly. Notify the thread as well.
+        `work` on it regularly. Notify the thread as well.
 
         Do not call this method from within the thread, as it will deadlock.
         """
@@ -103,7 +103,7 @@ class PlayerWorkerThread(threading.Thread):
 
         self.notify()
 
-    def remove(self, player):
+    def remove(self, player: 'AbstractAudioPlayer') -> None:
         """
         Remove a player from the PlayerWorkerThread, or ignore if it does
         not exist.
@@ -115,15 +115,3 @@ class PlayerWorkerThread(threading.Thread):
         if player in self.players:
             with self._operation_lock:
                 self.players.remove(player)
-
-            # self.notify()
-
-    @classmethod
-    def atexit(cls):
-        for thread in list(cls._threads):
-            thread.stop()
-        # Can't be 100% sure that all threads are stopped here as it is technically possible that
-        # a thread may just have removed itself from cls._threads as the last action in `run()`
-        # and then was unscheduled; But it will definitely finish very soon after anyways
-
-atexit.register(PlayerWorkerThread.atexit)

--- a/pyglet/util.py
+++ b/pyglet/util.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import math
 import sys
 from typing import Optional, Union, Callable
 
@@ -80,6 +81,22 @@ def debug_print(pyglet_option_name: str = 'debug') -> Callable[[str], bool]:
     if enabled:
         return _debug_print_real
     return _debug_print_dummy
+
+
+# Based on: https://stackoverflow.com/a/56225940
+def closest_power_of_two(x: int) -> int:
+    if x <= 2:
+        return 2
+    if (x >> (x.bit_length() - 2)) & 1:
+        return 1 << math.ceil(math.log2(x))
+    else:
+        return 1 << math.floor(math.log2(x))
+
+
+def next_or_equal_power_of_two(x: int) -> int:
+    if x <= 1:
+        return 1
+    return 1 << math.ceil(math.log2(x))
 
 
 class CodecRegistry:

--- a/tests/integration/media/test_directsound.py
+++ b/tests/integration/media/test_directsound.py
@@ -82,14 +82,14 @@ def audio_format_3d(request):
 
 @pytest.fixture
 def buffer_(driver, audio_format):
-    buffer = driver.create_buffer(audio_format)
+    buffer = driver.create_buffer(audio_format, int(audio_format.bytes_per_second * 1.0))
     yield buffer
     buffer.delete()
 
 
 @pytest.fixture
 def buffer_3d(driver, audio_format_3d):
-    buffer = driver.create_buffer(audio_format_3d)
+    buffer = driver.create_buffer(audio_format_3d, int(audio_format_3d.bytes_per_second * 1.0))
     assert buffer.is3d
     yield buffer
     buffer.delete()
@@ -122,7 +122,7 @@ def test_driver_create():
 
 
 def test_create_buffer(driver, audio_format):
-    buf = driver.create_buffer(audio_format)
+    buf = driver.create_buffer(audio_format, int(audio_format.bytes_per_second * 1.0))
     del buf
 
 

--- a/tests/integration/media/test_driver.py
+++ b/tests/integration/media/test_driver.py
@@ -43,7 +43,7 @@ class SilentTestSource(Silence):
         self.bytes_read = 0
 
     def get_audio_data(self, nbytes):
-        data = super(Silence, self).get_audio_data(nbytes)
+        data = super().get_audio_data(nbytes)
         if data is not None:
             self.bytes_read += data.length
         return data

--- a/tests/integration/media/test_driver.py
+++ b/tests/integration/media/test_driver.py
@@ -10,16 +10,26 @@ pyglet.options['debug_media'] = _debug
 pyglet.options['debug_media_buffers'] = _debug
 
 import pyglet.app
+from pyglet.media.player import PlaybackTimer
 from pyglet.media.synthesis import Silence
 
 from .mock_player import MockPlayer
 
 
-class MockPlayerWithMockTime(MockPlayer):
+class _FakeDispatchEvent:
+    def dispatch_event(self, *_, **__):
+        pass
+
+
+class MockPlayerWithMockTime(MockPlayer, _FakeDispatchEvent):
+    def __init__(self, event_loop):
+        super().__init__(event_loop)
+        self.last_seek_time = 0.0
+        self.timer = PlaybackTimer()
 
     @property
     def time(self):
-        return 0
+        return self.timer.get_time()
 
 
 @pytest.fixture
@@ -32,8 +42,8 @@ class SilentTestSource(Silence):
         super().__init__(duration, frequency, sample_rate, envelope)
         self.bytes_read = 0
 
-    def get_audio_data(self, nbytes, compensation_time=0.0):
-        data = super(Silence, self).get_audio_data(nbytes, compensation_time)
+    def get_audio_data(self, nbytes):
+        data = super(Silence, self).get_audio_data(nbytes)
         if data is not None:
             self.bytes_read += data.length
         return data
@@ -114,14 +124,23 @@ def test_audio_player_clear(driver, player):
     audio_player = driver.create_audio_player(source, player)
     try:
         audio_player.play()
+        player.timer.start()
         player.wait(.5)
+
         assert 0. < audio_player.get_time() < 5.
 
         audio_player.stop()
+        player.timer.pause()
+
         source.seek(5.)
+        player.last_seek_time = 5.
+        player.timer.set_time(5.)
         audio_player.clear()
         audio_player.play()
+        player.timer.start()
+
         player.wait(.3)
+
         assert 5. <= audio_player.get_time() < 10.
 
     finally:
@@ -135,6 +154,7 @@ def test_audio_player_time(driver, player):
     audio_player = driver.create_audio_player(source, player)
     try:
         audio_player.play()
+        player.timer.start()
         last_time = audio_player.get_time()
         # Needs to run until at least the initial buffer is processed. Ideal time is 1 sec, so run
         # more than 1 sec.

--- a/tests/integration/media/test_player.py
+++ b/tests/integration/media/test_player.py
@@ -28,7 +28,7 @@ class SilentTestSource(Silence):
         self.bytes_read = 0
 
     def get_audio_data(self, nbytes):
-        data = super(Silence, self).get_audio_data(nbytes)
+        data = super().get_audio_data(nbytes)
         if data is not None:
             self.bytes_read += data.length
         return data

--- a/tests/integration/media/test_player.py
+++ b/tests/integration/media/test_player.py
@@ -19,15 +19,6 @@ class PlayerTest(MockPlayer, Player):
 
 @pytest.fixture
 def player(event_loop):
-    # When running this in the same session after other tests (not exactly sure which ones and
-    # why), the audio driver becomes None, causing players to not create audio players, to not
-    # consume the sources, and then fail the tests.
-    # Reloading the module here fixes that.
-    import pyglet.media.drivers
-    if pyglet.media.drivers._audio_driver is None:
-        import importlib
-        importlib.reload(pyglet.media.drivers)
-
     return PlayerTest(event_loop)
 
 

--- a/tests/integration/media/test_pulse.py
+++ b/tests/integration/media/test_pulse.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.skipif(interface is None, reason='requires PulseAudio')
 
 @pytest.fixture
 def mainloop():
-    return interface.PulseAudioMainLoop()
+    return interface.PulseAudioMainloop()
 
 
 def test_mainloop_run(mainloop):
@@ -29,14 +29,14 @@ def test_mainloop_run(mainloop):
 
 def test_mainloop_lock(mainloop):
     mainloop.start()
-    mainloop.lock()
+    mainloop.lock_()
     mainloop.unlock()
     mainloop.delete()
 
 
 def test_mainloop_signal(mainloop):
     mainloop.start()
-    with mainloop:
+    with mainloop.lock:
         mainloop.signal()
     mainloop.delete()
 
@@ -45,12 +45,12 @@ def test_mainloop_wait_signal(mainloop):
     mainloop.start()
 
     def signal():
-        with mainloop:
+        with mainloop.lock:
             mainloop.signal()
     t = Timer(.1, signal)
     t.start()
 
-    with mainloop:
+    with mainloop.lock:
         mainloop.wait()
     mainloop.delete()
 
@@ -58,11 +58,11 @@ def test_mainloop_wait_signal(mainloop):
 @pytest.fixture
 def context(mainloop):
     mainloop.start()
-    with mainloop:
+    with mainloop.lock:
         context = mainloop.create_context()
     yield context
 
-    with context:
+    with context.mainloop.lock:
         context.delete()
     mainloop.delete()
 
@@ -76,7 +76,7 @@ def test_context_not_connected(context):
     assert context.server_protocol_version == None
     assert context.is_local == None
 
-    with context:
+    with context.mainloop.lock:
         context.delete()
 
     assert context.is_ready == False
@@ -107,7 +107,7 @@ def test_context_connect(context):
     assert isinstance(context.server_protocol_version, numbers.Integral)
     assert context.is_local == True
 
-    with context:
+    with context.mainloop.lock:
         context.delete()
 
     assert context.is_ready == False
@@ -123,7 +123,7 @@ def test_context_connect(context):
 def stream(context):
     context.connect()
     audio_format = AudioFormat(1, 16, 44100)
-    with context:
+    with context.mainloop.lock:
         stream = context.create_stream(audio_format)
     return stream
 
@@ -135,16 +135,18 @@ def audio_source():
 
 @pytest.fixture
 def filled_stream(stream, audio_source):
-    with stream:
+    with stream.mainloop.lock:
         stream.connect_playback()
 
     assert stream.is_ready
-    assert stream.writable_size > 0
+    with stream.mainloop.lock:
+        writable_size = stream.get_writable_size()
+        assert writable_size > 0
 
-    nbytes = min(1024, stream.writable_size)
+    nbytes = min(1024, writable_size)
     audio_data = audio_source.get_audio_data(nbytes)
-    with stream:
-        stream.write(audio_data)
+    with stream.mainloop.lock:
+        stream.write(audio_data.pointer, nbytes)
 
     assert stream.is_ready
     return stream
@@ -157,7 +159,7 @@ def test_stream_create(stream):
     assert stream.is_failed == False
     assert stream.is_terminated == False
 
-    with stream:
+    with stream.mainloop.lock:
         stream.delete()
 
     assert stream.is_unconnected == True
@@ -173,9 +175,9 @@ def test_stream_connect(stream):
     assert stream.is_ready == False
     assert stream.is_failed == False
     assert stream.is_terminated == False
-    assert isinstance(stream.index, numbers.Integral)
+    assert stream.index is None
 
-    with stream:
+    with stream.mainloop.lock:
         stream.connect_playback()
 
     assert stream.is_unconnected == False
@@ -185,7 +187,7 @@ def test_stream_connect(stream):
     assert stream.is_terminated == False
     assert isinstance(stream.index, numbers.Integral)
 
-    with stream:
+    with stream.mainloop.lock:
         stream.delete()
 
     assert stream.is_unconnected == False
@@ -197,21 +199,24 @@ def test_stream_connect(stream):
 
 
 def test_stream_write(stream, audio_source):
-    with stream:
+    with stream.mainloop.lock:
         stream.connect_playback()
 
     assert stream.is_ready
-    assert stream.writable_size > 0
 
-    nbytes = min(1024, stream.writable_size)
+    with stream.mainloop.lock:
+        writable_size = stream.get_writable_size()
+        assert writable_size > 0
+
+    nbytes = min(1024, writable_size)
     audio_data = audio_source.get_audio_data(nbytes)
-    with stream:
-        written = stream.write(audio_data)
+    with stream.mainloop.lock:
+        written = stream.write(audio_data.pointer, nbytes)
     assert written == nbytes
 
     assert stream.is_ready
 
-    with stream:
+    with stream.mainloop.lock:
         stream.delete()
 
     assert stream.is_terminated
@@ -219,104 +224,98 @@ def test_stream_write(stream, audio_source):
 
 
 def test_stream_timing_info(filled_stream):
-    with filled_stream:
+    with filled_stream.mainloop.lock:
         op = filled_stream.update_timing_info()
         op.wait()
     assert op.is_done
+    op.delete()
+
     info = filled_stream.get_timing_info()
     assert info is not None
 
-    with filled_stream:
-        op.delete()
-
 
 def test_stream_trigger(filled_stream):
-    with filled_stream:
+    with filled_stream.mainloop.lock:
         op = filled_stream.trigger()
         op.wait()
     assert op.is_done
-
-    with filled_stream:
-        op.delete()
+    op.delete()
 
 
 def test_stream_prebuf(filled_stream):
-    with filled_stream:
+    with filled_stream.mainloop.lock:
         op = filled_stream.prebuf()
         op.wait()
     assert op.is_done
-
-    with filled_stream:
-        op.delete()
+    op.delete()
 
 
 def test_stream_cork(filled_stream):
-    assert filled_stream.is_corked
+    assert filled_stream.is_corked()
 
-    with filled_stream:
+    with filled_stream.mainloop.lock:
         op = filled_stream.resume()
         op.wait()
-    assert op.is_done
-    assert not filled_stream.is_corked
+        assert op.is_done
+        assert not filled_stream.is_corked()
+    op.delete()
 
-    with filled_stream:
-        op.delete()
+    with filled_stream.mainloop.lock:
         op = filled_stream.pause()
         op.wait()
-    assert op.is_done
-    assert filled_stream.is_corked
-
-    with filled_stream:
-        op.delete()
+        assert op.is_done
+        assert filled_stream.is_corked()
+    op.delete()
 
 
 def test_stream_update_sample_rate(filled_stream):
-    with filled_stream:
+    with filled_stream.mainloop.lock:
         op = filled_stream.update_sample_rate(44100)
         op.wait()
     assert op.is_done
-
-    with filled_stream:
-        op.delete()
+    op.delete()
 
 
 def test_stream_write_needed(stream, audio_source, event_loop):
-    with stream:
+    with stream.mainloop.lock:
         stream.connect_playback()
 
     assert stream.is_ready
-    assert stream.writable_size > 0
 
-    @stream.event
-    def on_write_needed(nbytes, underflow):
+    with stream.mainloop.lock:
+        writable_size = stream.get_writable_size()
+        assert writable_size > 0
+
+    def on_write_needed(_stream, nbytes, _userdata):
         on_write_needed.nbytes = nbytes
-        on_write_needed.underflow = underflow
-        if underflow is True:
-            event_loop.interrupt_event_loop()
-        return pyglet.event.EVENT_HANDLED
 
     on_write_needed.nbytes = None
-    on_write_needed.underflow = None
 
-    audio_data = audio_source.get_audio_data(stream.writable_size)
-    with stream:
-        stream.write(audio_data)
+    def on_underflow(_stream, _userdata):
+        on_underflow.underflow = True
+        event_loop.interrupt_event_loop()
+
+    on_underflow.underflow = False
+
+    stream.set_write_callback(on_write_needed)
+    stream.set_underflow_callback(on_underflow)
+
+    audio_data = audio_source.get_audio_data(writable_size)
+    with stream.mainloop.lock:
+        stream.write(audio_data.pointer, audio_data.length)
     assert stream.is_ready
-    assert not stream.underflow
-    with stream:
+
+    with stream.mainloop.lock:
         stream.resume().wait().delete()
 
     event_loop.run_event_loop(duration=0.1)
 
     assert on_write_needed.nbytes > 0
-    assert on_write_needed.underflow == False
-    assert not stream.underflow
+    assert on_underflow.underflow == False
 
     on_write_needed.nbytes = None
-    on_write_needed.underflow = None
+    on_underflow.underflow = None
 
     event_loop.run_event_loop(duration=5.0)
     assert on_write_needed.nbytes > 0
-    assert on_write_needed.underflow == True
-    assert stream.underflow
-
+    assert on_underflow.underflow == True

--- a/tests/unit/media/test_player.py
+++ b/tests/unit/media/test_player.py
@@ -617,10 +617,8 @@ class PlayerTestCase(unittest.TestCase):
         self.player.next_source()
         self.assert_new_texture_created(self.video_format_2)
         self.assert_update_texture_unscheduled()
-        # schedule_once called twice:
-        #   - Once for seeking back to 0 the previous source in next_source()
-        #   - Once for scheduling the next source update_texture
-        assert self.mock_clock.schedule_once.call_count == 2
+        # schedule_once called for scheduling the next source update_texture
+        assert self.mock_clock.schedule_once.call_count == 1
         self.mock_clock.schedule_once.assert_called_with(self.player.update_texture, 0)
 
     def test_video_seek_next_frame(self):

--- a/tests/unit/media/test_player.py
+++ b/tests/unit/media/test_player.py
@@ -617,8 +617,10 @@ class PlayerTestCase(unittest.TestCase):
         self.player.next_source()
         self.assert_new_texture_created(self.video_format_2)
         self.assert_update_texture_unscheduled()
-        # schedule_once called for scheduling the next source update_texture
-        assert self.mock_clock.schedule_once.call_count == 1
+        # schedule_once called twice:
+        #   - Once for seeking back to 0 the previous source in next_source()
+        #   - Once for scheduling the next source update_texture
+        assert self.mock_clock.schedule_once.call_count == 2
         self.mock_clock.schedule_once.assert_called_with(self.player.update_texture, 0)
 
     def test_video_seek_next_frame(self):

--- a/tests/unit/media/test_player.py
+++ b/tests/unit/media/test_player.py
@@ -50,6 +50,7 @@ class PlayerTestCase(unittest.TestCase):
         type(mock_source).video_format = mock.PropertyMock(return_value=video_format)
         type(mock_source.get_queue_source.return_value).audio_format = mock.PropertyMock(return_value=audio_format)
         type(mock_source.get_queue_source.return_value).video_format = mock.PropertyMock(return_value=video_format)
+        type(mock_source.get_queue_source.return_value).duration = mock.PropertyMock(return_value=None)
         if video_format:
             mock_source.video_format.frame_rate = 30
         return mock_source

--- a/tests/unit/media/test_sources.py
+++ b/tests/unit/media/test_sources.py
@@ -9,6 +9,11 @@ from pyglet.media.drivers.base import MediaEvent
 from pyglet.media.codecs.base import *
 
 
+
+def _bytes_from_audiodata(audio_data):
+    return memoryview(audio_data.data).tobytes()
+
+
 class AudioFormatTestCase(unittest.TestCase):
     def test_equality_true(self):
         af1 = AudioFormat(2, 8, 44100)
@@ -30,11 +35,25 @@ class AudioFormatTestCase(unittest.TestCase):
         af1 = AudioFormat(1, 8, 22050)
         af2 = AudioFormat(2, 16, 44100)
 
-        self.assertEqual(af1.bytes_per_sample, 1)
+        self.assertEqual(af1.bytes_per_frame, 1)
         self.assertEqual(af1.bytes_per_second, 22050)
 
-        self.assertEqual(af2.bytes_per_sample, 4)
+        self.assertEqual(af2.bytes_per_frame, 4)
         self.assertEqual(af2.bytes_per_second, 176400)
+
+    def test_alignment(self):
+        af = AudioFormat(2, 16, 44100)
+
+        self.assertEqual(af.align(2049), 2048)
+        self.assertEqual(af.align(2048), 2048)
+        self.assertEqual(af.align(2047), 2044)
+        self.assertEqual(af.align(0), 0)
+        self.assertEqual(af.align(-1), -4)
+        self.assertEqual(af.align_ceil(2049), 2052)
+        self.assertEqual(af.align_ceil(2048), 2048)
+        self.assertEqual(af.align_ceil(2047), 2048)
+        self.assertEqual(af.align_ceil(0), 0)
+        self.assertEqual(af.align_ceil(-1), 0)
 
     def test_repr(self):
         af1 = AudioFormat(1, 8, 22050)
@@ -51,92 +70,26 @@ class AudioDataTestCase(unittest.TestCase):
     def create_string_buffer(self, data):
         return ctypes.create_string_buffer(data)
 
-    def test_consume_part_of_data(self):
-        audio_format = AudioFormat(1, 8, 11025)
-        duration = 1.0
-        length = int(duration * audio_format.bytes_per_second)
-        data = self.generate_random_string_data(length)
+    def test_pointer_bytes(self):
+        source_bytes = self.generate_random_string_data(2048)
+        assert len(source_bytes) == 2048
 
-        audio_data = AudioData(data, length, 0.0, duration, (MediaEvent(0.0, 'event'),))
+        audio_data = AudioData(source_bytes, 2048)
 
-        chunk_duration = 0.1
-        chunk_size = int(chunk_duration * audio_format.bytes_per_second)
-        self.assertLessEqual(chunk_size, length)
+        self.assertIsInstance(audio_data.pointer, int)
+        self.assertGreater(audio_data.pointer, 0)
 
-        audio_data.consume(chunk_size, audio_format)
+        retrieved_bytes = ctypes.string_at(audio_data.pointer, audio_data.length)
+        self.assertEqual(retrieved_bytes, source_bytes)
 
-        self.assertEqual(audio_data.length, length - chunk_size)
-        self.assertAlmostEqual(audio_data.duration, duration - chunk_duration, places=2)
-        self.assertAlmostEqual(audio_data.timestamp, chunk_duration, places=2)
+    def test_buffer_protocol(self):
+        d0 = AudioData(b"01234567", 8)
+        d1 = AudioData((ctypes.c_char * 24)(), 24)
+        d2 = AudioData(bytearray(64), 64)
 
-        self.assertEqual(audio_data.get_string_data(), data[chunk_size:])
-
-        self.assertTupleEqual(audio_data.events, ())
-
-    def test_consume_too_much_data(self):
-        audio_format = AudioFormat(1, 8, 11025)
-        duration = 1.0
-        length = int(duration * audio_format.bytes_per_second)
-        data = self.generate_random_string_data(length)
-
-        audio_data = AudioData(data, length, 0.0, duration, (MediaEvent(0.0, 'event'),))
-
-        chunk_duration = 1.1
-        chunk_size = int(chunk_duration * audio_format.bytes_per_second)
-        self.assertGreater(chunk_size, length)
-
-        audio_data.consume(chunk_size, audio_format)
-
-        self.assertEqual(audio_data.length, 0)
-        self.assertAlmostEqual(audio_data.duration, 0.0, places=2)
-        self.assertAlmostEqual(audio_data.timestamp, duration, places=2)
-
-        self.assertEqual(audio_data.get_string_data(), b'')
-
-        self.assertTupleEqual(audio_data.events, ())
-
-    def test_consume_non_str_data(self):
-        audio_format = AudioFormat(1, 8, 11025)
-        duration = 1.0
-        length = int(duration * audio_format.bytes_per_second)
-        data = self.generate_random_string_data(length)
-        non_str_data = self.create_string_buffer(data)
-
-        audio_data = AudioData(non_str_data, length, 0.0, duration, (MediaEvent(0.0, 'event'),))
-
-        chunk_duration = 0.1
-        chunk_size = int(chunk_duration * audio_format.bytes_per_second)
-        self.assertLessEqual(chunk_size, length)
-
-        audio_data.consume(chunk_size, audio_format)
-
-        self.assertEqual(audio_data.length, length - chunk_size)
-        self.assertAlmostEqual(audio_data.duration, duration - chunk_duration, places=2)
-        self.assertAlmostEqual(audio_data.timestamp, chunk_duration, places=2)
-
-        self.assertEqual(audio_data.get_string_data(), data[chunk_size:])
-
-        self.assertTupleEqual(audio_data.events, ())
-
-    def test_consume_only_events(self):
-        audio_format = AudioFormat(1, 8, 11025)
-        duration = 1.0
-        length = int(duration * audio_format.bytes_per_second)
-        data = self.generate_random_string_data(length)
-
-        audio_data = AudioData(data, length, 0.0, duration, (MediaEvent(0.0, 'event'),))
-
-        chunk_size = 0
-
-        audio_data.consume(chunk_size, audio_format)
-
-        self.assertEqual(audio_data.length, length)
-        self.assertAlmostEqual(audio_data.duration, duration, places=2)
-        self.assertAlmostEqual(audio_data.timestamp, 0., places=2)
-
-        self.assertEqual(audio_data.get_string_data(), data)
-
-        self.assertTupleEqual(audio_data.events, ())
+        self.assertEqual(_bytes_from_audiodata(d0), b"01234567")
+        self.assertEqual(_bytes_from_audiodata(d1), b"\x00" * 24)
+        self.assertEqual(_bytes_from_audiodata(d2), b"\x00" * 64)
 
 
 class SourceTestCase(unittest.TestCase):
@@ -181,18 +134,42 @@ class SourceTestCase(unittest.TestCase):
         self.assertIsInstance(animation, pyglet.image.Animation)
         self.assertEqual(len(animation.frames), 0)
 
-
-class StreamingSourceTestCase(unittest.TestCase):
     def test_can_queue_only_once(self):
         source = StreamingSource()
         self.assertFalse(source.is_player_source)
 
         ret = source.get_queue_source()
-        self.assertIs(ret, source)
+        self.assertTrue(ret.is_player_source)
         self.assertTrue(source.is_player_source)
 
         with self.assertRaises(MediaException):
             source.get_queue_source()
+
+        ret.is_player_source = False
+        self.assertFalse(ret.is_player_source)
+        self.assertFalse(source.is_player_source)
+
+        ret = source.get_queue_source()
+        with self.assertRaises(MediaException):
+            ret.get_queue_source()
+
+    def test_precise_queue_source(self):
+        source = StreamingSource()
+        with mock.patch.object(source, "is_precise", lambda: True):
+            qsource = source.get_queue_source()
+            self.assertIs(qsource, source)
+            self.assertTrue(qsource.is_player_source)
+
+    def test_nonprecise_queue_source(self):
+        source = Source()
+        qsource = source.get_queue_source()
+        self.assertIsNot(qsource, source)
+        self.assertIsInstance(qsource, PreciseStreamingSource)
+
+        source = StreamingSource()
+        qsource = source.get_queue_source()
+        self.assertIsNot(qsource, source)
+        self.assertIsInstance(qsource, PreciseStreamingSource)
 
 
 class StaticSourceTestCase(unittest.TestCase):
@@ -213,10 +190,10 @@ class StaticSourceTestCase(unittest.TestCase):
             return AudioData(data, len(data), 0.0, 1.0, ())
         self.mock_queue_source.get_audio_data.side_effect = _get_audio_data
 
-        type(self.mock_queue_source).audio_format = mock.PropertyMock(return_value=AudioFormat(channels, bitrate, 11025))
-        type(self.mock_queue_source).video_format = mock.PropertyMock(return_value=None)
-        type(self.mock_source).audio_format = mock.PropertyMock(return_value=AudioFormat(channels, bitrate, 11025))
-        type(self.mock_source).video_format = mock.PropertyMock(return_value=None)
+        self.mock_queue_source.audio_format = AudioFormat(channels, bitrate, 11025)
+        self.mock_queue_source.video_format = None
+        self.mock_source.audio_format = AudioFormat(channels, bitrate, 11025)
+        self.mock_source.video_format = None
 
 
     def test_reads_all_data_on_init(self):
@@ -228,12 +205,12 @@ class StaticSourceTestCase(unittest.TestCase):
 
         # Try to read all data plus more, more should be ignored
         returned_audio_data = static_source.get_queue_source().get_audio_data(len(self.mock_audio_data) + 1024)
-        self.assertEqual(returned_audio_data.get_string_data(), self.mock_audio_data, 'All data from the mock should be returned')
+        self.assertEqual(_bytes_from_audiodata(returned_audio_data), self.mock_audio_data, 'All data from the mock should be returned')
         self.assertAlmostEqual(returned_audio_data.duration, 5.0)
 
     def test_video_not_supported(self):
         self.create_valid_mock_source()
-        type(self.mock_queue_source).video_format = mock.PropertyMock(return_value=VideoFormat(800, 600))
+        self.mock_queue_source.video_format = VideoFormat(800, 600)
 
         with self.assertRaises(NotImplementedError):
             static_source = StaticSource(self.mock_source)
@@ -247,7 +224,7 @@ class StaticSourceTestCase(unittest.TestCase):
         returned_audio_data = queue_source.get_audio_data(len(self.mock_audio_data))
         self.assertAlmostEqual(returned_audio_data.duration, 4.0)
         self.assertEqual(returned_audio_data.length, len(self.mock_audio_data)-11025)
-        self.assertEqual(returned_audio_data.get_string_data(), self.mock_audio_data[11025:], 'Should have seeked past 1 second')
+        self.assertEqual(_bytes_from_audiodata(returned_audio_data), self.mock_audio_data[11025:], 'Should have seeked past 1 second')
 
     def test_multiple_queued(self):
         self.create_valid_mock_source()
@@ -267,7 +244,7 @@ class StaticSourceTestCase(unittest.TestCase):
         returned_audio_data = queue_source1.get_audio_data(len(self.mock_audio_data))
         self.assertAlmostEqual(returned_audio_data.duration, 4.0)
         self.assertEqual(returned_audio_data.length, len(self.mock_audio_data)-11025)
-        self.assertEqual(returned_audio_data.get_string_data(), self.mock_audio_data[11025:], 'Should have seeked past 1 second')
+        self.assertEqual(_bytes_from_audiodata(returned_audio_data), self.mock_audio_data[11025:], 'Should have seeked past 1 second')
 
     def test_seek_aligned_to_sample_size_2_bytes(self):
         self.create_valid_mock_source(bitrate=16, channels=1)
@@ -278,14 +255,6 @@ class StaticSourceTestCase(unittest.TestCase):
         returned_audio_data = queue_source.get_audio_data(len(self.mock_audio_data))
         self.assertEqual(returned_audio_data.length % 2, 0, 'Must seek and return aligned to 2 byte chunks')
 
-    def test_consume_aligned_to_sample_size_2_bytes(self):
-        self.create_valid_mock_source(bitrate=16, channels=1)
-        static_source = StaticSource(self.mock_source)
-
-        queue_source = static_source.get_queue_source()
-        returned_audio_data = queue_source.get_audio_data(1000*2+1)
-        self.assertEqual(returned_audio_data.length % 2, 0, 'Must return aligned to 2 byte chunks')
-
     def test_seek_aligned_to_sample_size_4_bytes(self):
         self.create_valid_mock_source(bitrate=16, channels=2)
         static_source = StaticSource(self.mock_source)
@@ -295,23 +264,15 @@ class StaticSourceTestCase(unittest.TestCase):
         returned_audio_data = queue_source.get_audio_data(len(self.mock_audio_data))
         self.assertEqual(returned_audio_data.length % 4, 0, 'Must seek and return aligned to 4 byte chunks')
 
-    def test_consume_aligned_to_sample_size_4_bytes(self):
-        self.create_valid_mock_source(bitrate=16, channels=2)
-        static_source = StaticSource(self.mock_source)
-
-        queue_source = static_source.get_queue_source()
-        returned_audio_data = queue_source.get_audio_data(1000*4+3)
-        self.assertEqual(returned_audio_data.length % 4, 0, 'Must return aligned to 4 byte chunks')
-
     def test_empty_source(self):
         """Test that wrapping an empty source does not cause trouble."""
         self.mock_source = mock.MagicMock()
         self.mock_queue_source = self.mock_source.get_queue_source.return_value
 
-        type(self.mock_queue_source).audio_format = mock.PropertyMock(return_value=None)
-        type(self.mock_queue_source).video_format = mock.PropertyMock(return_value=None)
-        type(self.mock_source).audio_format = mock.PropertyMock(return_value=None)
-        type(self.mock_source).video_format = mock.PropertyMock(return_value=None)
+        self.mock_queue_source.audio_format = None
+        self.mock_queue_source.video_format = None
+        self.mock_source.audio_format = None
+        self.mock_source.video_format = None
 
         static_source = StaticSource(self.mock_source)
 
@@ -338,3 +299,52 @@ class StaticSourceTestCase(unittest.TestCase):
         self.assertIsNone(no_more_audio_data)
 
 
+@unittest.skip('Too dangerous to modify 2.0.x\'s SourceGroups, this test will fail for them')
+class SourceGroupTestCase(unittest.TestCase):
+    def test_empty(self):
+        group = SourceGroup()
+        self.assertIsNone(group.get_audio_data(2048))
+
+    def test_functionality(self):
+        fake_data = ((b'a', 1000, 0.5), (b'b', 40000, 2.0), (b'c', 20000, 4.0), (b'd', 9992, 4.0))
+        audio_data = [AudioData(b * l, l) for b, l, _ in fake_data]
+        audio_data[0].timestamp = 1.23
+
+        expected_data = b''.join(d * l for d, l, _ in fake_data)
+        expected_duration = sum(d for _, _, d in fake_data)
+        total_length = len(expected_data)
+
+        sources = [mock.MagicMock(audio_format=AudioFormat(2, 8, 11025)) for _ in range(4)]
+        exhausted = [False] * 4
+
+        for i, mock_source in enumerate(sources):
+            def _get_audio_data(_, j=i):
+                if exhausted[j]:
+                    return None
+                exhausted[j] = True
+                return audio_data[j]
+
+            mock_source.duration = fake_data[i][2]
+            mock_source.get_audio_data.side_effect = _get_audio_data
+            mock_source.get_queue_source.return_value = mock_source
+
+        group = SourceGroup()
+        for mock_source in sources:
+            group.add(mock_source)
+
+        ret_data = group.get_audio_data(total_length)
+        self.assertEqual(expected_data, ret_data.data)
+        self.assertAlmostEqual(ret_data.timestamp, 1.23)
+        self.assertAlmostEqual(ret_data.duration, expected_duration)
+
+    def test_inequal_audio_format(self):
+        source_a = mock.Mock(audio_format=AudioFormat(1, 8, 44100), duration=None)
+        source_b = mock.Mock(audio_format=AudioFormat(2, 16, 44100), duration=None)
+        source_a.get_queue_source.return_value = source_a
+        source_b.get_queue_source.return_value = source_b
+
+        group = SourceGroup()
+        group.add(source_a)
+        self.assertEqual(group.audio_format, source_a.audio_format)
+        with self.assertRaises(MediaException):
+            group.add(source_b)


### PR DESCRIPTION
Well, gotta get this started somehow.
This PR contains significant changes to all audio driver implementations as well as slight changes (which should by all means be non-destructive and allow to keep 2.0.x compatability) to the `Source`s.
This should be thoroughly tested with many real examples on all platforms before going further.

## Highlights
### Automated syncing
High level players' clocks are seen as the master syncing point for a video/sound.  
Previously, whenever an audio player would deviate from its player's clock, nothing would get it back in line with it, leading to desync if a video should buffer or if an audio backend suffers from a creeping desync over a longer period.  
pyglet had a synchronization feature with the `compensation_time` parameter, but it was unstable and supposed to be implemented by drivers. The only decoder that to my knowledge did this was ffmpeg, which did so rather often by slowing down/resampling audio by very noticeable amounts, which wasn't really a blast to listen to.  
All other internal decoders completely ignore this parameter.

Now, a flat average of the last few play cursor position is kept every time an audio player requests new data. If this average exceeds 30ms in any direction, 12ms samples are either dropped or repeated (embedding silence) which is noticeable but only if you really actively listen to it.  
The compensated byte count is then faked back into relevant calculations involving the play cursor, so it's as if the player is still on track, even if the hard drive were to be unplugged for a few seconds.  
If at any point an audio player lags behind its high level player's clock by more than 280ms, the desync is considered extreme, the flat average is reset and the entire difference is requested and skipped. This is not done if the audio player should start running **ahead** of its clock, as A: it's unlikely to ever happen and B: i am trying to not run seek operations on the source behind the client's back.

### Deprecation of the `compensation_time` parameter.
Tying directly into the previous point, this parameter will unconditionally be given as `0.0` by all pyglet internals and should ideally be gone by pyglet `2.1`.

### High level player changes
Addition of `last_seek_time`. This is a value simply set to the last time sought to. Used for player syncing, so that audio players do not have to remember their position in the source between seeks.
**This might pose danger to pyglet 2.0.x compatability. A source that does not seek accurately will cause trouble for the new audio backend.**

Some slightly more robust handling of sources and ensuring the unsetting of `is_player_source` upon a high level player's destruction.

For now, high level players will run an additional check and apply `PreciseStreamingSource`s to their queue elements directly. This is done due to the relatively unreliable inheritance strategy of sources. If this check were to be added to `Source.get_queue_source`, it can't be certain that it will be called, as `StreamingSource.get_queue_source` does not contain an appropiate `super()` call. With this bandaid, user code for `2.0.x` should be safe.

### `AudioData` improvements
The purpose of `AudioData` is admittably subjective. In my eyes, it is used to contain decoded audio data and pass it to backends, being not much more than a messenger from a `Source` to an audio player.  
Its containment of timing information is thus unfitting, as `AudioData` contains a second set of half-information through `timestamp` and `duration`. Knowing the timestamp of an `AudioData` packet in a void is practically not required, and the `duration` depends on the sample rate you play it with, which should be known by whatever receives the `AudioData`.  
This information is retrieved by audio players through more ideal ways now, especially as most decoders were incorrectly providing it in the first place and it anyway was used only for the rather fragile and practically unused dispatching of `MediaEvent`s.

The `consume` method present on them was capable of mutating `AudioData` by slicing it, changing its `duration`/`timestamp`/`length`, copying data unnecessarily and also containing a bug had it received a ctypes array of a type whose size was not 1.  
Thanks to audio player rewrites and the `PreciseStreamingSource` this method is not needed anymore and has been removed.

The `get_string_data` method was removed, as it proved unnecessary to get this data out of `AudioData` by copying it into a Python object beforehand.  
All usage sites have been changed to either use `data`, which is sure to support the buffer protocol, or, in case of the tests, been given a small function with the equivalent body.

A `pointer` attribute has been added, which is an int with the direct memory address pointing to the data contained to the data in the `AudioData`.  
It is fetched on `AudioData` initialization. `AudioData.pointer` is now how the data is passed to the ctypes functions by all audio data backends.  
No compromises on formats have been made, in fact, `AudioData` can now be constructed from `bytes`, `ctypes` objects, or anything exposing a writable buffer.  
(Sadly, readable buffers are knowingly excluded, as ctypes refuses to create those without a copy. The C-API hack required to get a buffer from out of an object on `<=3.11` would be too funky, if possible at all.)

### Alignment
Audio frame alignment is not a new term by any means, but simply defines whether a given amout of bytes contain a clean number of audio frames.  
(A frame being 2 shorts (4 bytes) for a two-channel 16bit source, 1 byte for a mono 8bit source etc.)  

This alignment was never really enforced, as most backends (such as observably PulseAudio and OpenAL) have it as a silent contract; making only aligned requests themselves or erroring when attempting to buffer non-aligned-sized data respectively.  
Most sources contained rounding operations that at some point caused the amount of requested bytes to be corrected, but this was always hazy and never explicitly stated.  
So: pyglet will now never make call `get_audio_data` with a number of bytes that does not align to the source's `audio_format`.
(Admittedly this is a statement built on sand, as all calculations just happen to kinda work, involving multiplications and constant factors that play nice with the fact pyglet effectively only supports audio frames of sizes 1,2 or 4.)

### Minimum request size
As a bonus to the previous point, pyglet will now not `get_audio_data` with a requested size of 0 bytes, eradicating "empty `AudioData` or source empty?" ambiguity.  
In fact, to have a reasonable minimum for an operation that might involve I/O, requests will always be at least 1024 bytes.

### Precise sources
Sources now have a new method: `is_precise()`. By default, it returns `False` and it determines whether a source is precise.  
What does that even mean? Let me quote its docstring:
> ``x`` bytes on source ``s`` are considered aligned if
> ``x % s.audio_format.bytes_per_frame == 0``, so there'd be no partial
> audio frame in the returned data.
> 
> A source is precise if - for an aligned request of ``x`` bytes - it
> returns:
> - If ``x`` or more bytes are available, ``x`` bytes.
> - If not enough bytes are available anymore, ``r`` bytes where
>   ``r < x`` and ``r`` is aligned.
> 
> A source is **not** precise if it does any of these:
>  - Return less than ``x`` bytes for an aligned request of ``x``
>    bytes although data still remains so that an additional request
>    would return additional :class:`.AudioData` / not ``None``.
>  - Return more bytes than requested.
>  - Return an unaligned amount of bytes for an aligned request.

And since pyglet now doesn't make unaligned requests, sources don't need to worry about getting those at all anymore.

The `is_precise()` method is supposed to be overridden by `Source` subclasses to mark them as precise.  
This allows audio players to request data from them directly, knowing for sure that they will either get exactly as many bytes as requested or less.

This ties into the removal of the `AudioData.consume` method as well.  
Some kind of `AudioData` buffer was maintained by a few audio player implementations, but now they no longer need to worry about cutting up the received amount of data anymore.  
If a source is imprecise, pyglet will wrap it in a `PreciseStreamingSource` before passing it into audio drivers. This is what performs the "cutting up" now.  
This will create overhead copying data around in bytearrays, so it's generally a good idea to use/write precise decoders.

### Typing
Large parts of `player.py` and `codecs/base.py` have been enhanced with type annotations.  

Typing of some audio player implementations exists as well, but is irrelevant for anything public facing.

### Various audio driver improvements
Most audio backends now use weakrefs and `__del__` in a far less frequent manner, favoring controlled teardown above manual refcycle management.

All audio drivers are fundamentally rewritten to use a `PlayerWorkerThread`, only ever 
reading/streaming audio data from this thread.

All audio drivers are now safe against repeated calls to `delete()`.

### Various audio player improvements
All audio player implementations now share more common code for buffer sizing, refilling and event dispatching.

As with the drivers, greatly reduced usage of `__del__`.

No more usage of `AudioData`'s `.duration` and `.timestamp`s to report the time. Time reporting has largely been reduced to the most recent play cursor, which is then processed by the common `AbstractAudioPlayer` class in conjunction with the new `Player.last_seek_time`.

### OpenAL changes
There now is only one buffer pool per device, as opposed to each source creating its own, which should greatly optimize things via their reusage.

### PulseAudio changes
Has gone through the biggest rewrite, fixing at least one instance of a missing mainloop lock (while hopefully not introducing more).

Deadlock involving the `PulseAudioMainloop.wait` method fixed.  
This deadlock could be reproduced consistently by creating around 20 balls in the `noisy` example and waiting for a few seconds.

Submits data from within the write callback instantly if available, else waits for the worker thread.

Now uses pa_stream_begin_write, though other than PA recommending it, it now makes Python responsible for copying.

### XAudio2 changes
Does not refill data from within engine callbacks anymore.

Voice resetting/flushing is now responsibility of the driver. This process will now also reset `SamplesPlayed` by playing silence tagged with `XAUDIO2_END_OF_STREAM`.

Now dispatches `MediaEvent`s as granularly as its `work` method runs, not every time a buffer is removed.

Voice keys do not include sample rate anymore, instead just setting it on retrieval with `SetSourceVoiceSampleRate`, which allows for less strict recycling of voices.

Now properly deals with the astronomically unlikely event of underflowing and the source running out afterwards due to I/O hang.

Has been fitted with an engine lock in order to avoid more very unlikely, but, if i didn't think incorrectly, possible, race conditions.

### Silent changes
The silent audio driver now behaves like an actual audio driver, requesting audio data and dispatching events.


## Smaller changes
Players are now explicitly `.delete()`d in the `Source.play` fire-and-forget function.

`AbstractAudioPlayer.get_time()` has been removed.  
It usually was not necessary to have a 100% accurate time that queried the audio backend in the places this function was used, those being a debug statement and the tests.

All relevant tests have been changed along to still work with the new architecture properly.

## Things that still need clarification/work:
- The documentation.
  - [ ] The only changes are present in `media/base.py`/some sources and very minor ones in `media/player.py`. They need some more looks.
  - [X] The developer guide to the media module is very out of date and even more so with this rework. Should it be updated?  
    Will look into it at a later point, ideally once this is merged in with any potential changes that may still come up.
- [X] The `__hold_on` hack: Somewhere in `player.py`'s source swapping logic, this variable is used to hold on to a source as otherwise accessing it via a weakref ~~has a chance to hang. This is weird, usually you'd expect an error about the object being expired.~~  
This error turned out to be caused by pyglet's `dispatch_posted_events` suppressing `ReferenceError`s. The "hang" was just the `next_source` method erroring out, causing the player to stop acting.
- [ ] `duration` is now important to clamp seek timestamps (see `last_seek_time`), or should the given timestamps already be clamped? The current documentation is a bit ambiguous on this.
- [ ] Review of the typing; it's definitely not perfect.


## Issues confirmed to be fixed:
 - #393 (ffmpeg resampling)
 - #497 (ffmpeg resampling)
 - #424 (OpenAL fails looping short sounds)

## Issues possibly fixed:
 - #407 (No sound with PulseAudio driver)
 - #952 (PulseAudio exception)
 - #836 (OpenAL assertion errors non-reproducible due to partial source code)
 - #576 ("distortions in both image stream and audio")
 - #669 (XAudio2 \_\_del\_\_-related shutdown exceptions )

I'd be very thankful for even the tiniest bit of feedback, nitpicking and any test results, positive or negative.
Especially Mac and Windows tests are still needed.
That's the end of the initial post, thank you for reading.
