### PR TITLE
3.12 fix backport for 1.5

### DIFF
--- a/pyglet/font/win32.py
+++ b/pyglet/font/win32.py
@@ -318,7 +318,7 @@ class GDIPlusGlyphRenderer(Win32GlyphRenderer):
             pass
 
     def _create_bitmap(self, width, height):
-        self._data = (ctypes.c_byte * (4 * width * height))()
+        self._data = (BYTE * (4 * width * height))()
         self._bitmap = ctypes.c_void_p()
         self._format = PixelFormat32bppARGB 
         gdiplus.GdipCreateBitmapFromScan0(width, height, width * 4,
@@ -511,6 +511,12 @@ class GDIPlusFont(Win32Font):
         self._name = name
 
         family = ctypes.c_void_p()
+
+        # GDI will add @ in front of a localized font for some Asian languages. However, GDI will also not find it
+        # based on that name (???). Here we remove it before checking font collections.
+        if name[0] == "@":
+            name = name[1:]
+
         name = ctypes.c_wchar_p(name)
 
         # Look in private collection first:
@@ -519,6 +525,9 @@ class GDIPlusFont(Win32Font):
 
         # Then in system collection:
         if not family:
+            if _debug_font:
+                print(f"Warning: Font '{name}' was not found. Defaulting to: {self._default_name}")
+
             gdiplus.GdipCreateFontFamilyFromName(name, None, ctypes.byref(family))
 
         # Nothing found, use default font.

--- a/pyglet/image/codecs/wic.py
+++ b/pyglet/image/codecs/wic.py
@@ -607,7 +607,7 @@ class WICEncoder(ImageEncoder):
 
         frame.SetPixelFormat(byref(default_format))
 
-        data = (c_byte * size).from_buffer(bytearray(image_data))
+        data = (BYTE * size).from_buffer(bytearray(image_data))
 
         frame.WritePixels(image.height, pitch, size, data)
 

--- a/pyglet/libs/win32/types.py
+++ b/pyglet/libs/win32/types.py
@@ -34,6 +34,7 @@
 # ----------------------------------------------------------------------------
 
 import ctypes
+import sys
 
 from ctypes import *
 from ctypes.wintypes import *
@@ -96,6 +97,11 @@ LONG_PTR = HANDLE
 HDROP = HANDLE
 LPTSTR = LPWSTR
 LPSTREAM = c_void_p
+
+# Fixed in python 3.12. Is c_byte on other versions.
+# Ensure it's the same across all versions.
+if sys.version_info < (3, 12):
+    BYTE = c_ubyte
 
 LF_FACESIZE = 32
 CCHDEVICENAME = 32


### PR DESCRIPTION
Use correct data types
Define BYTE using the correct type when using an older Python version. Fix expected data type of BYTE for IWICBitmapFrameEncode data. Add a warning if the GDIFont cannot find a font and reverts to default. Add a catch and check for a localized font name from GDI enumeration. This fixes an issue with the font_comparison where fonts with @ in front were falling back to the default font.