### PR TITLE
Improve VBO binding.

### DIFF
--- a/pyglet/gl/lib.py
+++ b/pyglet/gl/lib.py
@@ -83,6 +83,7 @@ def decorate_function(func, name):
     if _debug_gl:
         if name not in ('glGetError',) and name[:3] not in ('glX', 'agl', 'wgl'):
             func.errcheck = errcheck
+            func.__name__ = name
 
 
 link_AGL = None

--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -303,3 +303,4 @@ class BufferObjectRegion:
         buffer = self.buffer
         buffer._dirty_min = min(buffer._dirty_min, self.start)
         buffer._dirty_max = max(buffer._dirty_max, self.end)
+        buffer._dirty = True

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -97,7 +97,6 @@ class VertexDomain:
         self.buffer_attributes = []     # list of (buffer, attributes)
 
         self._property_dict = {}        # name: property(_getter, _setter)
-        self._dirty_attribs = set()
 
         for name, meta in attribute_meta.items():
             assert meta['format'][0] in _gl_types, f"'{meta['format']}' is not a valid atrribute format for '{name}'."
@@ -109,7 +108,7 @@ class VertexDomain:
             self.attribute_names[attribute.name] = attribute
 
             # Create buffer:
-            attribute.buffer = AttributeBufferObject(self._dirty_attribs, attribute.stride * self.allocator.capacity, attribute)
+            attribute.buffer = AttributeBufferObject(attribute.stride * self.allocator.capacity, attribute)
 
             self.buffer_attributes.append((attribute.buffer, (attribute,)))
 
@@ -176,9 +175,8 @@ class VertexDomain:
 
         """
         self.vao.bind()
-        for buffer in self._dirty_attribs:
-            buffer.bind()
-        self._dirty_attribs.clear()
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
 
         starts, sizes = self.allocator.get_allocated_regions()
         primcount = len(starts)
@@ -206,9 +204,8 @@ class VertexDomain:
 
         """
         self.vao.bind()
-        for buffer in self._dirty_attribs:
-            buffer.bind()
-        self._dirty_attribs.clear()
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
 
         glDrawArrays(mode, vertex_list.start, vertex_list.count)
 
@@ -392,9 +389,8 @@ class IndexedVertexDomain(VertexDomain):
 
         """
         self.vao.bind()
-        for buffer in self._dirty_attribs:
-            buffer.bind()
-        self._dirty_attribs.clear()
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
 
         starts, sizes = self.index_allocator.get_allocated_regions()
         primcount = len(starts)
@@ -424,9 +420,8 @@ class IndexedVertexDomain(VertexDomain):
 
         """
         self.vao.bind()
-        for buffer in self._dirty_attribs:
-            buffer.bind()
-        self._dirty_attribs.clear()
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
 
         glDrawElements(mode, vertex_list.index_count, self.index_gl_type,
                        self.index_buffer.ptr +


### PR DESCRIPTION
When tracing I noticed that the VBO's we use for binding were getting binded every draw call.

```py
glBindVertexArray
glBindBuffer
glBindBuffer
glBindBuffer
glBindBuffer
glBindBuffer
glBindBuffer
glDrawElements
```

Binding is normally done only when uploading data from what I read. Looking further this is done because we are grouping changes all at once in our data before submitting it to the GPU. The problem is that we tie this data upload to `bind` which was binding the VBO regardless of if it was 'dirty'.  Maybe there is a better way to do this, but I have just created a dirty set which can be iterated only when an attribute changes data, rather than every time.

Also, set the __name__ on GL functions so they don't all show up as <WinFunctionType object at X> during trace, so it's readable.

Changing this with 20,000 sprites gained me ~20% more FPS. 450-560