### PR TITLE
Make WidgetBase.enabled an instance property

### DIFF
--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -23,7 +23,8 @@ class WidgetBase(EventDispatcher):
     def _set_enabled(self, enabled: bool) -> None:
         """Internal hook for setting enabled.
 
-        Override this in subclasses.
+        Override this in subclasses to perform effects when a widget is
+        enabled or disabled.
         """
         pass
 
@@ -31,8 +32,14 @@ class WidgetBase(EventDispatcher):
     def enabled(self) -> bool:
         """Get/set whether this widget is enabled.
 
-        Override this property on subclasses to respond to changes in
-        status cleanly.
+        To react to changes in this value, override
+        :py:meth:`._set_enabled` on widgets. For example, you may want
+        to cue the user by:
+
+        * Play an animation
+        * Set a highlight color or effect around
+        * Play a sound
+
         """
         return self._enabled
 

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -20,6 +20,13 @@ class WidgetBase(EventDispatcher):
         self._fg_group = None
         self._enabled = True
 
+    def _set_enabled(self, enabled: bool) -> None:
+        """Internal hook for setting enabled.
+
+        Override this in subclasses.
+        """
+        pass
+
     @property
     def enabled(self) -> bool:
         """Get/set whether this widget is enabled.
@@ -34,6 +41,7 @@ class WidgetBase(EventDispatcher):
         if self._enabled == new_enabled:
             return
         self._enabled = new_enabled
+        self._set_enabled(new_enabled)
 
     def update_groups(self, order):
         pass

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -36,9 +36,9 @@ class WidgetBase(EventDispatcher):
         :py:meth:`._set_enabled` on widgets. For example, you may want
         to cue the user by:
 
-        * Play an animation
-        * Set a highlight color or effect around
-        * Play a sound
+        * Playing an animation and/or sound
+        * Setting a highlight color
+        * Displaying a toast or notification
 
         """
         return self._enabled

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -18,7 +18,17 @@ class WidgetBase(EventDispatcher):
         self._height = height
         self._bg_group = None
         self._fg_group = None
-        self.enabled = True
+        self._enabled = True
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, new_enabled: bool) -> None:
+        if self._enabled == new_enabled:
+            return
+        self._enabled = new_enabled
 
     def update_groups(self, order):
         pass

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -22,6 +22,11 @@ class WidgetBase(EventDispatcher):
 
     @property
     def enabled(self) -> bool:
+        """Get/set whether this widget is enabled.
+
+        Override this property on subclasses to respond to changes in
+        status cleanly.
+        """
         return self._enabled
 
     @enabled.setter


### PR DESCRIPTION
### Why

1. Allow subclasses to respond to changes in `enabled` status
2. Consistency: everything else has:
    1. a protected instance variable
    2. a property to expose the instance variable
3. No apparent conflicts with other UI efforts such as #930
