### PR TITLE
More careful deletion of OpenGL objects

### DIFF
--- a/pyglet/gl/base.py
+++ b/pyglet/gl/base.py
@@ -454,7 +454,7 @@ class Context:
             `shader_id` : int
                 The OpenGL name of the Shader to delete.
 
-        .. versionadded:: 2.0.XXX
+        .. versionadded:: 2.0.10
         """
         if self._safe_to_operate_on_object_space():
             gl.glDeleteShader(gl.GLuint(shader_id))
@@ -472,7 +472,7 @@ class Context:
             `rbo_id` : int
                 The OpenGL name of the Shader Program to delete.
 
-        .. versionadded:: 2.0.XXX
+        .. versionadded:: 2.0.10
         """
         if self._safe_to_operate_on_object_space():
             gl.glDeleteRenderbuffers(1, gl.GLuint(rbo_id))
@@ -510,7 +510,7 @@ class Context:
             `fbo_id` : int
                 The OpenGL name of the Framebuffer Object to delete.
 
-        .. versionadded:: 2.0.XXX
+        .. versionadded:: 2.0.10
         """
         if self._safe_to_operate_on():
             gl.glDeleteFramebuffers(1, gl.GLuint(fbo_id))

--- a/pyglet/gl/base.py
+++ b/pyglet/gl/base.py
@@ -1,6 +1,7 @@
 import weakref
 
 from enum import Enum
+import threading
 from typing import Tuple
 
 import pyglet
@@ -207,13 +208,42 @@ class CanvasConfig(Config):
         return True
 
 
+class _ObjectPurgatory:
+    def __init__(self, deletion_function, delete_array=True):
+        self.list = []
+        self.deletion_function = deletion_function
+        self.delete_array = delete_array
+
+    def append(self, name):
+        self.list.append(name)
+
+    def delete(self):
+        # Release all objects scheduled for deletion.
+        # Note that the garbage collector introduces a race condition:
+        # It may add other objects through `append` while this method runs.
+        # So, drain the list relying on `pop`'s atomicity.
+        if not self.list:
+            return
+
+        local = []
+        while self.list:
+            local.append(self.list.pop())
+
+        if self.delete_array:
+            self.deletion_function(len(local), (gl.GLuint * len(local))(*local))
+        else:
+            for name in local:
+                self.deletion_function(gl.GLuint(name))
+
+
 class ObjectSpace:
     def __init__(self):
-        # Textures and buffers scheduled for deletion
-        # the next time this object space is active.
-        self.doomed_textures = []
-        self.doomed_buffers = []
-        self.doomed_shader_programs = []
+        # Objects scheduled for deletion the next time this object space is active.
+        self.doomed_textures = _ObjectPurgatory(gl.glDeleteTextures)
+        self.doomed_buffers = _ObjectPurgatory(gl.glDeleteBuffers)
+        self.doomed_shader_programs = _ObjectPurgatory(gl.glDeleteProgram, False)
+        self.doomed_shaders = _ObjectPurgatory(gl.glDeleteShader, False)
+        self.doomed_renderbuffers = _ObjectPurgatory(gl.glDeleteRenderbuffers)
 
 
 class Context:
@@ -235,7 +265,8 @@ class Context:
         self.context_share = context_share
         self.canvas = None
 
-        self.doomed_vaos = []
+        self.doomed_vaos = _ObjectPurgatory(gl.glDeleteVertexArrays)
+        self.doomed_framebuffers = _ObjectPurgatory(gl.glDeleteFramebuffers)
 
         if context_share:
             self.object_space = context_share.object_space
@@ -277,28 +308,13 @@ class Context:
             self._info = gl_info.GLInfo()
             self._info.set_active_context()
 
-        # Release Textures, Buffers, and VAOs on this context scheduled for
-        # deletion. Note that the garbage collector may introduce a race
-        # condition, so operate on a copy, and clear the list afterward.
-        if self.object_space.doomed_textures:
-            textures = self.object_space.doomed_textures[:]
-            textures = (gl.GLuint * len(textures))(*textures)
-            gl.glDeleteTextures(len(textures), textures)
-            self.object_space.doomed_textures.clear()
-        if self.object_space.doomed_buffers:
-            buffers = self.object_space.doomed_buffers[:]
-            buffers = (gl.GLuint * len(buffers))(*buffers)
-            gl.glDeleteBuffers(len(buffers), buffers)
-            self.object_space.doomed_buffers.clear()
-        if self.object_space.doomed_shader_programs:
-            for program_id in self.object_space.doomed_shader_programs:
-                gl.glDeleteProgram(program_id)
-            self.object_space.doomed_shader_programs.clear()
-        if self.doomed_vaos:
-            vaos = self.doomed_vaos[:]
-            vaos = (gl.GLuint * len(vaos))(*vaos)
-            gl.glDeleteVertexArrays(len(vaos), vaos)
-            self.doomed_vaos.clear()
+        self.object_space.doomed_textures.delete()
+        self.object_space.doomed_buffers.delete()
+        self.object_space.doomed_shader_programs.delete()
+        self.object_space.doomed_shaders.delete()
+        self.object_space.doomed_renderbuffers.delete()
+        self.doomed_vaos.delete()
+        self.doomed_framebuffers.delete()
 
     def destroy(self):
         """Release the context.
@@ -317,6 +333,13 @@ class Context:
             # Switch back to shadow context.
             if gl._shadow_window is not None:
                 gl._shadow_window.switch_to()
+
+    def _safe_to_delete_from_object_space(self):
+        return (self.object_space is gl.current_context.object_space and
+                threading.current_thread() is threading.main_thread())
+
+    def _safe_to_delete_from_self(self):
+        return gl.current_context is self and threading.current_thread() is threading.main_thread()
 
     def create_program(self, *sources: Tuple[str, str], program_class=None):
         """Create a ShaderProgram from OpenGL GLSL source.
@@ -347,25 +370,30 @@ class Context:
         return program
 
     def delete_texture(self, texture_id):
-        """Safely delete a Texture belonging to this context.
+        """Safely delete a Texture belonging to this context's object space.
 
-        Usually, the Texture is released immediately using
-        ``glDeleteTextures``, however if another context that does not share
-        this context's object space is currently active, the deletion will
-        be deferred until an appropriate context is activated.
+        This method will delete the texture immediately via
+        ``glDeleteTextures`` if the current context's object space is the same
+        as this context's object space and it is called from the main thread.
+
+        Otherwise, the texture will only be marked for deletion, postponing
+        it until any context with the same object space becomes active again.
+
+        This makes it safe to call from anywhere, including other threads.
 
         :Parameters:
             `texture_id` : int
                 The OpenGL name of the Texture to delete.
 
         """
-        if self.object_space is gl.current_context.object_space:
+        if self._safe_to_delete_from_object_space():
             gl.glDeleteTextures(1, gl.GLuint(texture_id))
         else:
             self.object_space.doomed_textures.append(texture_id)
 
     def delete_buffer(self, buffer_id):
-        """Safely delete a Buffer object belonging to this context.
+        """Safely delete a Buffer object belonging to this context's object
+        space.
 
         This method behaves similarly to `delete_texture`, though for
         ``glDeleteBuffers`` instead of ``glDeleteTextures``.
@@ -376,30 +404,14 @@ class Context:
 
         .. versionadded:: 1.1
         """
-        if self.object_space is gl.current_context.object_space and False:
+        if self._safe_to_delete_from_object_space():
             gl.glDeleteBuffers(1, gl.GLuint(buffer_id))
         else:
             self.object_space.doomed_buffers.append(buffer_id)
 
-    def delete_vao(self, vao_id):
-        """Safely delete a Vertex Array Object belonging to this context.
-
-        This method behaves similarly to `delete_texture`, though for
-        ``glDeleteVertexArrays`` instead of ``glDeleteTextures``.
-
-        :Parameters:
-            `vao_id` : int
-                The OpenGL name of the Vertex Array to delete.
-
-        .. versionadded:: 2.0
-        """
-        if gl.current_context is self:
-            gl.glDeleteVertexArrays(1, gl.GLuint(vao_id))
-        else:
-            self.doomed_vaos.append(vao_id)
-
     def delete_shader_program(self, program_id):
-        """Safely delete a Shader Program belonging to this context.
+        """Safely delete a Shader Program belonging to this context's
+        object space.
 
         This method behaves similarly to `delete_texture`, though for
         ``glDeleteProgram`` instead of ``glDeleteTextures``.
@@ -410,10 +422,82 @@ class Context:
 
         .. versionadded:: 2.0
         """
-        if gl.current_context is self:
-            gl.glDeleteProgram(program_id)
+        if self._safe_to_delete_from_object_space():
+            gl.glDeleteProgram(gl.GLuint(program_id))
         else:
             self.object_space.doomed_shader_programs.append(program_id)
+
+    def delete_shader(self, shader_id):
+        """Safely delete a Shader belonging to this context's object space.
+
+        This method behaves similarly to `delete_texture`, though for
+        ``glDeleteShader`` instead of ``glDeleteTextures``.
+
+        :Parameters:
+            `shader_id` : int
+                The OpenGL name of the Shader to delete.
+
+        .. versionadded:: 2.0.XXX
+        """
+        if self._safe_to_delete_from_object_space():
+            gl.glDeleteShader(gl.GLuint(shader_id))
+        else:
+            self.object_space.doomed_shaders.append(shader_id)
+
+    def delete_renderbuffer(self, rbo_id):
+        """Safely delete a Renderbuffer Object belonging to this context's
+        object space.
+
+        This method behaves similarly to `delete_texture`, though for
+        ``glDeleteRenderbuffers`` instead of ``glDeleteTextures``.
+
+        :Parameters:
+            `rbo_id` : int
+                The OpenGL name of the Shader Program to delete.
+
+        .. versionadded:: 2.0.XXX
+        """
+        if self._safe_to_delete_from_object_space():
+            gl.glDeleteRenderbuffers(1, gl.GLuint(rbo_id))
+        else:
+            self.object_space.doomed_renderbuffers.append(rbo_id)
+
+    def delete_vao(self, vao_id):
+        """Safely delete a Vertex Array Object belonging to this context.
+
+        This method behaves similarly to `delete_texture`, though for
+        ``glDeleteVertexArrays`` instead of ``glDeleteTextures``.
+
+        As they cannot be shared, the given VAO will only be deleted
+        once this exact context is activated again.
+
+        :Parameters:
+            `vao_id` : int
+                The OpenGL name of the Vertex Array to delete.
+
+        .. versionadded:: 2.0
+        """
+        if self._safe_to_delete_from_self():
+            gl.glDeleteVertexArrays(1, gl.GLuint(vao_id))
+        else:
+            self.doomed_vaos.append(vao_id)
+
+    def delete_framebuffer(self, fbo_id):
+        """Safely delete a Framebuffer Object belonging to this context.
+
+        This method behaves similarly to `delete_vao`, though for
+        ``glDeleteFramebuffers`` instead of ``glDeleteVertexArrays``.
+
+        :Parameters:
+            `fbo_id` : int
+                The OpenGL name of the Framebuffer Object to delete.
+
+        .. versionadded:: 2.0.XXX
+        """
+        if self._safe_to_delete_from_self():
+            gl.glDeleteFramebuffers(1, gl.GLuint(fbo_id))
+        else:
+            self.doomed_framebuffers.append(fbo_id)
 
     def get_info(self):
         """Get the OpenGL information for this context.

--- a/pyglet/gl/lib.py
+++ b/pyglet/gl/lib.py
@@ -62,8 +62,7 @@ def errcheck(result, func, arguments):
             print(name)
 
     from pyglet import gl
-    context = gl.current_context
-    if not context:
+    if not gl.current_context:
         raise GLException('No GL context; create a Window first')
     error = gl.glGetError()
     if error:

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -674,6 +674,7 @@ class Shader:
     """
 
     def __init__(self, source_string: str, shader_type: str):
+        self._context = pyglet.gl.current_context
         self._id = None
         self.type = shader_type
 
@@ -689,6 +690,7 @@ class Shader:
         source_length = c_int(len(shader_source_utf8))
 
         shader_id = glCreateShader(shader_type)
+        self._id = shader_id
         glShaderSource(shader_id, 1, byref(source_buffer_pointer), source_length)
         glCompileShader(shader_id)
 
@@ -708,8 +710,6 @@ class Shader:
 
         elif _debug_gl_shaders:
             print(self._get_shader_log(shader_id))
-
-        self._id = shader_id
 
     @property
     def id(self):
@@ -735,16 +735,16 @@ class Shader:
         glGetShaderSource(shader_id, source_length, None, source_str)
         return source_str.value.decode('utf8')
 
+    def delete(self):
+        glDeleteShader(self._id)
+        self._id = None
+
     def __del__(self):
-        try:
+        if self._id is not None:
             glDeleteShader(self._id)
             if _debug_gl_shaders:
                 print(f"Destroyed {self.type} Shader '{self._id}'")
-
-        except Exception:
-            # Interpreter is shutting down,
-            # or Shader failed to compile.
-            pass
+            self._id = None
 
     def __repr__(self):
         return "{0}(id={1}, type={2})".format(self.__class__.__name__, self.id, self.type)
@@ -756,6 +756,8 @@ class ShaderProgram:
     __slots__ = '_id', '_context', '_attributes', '_uniforms', '_uniform_blocks', '__weakref__'
 
     def __init__(self, *shaders: Shader):
+        self._id = None
+
         assert shaders, "At least one Shader object is required."
         self._id = _link_program(*shaders)
         self._context = pyglet.gl.current_context
@@ -799,13 +801,14 @@ class ShaderProgram:
     def __exit__(self, *_):
         glUseProgram(0)
 
+    def delete(self):
+        glDeleteProgram(self._id)
+        self._id = None
+
     def __del__(self):
-        try:
-            self._context.delete_shader_program(self.id)
-        except Exception:
-            # Interpreter is shutting down,
-            # or ShaderProgram failed to link.
-            pass
+        if self._id is not None:
+            self._context.delete_shader_program(self._id)
+            self._id = None
 
     def __setitem__(self, key, value):
         try:
@@ -930,6 +933,8 @@ class ComputeShaderProgram:
 
     def __init__(self, source: str):
         """Create an OpenGL ComputeShaderProgram from source."""
+        self._id = None
+
         if not (gl_info.have_version(4, 3) or gl_info.have_extension("GL_ARB_compute_shader")):
             raise ShaderException("Compute Shader not supported. OpenGL Context version must be at least "
                                   "4.3 or higher, or 4.2 with the 'GL_ARB_compute_shader' extension.")
@@ -1002,13 +1007,14 @@ class ComputeShaderProgram:
     def __exit__(self, *_):
         glUseProgram(0)
 
+    def delete(self):
+        glDeleteProgram(self._id)
+        self._id = None
+
     def __del__(self):
-        try:
-            self._context.delete_shader_program(self.id)
-        except Exception:
-            # Interpreter is shutting down,
-            # or ShaderProgram failed to link.
-            pass
+        if self._id is not None:
+            self._context.delete_shader_program(self._id)
+            self._id = None
 
     def __setitem__(self, key, value):
         try:

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -741,10 +741,13 @@ class Shader:
 
     def __del__(self):
         if self._id is not None:
-            glDeleteShader(self._id)
-            if _debug_gl_shaders:
-                print(f"Destroyed {self.type} Shader '{self._id}'")
-            self._id = None
+            try:
+                self._context.delete_shader(self._id)
+                if _debug_gl_shaders:
+                    print(f"Destroyed {self.type} Shader '{self._id}'")
+                self._id = None
+            except (AttributeError, ImportError):
+                pass  # Interpreter is shutting down
 
     def __repr__(self):
         return "{0}(id={1}, type={2})".format(self.__class__.__name__, self.id, self.type)
@@ -807,8 +810,11 @@ class ShaderProgram:
 
     def __del__(self):
         if self._id is not None:
-            self._context.delete_shader_program(self._id)
-            self._id = None
+            try:
+                self._context.delete_shader_program(self._id)
+                self._id = None
+            except (AttributeError, ImportError):
+                pass  # Interpreter is shutting down
 
     def __setitem__(self, key, value):
         try:
@@ -1013,8 +1019,11 @@ class ComputeShaderProgram:
 
     def __del__(self):
         if self._id is not None:
-            self._context.delete_shader_program(self._id)
-            self._id = None
+            try:
+                self._context.delete_shader_program(self._id)
+                self._id = None
+            except (AttributeError, ImportError):
+                pass  # Interpreter is shutting down
 
     def __setitem__(self, key, value):
         try:

--- a/pyglet/graphics/vertexarray.py
+++ b/pyglet/graphics/vertexarray.py
@@ -27,10 +27,8 @@ class VertexArray:
         glBindVertexArray(0)
 
     def delete(self):
-        try:
-            glDeleteVertexArrays(1, self._id)
-        except Exception:
-            pass
+        glDeleteVertexArrays(1, self._id)
+        self._id = None
 
     __enter__ = bind
 
@@ -38,11 +36,8 @@ class VertexArray:
         glBindVertexArray(0)
 
     def __del__(self):
-        try:
+        if self._id is not None:
             self._context.delete_vao(self.id)
-        # Python interpreter is shutting down:
-        except ImportError:
-            pass
 
     def __repr__(self):
         return "{}(id={})".format(self.__class__.__name__, self._id.value)

--- a/pyglet/graphics/vertexarray.py
+++ b/pyglet/graphics/vertexarray.py
@@ -37,7 +37,11 @@ class VertexArray:
 
     def __del__(self):
         if self._id is not None:
-            self._context.delete_vao(self.id)
+            try:
+                self._context.delete_vao(self.id)
+                self._id = None
+            except (ImportError, AttributeError):
+                pass  # Interpreter is shutting down
 
     def __repr__(self):
         return "{}(id={})".format(self.__class__.__name__, self._id.value)

--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -164,20 +164,14 @@ class BufferObject(AbstractBuffer):
     def unmap(self):
         glUnmapBuffer(GL_ARRAY_BUFFER)
 
-    def __del__(self):
-        try:
-            if self.id is not None:
-                self._context.delete_buffer(self.id)
-        except:
-            pass
-
     def delete(self):
-        buffer_id = GLuint(self.id)
-        try:
-            glDeleteBuffers(1, buffer_id)
-        except Exception:
-            pass
+        glDeleteBuffers(1, self.id)
         self.id = None
+
+    def __del__(self):
+        if self.id is not None:
+            self._context.delete_buffer(self.id)
+            self.id = None
 
     def resize(self, size):
         # Map, create a copy, then reinitialize.

--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -170,8 +170,11 @@ class BufferObject(AbstractBuffer):
 
     def __del__(self):
         if self.id is not None:
-            self._context.delete_buffer(self.id)
-            self.id = None
+            try:
+                self._context.delete_buffer(self.id)
+                self.id = None
+            except (AttributeError, ImportError):
+                pass  # Interpreter is shutting down
 
     def resize(self, size):
         # Map, create a copy, then reinitialize.

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1482,8 +1482,11 @@ class TextureRegion(Texture):
         return "{}(id={}, size={}x{}, owner={}x{})".format(self.__class__.__name__, self.id, self.width, self.height,
                                                            self.owner.width, self.owner.height)
 
+    # only the owner Texture should handle deletion
+    def delete(self):
+        pass
+
     def __del__(self):
-        # only the owner Texture should handle deletion
         pass
 
 

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1226,8 +1226,11 @@ class Texture(AbstractImage):
 
     def __del__(self):
         if self.id is not None:
-            self._context.delete_texture(self.id)
-            self.id = None
+            try:
+                self._context.delete_texture(self.id)
+                self.id = None
+            except (AttributeError, ImportError):
+                pass  # Interpreter is shutting down
 
     def bind(self, texture_unit: int = 0):
         """Bind to a specific Texture Unit by number."""

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1220,11 +1220,14 @@ class Texture(AbstractImage):
         self.id = tex_id
         self._context = pyglet.gl.current_context
 
+    def delete(self):
+        glDeleteTextures(1, self.id)
+        self.id = None
+
     def __del__(self):
-        try:
+        if self.id is not None:
             self._context.delete_texture(self.id)
-        except Exception:
-            pass
+            self.id = None
 
     def bind(self, texture_unit: int = 0):
         """Bind to a specific Texture Unit by number."""

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1221,6 +1221,9 @@ class Texture(AbstractImage):
         self._context = pyglet.gl.current_context
 
     def delete(self):
+        """Delete this texture and the memory it occupies.
+        After this, it may not be used anymore.
+        """
         glDeleteTextures(1, self.id)
         self.id = None
 
@@ -1485,8 +1488,10 @@ class TextureRegion(Texture):
         return "{}(id={}, size={}x{}, owner={}x{})".format(self.__class__.__name__, self.id, self.width, self.height,
                                                            self.owner.width, self.owner.height)
 
-    # only the owner Texture should handle deletion
     def delete(self):
+        """Deleting a TextureRegion has no effect. Operate on the owning
+        texture instead.
+        """
         pass
 
     def __del__(self):

--- a/pyglet/image/buffer.py
+++ b/pyglet/image/buffer.py
@@ -54,8 +54,11 @@ class Renderbuffer:
 
     def __del__(self):
         if self._id is not None:
-            self._context.delete_renderbuffer(self._id.value)
-            self._id = None
+            try:
+                self._context.delete_renderbuffer(self._id.value)
+                self._id = None
+            except (AttributeError, ImportError):
+                pass  # Interpreter is shutting down
 
     def __repr__(self):
         return "{}(id={})".format(self.__class__.__name__, self._id.value)
@@ -111,8 +114,11 @@ class Framebuffer:
 
     def __del__(self):
         if self._id is not None:
-            self._context.delete_framebuffer(self._id.value)
-            self._id = None
+            try:
+                self._context.delete_framebuffer(self._id.value)
+                self._id = None
+            except (AttributeError, ImportError):
+                pass  # Interpreter is shutting down
 
     @property
     def is_complete(self):
@@ -206,13 +212,6 @@ class Framebuffer:
         self._width = max(renderbuffer.width, self._width)
         self._height = max(renderbuffer.height, self._height)
         self.unbind()
-
-    def __del__(self):
-        try:
-            glDeleteFramebuffers(1, self._id)
-        # Python interpreter is shutting down:
-        except Exception:
-            pass
 
     def __repr__(self):
         return "{}(id={})".format(self.__class__.__name__, self._id.value)

--- a/pyglet/image/buffer.py
+++ b/pyglet/image/buffer.py
@@ -13,6 +13,7 @@ class Renderbuffer:
 
     def __init__(self, width, height, internal_format, samples=1):
         """Create an instance of a Renderbuffer object."""
+        self._context = pyglet.gl.current_context
         self._id = GLuint()
         self._width = width
         self._height = height
@@ -49,13 +50,12 @@ class Renderbuffer:
 
     def delete(self):
         glDeleteRenderbuffers(1, self._id)
+        self._id = None
 
     def __del__(self):
-        try:
-            glDeleteRenderbuffers(1, self._id)
-        # Python interpreter is shutting down:
-        except Exception:
-            pass
+        if self._id is not None:
+            self._context.delete_renderbuffer(self._id.value)
+            self._id = None
 
     def __repr__(self):
         return "{}(id={})".format(self.__class__.__name__, self._id.value)
@@ -71,6 +71,7 @@ class Framebuffer:
 
         .. versionadded:: 2.0
         """
+        self._context = pyglet.gl.current_context
         self._id = GLuint()
         glGenFramebuffers(1, self._id)
         self._attachment_types = 0
@@ -105,10 +106,13 @@ class Framebuffer:
             self.unbind()
 
     def delete(self):
-        try:
-            glDeleteFramebuffers(1, self._id)
-        except Exception:
-            pass
+        glDeleteFramebuffers(1, self._id)
+        self._id = None
+
+    def __del__(self):
+        if self._id is not None:
+            self._context.delete_framebuffer(self._id.value)
+            self._id = None
 
     @property
     def is_complete(self):


### PR DESCRIPTION
The `Context.delete_*` family of methods now performs checks whether the calling thread is the main thread to avoid headscratch-inducing OpenGL errors or segmentation faults caused by `__del__`. There now is one such method for each implemented OpenGL object.

The deletion paths of all wrapped OpenGL objects (Texture, BufferObject, ShaderProgram and ComputeShaderProgram, Shader, Renderbuffer, Framebuffer and VertexArrayObject) now behave similarly:
- All those objects now reference their owning context by storing the current context at creation.
- `delete` methods have been newly added to `Texture` and the three shader-related classes.
- `delete` will immediately call the appropiate `glDelete*` function and set the object's `id`/`_id` to `None`, without any safety or exception tests.
- `__del__` will not act if the object's id is `None`.
- `__del__` will use the appropiate `Context.delete_*` method to delete the object otherwise.
- `__del__` is wrapped in a suppressing `except` catching two types of errors that tend to ocurr when running the `Context.delete_*` methods on interpreter shutdown:
  - `ImportError`s (caused by a gl method's `errcheck`)
  - `AttributeError`s (caused by module-level variables such as the `gl` or `threading` module being set to `None`).