### PR TITLE
Add basic clipboard support.

### DIFF
--- a/examples/clipboard.py
+++ b/examples/clipboard.py
@@ -1,0 +1,18 @@
+import pyglet
+
+"""Simple example demonstrating how to get the text in the clipboard as well as putting text in the clipboard."""
+
+window = pyglet.window.Window()
+
+print("Existing Clipboard Text:", window.get_clipboard_text())
+
+@window.event
+def on_key_press(symbol, modifiers):
+    print("Clipboard changed to: Hello World!")
+
+    window.set_clipboard_text("Hello World!")
+
+    print("Clipboard Text:", window.get_clipboard_text())
+
+
+pyglet.app.run()

--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -218,6 +218,7 @@ NSApplicationDidUnhideNotification = c_void_p.in_dll(appkit, 'NSApplicationDidUn
 NSApplicationDidUpdateNotification = c_void_p.in_dll(appkit, 'NSApplicationDidUpdateNotification')
 NSPasteboardURLReadingFileURLsOnlyKey = c_void_p.in_dll(appkit, 'NSPasteboardURLReadingFileURLsOnlyKey')
 NSPasteboardTypeURL = c_void_p.in_dll(appkit, 'NSPasteboardTypeURL')
+NSPasteboardTypeString = c_void_p.in_dll(appkit, 'NSPasteboardTypeString')
 NSDragOperationGeneric = 4
 
 # /System/Library/Frameworks/AppKit.framework/Headers/NSEvent.h

--- a/pyglet/libs/win32/__init__.py
+++ b/pyglet/libs/win32/__init__.py
@@ -211,7 +211,18 @@ _user32.RegisterDeviceNotificationW.restype = HANDLE
 _user32.RegisterDeviceNotificationW.argtypes = [HANDLE, LPVOID, DWORD]
 _user32.UnregisterDeviceNotification.restype = BOOL
 _user32.UnregisterDeviceNotification.argtypes = [HANDLE]
-
+_user32.SetClipboardData.restype = HANDLE
+_user32.SetClipboardData.argtypes = [UINT, HANDLE]
+_user32.EmptyClipboard.restype = BOOL
+_user32.EmptyClipboard.argtypes = []
+_user32.OpenClipboard.restype = BOOL
+_user32.OpenClipboard.argtypes = [HWND]
+_user32.CloseClipboard.restype = BOOL
+_user32.CloseClipboard.argtypes = []
+_user32.GetClipboardData.restype = HANDLE
+_user32.GetClipboardData.argtypes = [UINT]
+_user32.SetClipboardData.restype = HANDLE
+_user32.SetClipboardData.argtypes = [UINT, HANDLE]
 
 # dwmapi
 _dwmapi.DwmIsCompositionEnabled.restype = c_int

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -791,6 +791,25 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
         """
         raise NotImplementedError()
 
+    def get_clipboard_text(self) -> str:
+        """Access the system clipboard and attempt to retrieve text.
+
+        :rtype: `str`
+        :return: A string from the clipboard. String will be empty if no text found.
+        """
+        raise NotImplementedError()
+
+    def set_clipboard_text(self, text: str):
+        """Access the system clipboard and set a text string as the clipboard data.
+
+        This will clear the existing clipboard.
+
+        :Parameters:
+            `text` : str
+                Text you want to place in the clipboard.
+        """
+        raise NotImplementedError()
+
     def minimize(self):
         """Minimize the window.
         """

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -21,6 +21,7 @@ NSColor = cocoapy.ObjCClass('NSColor')
 NSEvent = cocoapy.ObjCClass('NSEvent')
 NSArray = cocoapy.ObjCClass('NSArray')
 NSImage = cocoapy.ObjCClass('NSImage')
+NSPasteboard = cocoapy.ObjCClass('NSPasteboard')
 
 quartz = cocoapy.quartz
 cf = cocoapy.cf
@@ -566,6 +567,33 @@ class CocoaWindow(BaseWindow):
 
         NSApp = NSApplication.sharedApplication()
         NSApp.setPresentationOptions_(options)
+
+    def set_clipboard_text(self, text: str):
+        with AutoReleasePool():
+            pasteboard = NSPasteboard.generalPasteboard()
+
+            pasteboard.clearContents()
+
+            array = NSArray.arrayWithObject_(cocoapy.NSPasteboardTypeString)
+            pasteboard.declareTypes_owner_(array, None)
+
+            text_nsstring = cocoapy.get_NSString(text)
+
+            pasteboard.setString_forType_(text_nsstring, cocoapy.NSPasteboardTypeString)
+
+    def get_clipboard_text(self) -> str:
+        text = ''
+        with AutoReleasePool():
+            pasteboard = NSPasteboard.generalPasteboard()
+
+            if pasteboard.types().containsObject_(cocoapy.NSPasteboardTypeString):
+                text_obj = pasteboard.stringForType_(cocoapy.NSPasteboardTypeString)
+                if text_obj:
+                    text = text_obj.UTF8String().decode('utf-8')
+
+        return text
+
+
 
 
 __all__ = ["CocoaWindow"]

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -2,6 +2,7 @@ import unicodedata
 import urllib.parse
 from ctypes import *
 from functools import lru_cache
+from typing import Optional
 
 import pyglet
 from pyglet.window import WindowException, MouseCursorException
@@ -25,6 +26,7 @@ try:
 except ImportError:
     _have_xsync = False
 
+_debug = pyglet.options['debug_x11']
 
 class mwmhints_t(Structure):
     _fields_ = [
@@ -44,6 +46,7 @@ _can_detect_autorepeat = None
 
 XA_CARDINAL = 6  # Xatom.h:14
 XA_ATOM = 4
+XA_STRING = 31
 
 XDND_VERSION = 5
 
@@ -139,6 +142,9 @@ class XlibWindow(BaseWindow):
                                                                 byref(supported_rtrn))
         if _can_detect_autorepeat:
             self.pressed_keys = set()
+
+        # Store clipboard string to not query as much for pasting a lot.
+        self._clipboard_str: Optional[str] = None
 
     def _recreate(self, changes):
         # If flipping to/from fullscreen, need to recreate the window.  (This
@@ -284,6 +290,16 @@ class XlibWindow(BaseWindow):
 
             # Atoms required for Xdnd
             self._create_xdnd_atoms(self._x_display)
+
+            # Clipboard related atoms
+            self._clipboard_atom = xlib.XInternAtom(self._x_display, asbytes('CLIPBOARD'), False)
+            self._utf8_atom = xlib.XInternAtom(self._x_display, asbytes('UTF8_STRING'), False)
+            self._target_atom = xlib.XInternAtom(self._x_display, asbytes('TARGETS'), False)
+            self._incr_atom = xlib.XInternAtom(self._x_display, asbytes('INCR'), False)
+            self._clipboard_mgr_atom = xlib.XInternAtom(self._x_display, asbytes('CLIPBOARD_MANAGER'), False)
+
+            #self._clipboard_mgr_targets = xlib.XInternAtom(self._x_display, asbytes('SAVE_TARGETS'), False)
+            #self._selection_atom = xlib.XInternAtom(self._x_display, asbytes('PYGLET_SELECTION'), False)
 
             # Support for drag and dropping files needs to be enabled.
             if self._file_drops:
@@ -795,6 +811,73 @@ class XlibWindow(BaseWindow):
         atom = xlib.XInternAtom(self._x_display, asbytes('_NET_WM_ICON'), False)
         xlib.XChangeProperty(self._x_display, self._window, atom, XA_CARDINAL,
                              32, xlib.PropModeReplace, buffer, len(data)//sizeof(c_ulong))
+
+    def set_clipboard_text(self, text: str):
+        xlib.XSetSelectionOwner(self._x_display,
+                                self._clipboard_atom,
+                                self._window,
+                                xlib.CurrentTime)
+
+        if xlib.XGetSelectionOwner(self._x_display, self._clipboard_atom) == self._window:
+            self._clipboard_str = text
+            str_bytes = text.encode('utf-8')
+            size = len(str_bytes)
+
+            xlib.XChangeProperty(self._x_display, self._window,
+                                 self._clipboard_atom, self._utf8_atom, 8, xlib.PropModeReplace,
+                                 (c_ubyte * size).from_buffer_copy(str_bytes), size)
+        else:
+            if _debug:
+                print("X11: Couldn't become owner of clipboard.")
+
+    def get_clipboard_text(self) -> str:
+        if self._clipboard_str is not None:
+            return self._clipboard_str
+
+        owner = xlib.XGetSelectionOwner(self._x_display, self._clipboard_atom)
+
+        if not owner:
+            return ''
+
+        text = ''
+        if owner == self._window:
+            data, size, actual_atom = self.get_single_property(self._window, self._clipboard_atom,
+                                                  self._utf8_atom)
+        else:
+            notification = xlib.XEvent()
+
+            # Convert to selection notification.
+            xlib.XConvertSelection(self._x_display,
+                                   self._clipboard_atom,
+                                   self._utf8_atom,
+                                   self._clipboard_atom,
+                                   self._window,
+                                   xlib.CurrentTime)
+
+            while not xlib.XCheckTypedWindowEvent(self._x_display, self._window, xlib.SelectionNotify, byref(notification)):
+                self.dispatch_platform_event(notification)
+
+            if not notification.xselection.property:
+                return ''
+
+            data, size, actual_atom = self.get_single_property(notification.xselection.requestor, notification.xselection.property,
+                                                  self._utf8_atom)
+
+        if actual_atom == self._incr_atom:
+            # Not implemented.
+            if _debug:
+                print("X11: Clipboard data is too large, not implemented.")
+
+        elif actual_atom == self._utf8_atom:
+            if data:
+                text_bytes = string_at(data, size)
+
+                text = text_bytes.decode('utf-8')
+
+        self._clipboard_str = text
+
+        xlib.XFree(data)
+        return text
 
     # Private utility
 
@@ -1326,7 +1409,7 @@ class XlibWindow(BaseWindow):
             xlib.XFree(data)
 
     def get_single_property(self, window, atom_property, atom_type):
-        """ Returns the length and data of a window property. """
+        """ Returns the length, data, and actual atom of a window property. """
         actualAtom = xlib.Atom()
         actualFormat = c_int()
         itemCount = c_ulong()
@@ -1341,14 +1424,14 @@ class XlibWindow(BaseWindow):
                                 byref(bytesAfter),
                                 data)
 
-        return data, itemCount.value
+        return data, itemCount.value, actualAtom.value
 
     @XlibEventHandler(xlib.SelectionNotify)
     def _event_selection_notification(self, ev):
         if ev.xselection.property != 0 and ev.xselection.selection == self._xdnd_atoms['XdndSelection']:
             if self._xdnd_format:
                 # This will get the data
-                data, count = self.get_single_property(ev.xselection.requestor,
+                data, count, _ = self.get_single_property(ev.xselection.requestor,
                                                          ev.xselection.property,
                                                          ev.xselection.target)
 
@@ -1511,6 +1594,62 @@ class XlibWindow(BaseWindow):
     def _event_unmapnotify(self, ev):
         self._mapped = False
         self.dispatch_event('on_hide')
+
+    @XlibEventHandler(xlib.SelectionClear)
+    def _event_selection_clear(self, ev):
+        if ev.xselectionclear.selection == self._clipboard_atom:
+            # Another application cleared the clipboard.
+            self._clipboard_str = None
+
+    @XlibEventHandler(xlib.SelectionRequest)
+    def _event_selection_request(self, ev):
+        request = ev.xselectionrequest
+
+        if _debug:
+            rt = xlib.XGetAtomName(self._x_display, request.target)
+            rp = xlib.XGetAtomName(self._x_display, request.property)
+            print(f"X11 debug: request target {rt}")
+            print(f"X11 debug: request property {rp}")
+
+        out_event = xlib.XEvent()
+        out_event.xany.type = xlib.SelectionNotify
+        out_event.xselection.selection = request.selection
+        out_event.xselection.display = request.display
+        out_event.xselection.target = 0
+        out_event.xselection.property = 0
+        out_event.xselection.requestor = request.requestor
+        out_event.xselection.time = request.time
+
+        if (xlib.XGetSelectionOwner(self._x_display, self._clipboard_atom) == self._window and
+                ev.xselection.target == self._clipboard_atom):
+            if request.target == self._target_atom:
+                atoms_ar = (xlib.Atom * 1)(self._utf8_atom)
+                ptr = cast(pointer(atoms_ar), POINTER(c_ubyte))
+
+                xlib.XChangeProperty(self._x_display, request.requestor,
+                                     request.property, XA_ATOM, 32,
+                                     xlib.PropModeReplace,
+                                     ptr, sizeof(atoms_ar)//sizeof(c_ulong))
+                out_event.xselection.property = request.property
+                out_event.xselection.target = request.target
+
+            elif request.target == self._utf8_atom:
+                # We are being requested for a UTF-8 string.
+                text = self._clipboard_str.encode('utf-8')
+                size = len(self._clipboard_str)
+                xlib.XChangeProperty(self._x_display, request.requestor,
+                                     request.property, request.target, 8,
+                                     xlib.PropModeReplace,
+                                     (c_ubyte * size).from_buffer_copy(text), size)
+
+                out_event.xselection.property = request.property
+                out_event.xselection.target = request.target
+
+        # Send request event back to requestor with updated changes.
+        xlib.XSendEvent(self._x_display, request.requestor, 0, 0, byref(out_event))
+
+        # Seems to work find without it. May add later.
+        #xlib.XSync(self._x_display, False)
 
 
 __all__ = ["XlibEventHandler", "XlibWindow"]

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -296,10 +296,6 @@ class XlibWindow(BaseWindow):
             self._utf8_atom = xlib.XInternAtom(self._x_display, asbytes('UTF8_STRING'), False)
             self._target_atom = xlib.XInternAtom(self._x_display, asbytes('TARGETS'), False)
             self._incr_atom = xlib.XInternAtom(self._x_display, asbytes('INCR'), False)
-            self._clipboard_mgr_atom = xlib.XInternAtom(self._x_display, asbytes('CLIPBOARD_MANAGER'), False)
-
-            #self._clipboard_mgr_targets = xlib.XInternAtom(self._x_display, asbytes('SAVE_TARGETS'), False)
-            #self._selection_atom = xlib.XInternAtom(self._x_display, asbytes('PYGLET_SELECTION'), False)
 
             # Support for drag and dropping files needs to be enabled.
             if self._file_drops:


### PR DESCRIPTION
These changes allows you to call on the window to either get the text from the clipboard or put text into it. (`get_clipboard_text` and `set_clipboard_text`)

This does not handle any other information such as images or files, only text.

Tested on:
Linux (Ubuntu 22.04) - VM
Mac OS (Monterey) - VM
Windows 10

Basic example provided.

Disclaimer:
I did notice some copy and paste issues with Wayland (other programs would fail to get the clipboard data and paste either nothing, or it would paste sometimes). Researching a bit, this seems to be a common issue with Wayland and is mostly a OS/framework issue that is being worked on.

I also used a VM, so that may have attributed to it. However, a restart did fix the issues I was having. X11 mode tested and worked perfectly there every time.

Feel free to give some feedback or let me know if this worked or didn't work for you.