### PR TITLE
Remove incorrect includes from options dict page

### DIFF
--- a/doc/programming_guide/options.rst
+++ b/doc/programming_guide/options.rst
@@ -1,8 +1,7 @@
 Runtime Options
 ===============
 
-.. automodule:: pyglet
-   :members:
+.. autodata:: pyglet.options
 
 
 .. _guide_environment-settings:


### PR DESCRIPTION
**tl;dr:** Make sure the options page only shows the options dict info

### Changes

1. Use autodata directive instead of automodule to prevent showing wrong items on options page
2. Remove top-level docstring and version info currently shown on options page

### Comparison

#### Before
![image](https://github.com/pyglet/pyglet/assets/36696816/6e62c19b-445c-4041-8cd0-4106092e8c1b)


#### After

![image](https://github.com/pyglet/pyglet/assets/36696816/8e92a627-9633-4b63-b45f-dd58ac7d35d9)

### Testing

- [x] Built locally with `make html`
- [x] Tested with `python -m http.server -d _build/html` + opening in browser 