### PR TITLE
Add support for setting and getting arrays in a Uniform via wrapper.

### DIFF
--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -1,11 +1,10 @@
+import warnings
 from ctypes import *
 from weakref import proxy
 
 import pyglet
-
 from pyglet.gl import *
 from pyglet.graphics.vertexbuffer import BufferObject
-
 
 _debug_gl_shaders = pyglet.options['debug_gl_shaders']
 
@@ -925,9 +924,14 @@ class ShaderProgram:
         try:
             uniform = self._uniforms[key]
         except KeyError as err:
-            raise ShaderException(f"A Uniform with the name `{key}` was not found.\n"
-                                  f"The spelling may be incorrect, or if not in use it "
-                                  f"may have been optimized out by the OpenGL driver.") from err
+            msg = (f"A Uniform with the name `{key}` was not found.\n"
+            f"The spelling may be incorrect, or if not in use it "
+            f"may have been optimized out by the OpenGL driver.")
+            if _debug_gl_shaders:
+                warnings.warn(msg)
+                return
+            else:
+                raise ShaderException(msg) from err
         try:
             uniform.set(value)
         except GLException as err:
@@ -937,9 +941,14 @@ class ShaderProgram:
         try:
             uniform = self._uniforms[item]
         except KeyError as err:
-            raise ShaderException(f"A Uniform with the name `{item}` was not found.\n"
-                                  f"The spelling may be incorrect, or if not in use it "
-                                  f"may have been optimized out by the OpenGL driver.") from err
+            msg = (f"A Uniform with the name `{item}` was not found.\n"
+            f"The spelling may be incorrect, or if not in use it "
+            f"may have been optimized out by the OpenGL driver.")
+            if _debug_gl_shaders:
+                warnings.warn(msg)
+                return
+            else:
+                raise ShaderException() from err
         try:
             return uniform.get()
         except GLException as err:
@@ -1140,9 +1149,14 @@ class ComputeShaderProgram:
         try:
             uniform = self._uniforms[key]
         except KeyError as err:
-            raise ShaderException(f"A Uniform with the name `{key}` was not found.\n"
-                                  f"The spelling may be incorrect, or if not in use it "
-                                  f"may have been optimized out by the OpenGL driver.") from err
+            msg = (f"A Uniform with the name `{key}` was not found.\n"
+            f"The spelling may be incorrect, or if not in use it "
+            f"may have been optimized out by the OpenGL driver.")
+            if _debug_gl_shaders:
+                warnings.warn(msg)
+                return
+            else:
+                raise ShaderException() from err
         try:
             uniform.set(value)
         except GLException as err:
@@ -1152,9 +1166,14 @@ class ComputeShaderProgram:
         try:
             uniform = self._uniforms[item]
         except KeyError as err:
-            raise ShaderException(f"A Uniform with the name `{item}` was not found.\n"
-                                  f"The spelling may be incorrect, or if not in use it "
-                                  f"may have been optimized out by the OpenGL driver.") from err
+            msg = (f"A Uniform with the name `{item}` was not found.\n"
+            f"The spelling may be incorrect, or if not in use it "
+            f"may have been optimized out by the OpenGL driver.")
+            if _debug_gl_shaders:
+                warnings.warn(msg)
+                return
+            else:
+                raise ShaderException(msg) from err
         try:
             return uniform.get()
         except GLException as err:

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -242,7 +242,7 @@ class _UniformArray:
     Types with a length longer than 1 will be returned as tuples as an inner list would not support individual value
     reassignment. Array data must either be set in full, or by indexing."""
 
-    _slots_ = ('uniform', 'gl_type', 'gl_getter', 'gl_setter', 'is_matrix', 'dsa', '_c_array', '_ptr')
+    __slots__ = ('_uniform', '_gl_type', '_gl_getter', '_gl_setter', '_is_matrix', '_dsa', '_c_array', '_ptr')
     def __init__(self, uniform, gl_getter, gl_setter, gl_type, is_matrix, dsa):
         self._uniform = uniform
         self._gl_type = gl_type
@@ -265,12 +265,9 @@ class _UniformArray:
         raise ShaderException("Deleting items is not support for UniformArrays.")
 
     def __getitem__(self, key):
-        """Return as a tuple.
-        Returning as a list may imply setting inner list elements will update values.
-        """
+        #Return as a tuple. Returning as a list may imply setting inner list elements will update values.
         if isinstance(key, slice):
-            start, stop, step = key.start, key.stop, key.step
-            sliced_data = self._c_array[start:stop:step]
+            sliced_data = self._c_array[key]
             if self._uniform.length > 1:
                 return [tuple(data) for data in sliced_data]
             else:
@@ -281,8 +278,7 @@ class _UniformArray:
 
     def __setitem__(self, key, value):
         if isinstance(key, slice):
-            start, stop, step = key.start, key.stop, key.step
-            self._c_array[start:stop:step] = value
+            self._c_array[key] = value
             self._update_uniform(self._ptr)
             return
 


### PR DESCRIPTION
Allow setting arrays in uniforms in GLSL: `uniform vec3 positions[9]`. 

When accessing the shader via `program["positions"]` it will return this:
```py
UniformArray(uniform=positions, data=[(128.0, 128.0, 128.0), (57.0, 123.0, 149.0), (36.0, 64.0, 76.0), (255.0, 255.0, 255.0), (255.0, 0.0, 255.0), (52.0, 85.0, 100.0), (151.0, 151.0, 151.0), (0.0, 0.0, 0.0), (178.0, 184.0, 216.0)])
```

Can be used as a list for the most part, you can iterate over it and do most of the things a list can do. It does not support sub-list assignment. (for example you can't set a `program["positions"][0][1] = 20.0` you would have to pass the full data type type via `program["positions"][0] = (12.0, 10.0, 20.0)`)

Set data in full via `program["positions"] = new_full_array`

Supports index getting: `program["positions"][0]` and setting: `program["positions"][0] = (10.0, 20.0, 30.0)` or:
```py
array = program["positions"]
array[0] =  (10.0, 20.0, 30.0)
```
Also supports slicing.

Add checks for multidimensional arrays, as they can't be properly inspected. Not sure if I should raise an exception for them, warn, or just ignore, but went exception route for now. Can change if needed.

Looking for input on a change, when shader debugging is on, to either ignore or warn about getting/setting missing uniforms. When debugging or adjusting shaders, it gets quite annoying to have the program put out an exception when I have temporarily commented out some uniforms or ones that were optimized out. Would be nice if we can have an option to bypass this or at the least change to a warning.