### PR TITLE
Fixes for Python 3.12

### DIFF
--- a/pyglet/font/win32.py
+++ b/pyglet/font/win32.py
@@ -532,6 +532,12 @@ class GDIPlusFont(Win32Font):
         self._name = name
 
         family = ctypes.c_void_p()
+
+        # GDI will add @ in front of a localized font for some Asian languages. However, GDI will also not find it
+        # based on that name (???). Here we remove it before checking font collections.
+        if name[0] == "@":
+            name = name[1:]
+
         name = ctypes.c_wchar_p(name)
 
         # Look in private collection first:
@@ -540,6 +546,9 @@ class GDIPlusFont(Win32Font):
 
         # Then in system collection:
         if not family:
+            if _debug_font:
+                print(f"Warning: Font '{name}' was not found. Defaulting to: {self._default_name}")
+
             gdiplus.GdipCreateFontFamilyFromName(name, None, ctypes.byref(family))
 
         # Nothing found, use default font.

--- a/pyglet/font/win32.py
+++ b/pyglet/font/win32.py
@@ -336,7 +336,7 @@ class GDIPlusGlyphRenderer(Win32GlyphRenderer):
             pass
 
     def _create_bitmap(self, width, height):
-        self._data = (ctypes.c_byte * (4 * width * height))()
+        self._data = (BYTE * (4 * width * height))()
         self._bitmap = ctypes.c_void_p()
         self._format = PixelFormat32bppARGB
         gdiplus.GdipCreateBitmapFromScan0(width, height, width * 4,

--- a/pyglet/image/codecs/wic.py
+++ b/pyglet/image/codecs/wic.py
@@ -601,7 +601,7 @@ class WICEncoder(ImageEncoder):
 
         frame.SetPixelFormat(byref(default_format))
 
-        data = (c_byte * size).from_buffer(bytearray(image_data))
+        data = (BYTE * size).from_buffer(bytearray(image_data))
 
         frame.WritePixels(image.height, pitch, size, data)
 

--- a/pyglet/input/win32/xinput.py
+++ b/pyglet/input/win32/xinput.py
@@ -113,8 +113,8 @@ ERROR_SUCCESS = 0
 class XINPUT_GAMEPAD(Structure):
     _fields_ = [
         ('wButtons', WORD),
-        ('bLeftTrigger', UBYTE),
-        ('bRightTrigger', UBYTE),
+        ('bLeftTrigger', BYTE),
+        ('bRightTrigger', BYTE),
         ('sThumbLX', SHORT),
         ('sThumbLY', SHORT),
         ('sThumbRX', SHORT),

--- a/pyglet/libs/win32/types.py
+++ b/pyglet/libs/win32/types.py
@@ -1,4 +1,5 @@
 import ctypes
+import sys
 
 from ctypes import *
 from ctypes.wintypes import *
@@ -45,7 +46,6 @@ def POINTER_(obj):
 
 c_void_p = POINTER_(c_void)
 INT = c_int
-UBYTE = c_ubyte
 LPVOID = c_void_p
 HCURSOR = HANDLE
 LRESULT = LPARAM
@@ -61,6 +61,11 @@ LONG_PTR = HANDLE
 HDROP = HANDLE
 LPTSTR = LPWSTR
 LPSTREAM = c_void_p
+
+# Fixed in python 3.12. Is c_byte on other versions.
+# Ensure it's the same across all versions.
+if sys.version_info < (3, 12):
+    BYTE = c_ubyte
 
 LF_FACESIZE = 32
 CCHDEVICENAME = 32
@@ -572,12 +577,14 @@ class IStream(com.pIUnknown):
          com.STDMETHOD()),
     ]
 
+
 class DEV_BROADCAST_HDR(Structure):
     _fields_ = (
         ('dbch_size', DWORD),
         ('dbch_devicetype', DWORD),
         ('dbch_reserved', DWORD),
     )
+
 
 class DEV_BROADCAST_DEVICEINTERFACE(Structure):
     _fields_ = (


### PR DESCRIPTION
Overwrite BYTE for older Python versions to the correct type
Adjust datatypes to ensure proper usage of BYTE.
Add check for localized font name for GDIPlus Font renderer.
Add debug message if font falls back to default font name.

Should resolve: https://github.com/pyglet/pyglet/issues/964