### PR TITLE
Fix MatX subclasses typing

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -26,6 +26,7 @@ from collections.abc import Iterator as _Iterator
 
 
 number = _typing.Union[float, int]
+Mat3T = _typing.TypeVar("Mat3T", bound="Mat3")
 Mat4T = _typing.TypeVar("Mat4T", bound="Mat4")
 
 
@@ -627,7 +628,7 @@ class Mat3(tuple):
     the "@" operator.
     """
 
-    def __new__(cls, values: _Iterable[float] = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)) -> Mat3:
+    def __new__(cls: type[Mat3T], values: _Iterable[float] = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)) -> Mat3T:
         """Create a 3x3 Matrix
 
         A Mat3 can be created with a list or tuple of 9 values.
@@ -639,7 +640,7 @@ class Mat3(tuple):
             `values` : tuple of float or int
                 A tuple or list containing 9 floats or ints.
         """
-        new = super().__new__(Mat3, values)
+        new = super().__new__(cls, values)
         assert len(new) == 9, "A 3x3 Matrix requires 9 values"
         return new
 
@@ -720,10 +721,10 @@ class Mat3(tuple):
 
 class Mat4(tuple):
 
-    def __new__(cls, values: _Iterable[float] = (1.0, 0.0, 0.0, 0.0,
-                                                 0.0, 1.0, 0.0, 0.0,
-                                                 0.0, 0.0, 1.0, 0.0,
-                                                 0.0, 0.0, 0.0, 1.0,)) -> Mat4:
+    def __new__(cls: type[Mat4T], values: _Iterable[float] = (1.0, 0.0, 0.0, 0.0,
+                                                              0.0, 1.0, 0.0, 0.0,
+                                                              0.0, 0.0, 1.0, 0.0,
+                                                              0.0, 0.0, 0.0, 1.0,)) -> Mat4T:
         """Create a 4x4 Matrix.
 
         `Mat4` is an immutable 4x4 Matrix, which includs most common
@@ -738,7 +739,7 @@ class Mat4(tuple):
         .. note:: Matrix multiplication is performed using the "@" operator.
         """
 
-        new = super().__new__(Mat4, values)
+        new = super().__new__(cls, values)
         assert len(new) == 16, "A 4x4 Matrix requires 16 values"
         return new
 


### PR DESCRIPTION
A small PR just to clarify this point. We mentioned this a while back on the discord server.
The current implementation of Mat3/Mat4 overrides `__new__` in order to deal with the immutable nature of tuples. However, it forces the exact type Mat3/Mat4, so that it is not possible to subclass them correctly.

With the current implementation, this would happen:
```py
from pyglet.math import Mat4


class CustomMat4(Mat4):

    def custom_method(self):
        ...


custom_mat4 = CustomMat4()
print(type(custom_mat4))
# Mat4
custom_mat4.custom_method()
# 'Mat4' object has no attribute 'custom_method'
```
The behaviour is similar for `Mat3`.

This patch shall fix the issue, restoring the usual subclassing behaviour.

Please let me know if this was for some reason the intended behaviour.