### PR TITLE
Fix bad behavior when clearing `XAudio2AudioPlayer`

### DIFF
--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -183,6 +183,8 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
             self._xa2_source_voice.cone_orientation = _convert_coordinates(self.player.cone_orientation)
             self._xa2_source_voice.cone_outside_volume = self.player.cone_outer_gain
             self._set_cone_angles()
+            self.driver._xa2_driver.apply3d(self._xa2_source_voice, 2)
+            self.driver._xa2_driver._xaudio2.CommitChanges(2)
 
     def on_buffer_end(self, buffer_context_ptr: int) -> None:
         # Called from the XAudio2 thread.

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -173,7 +173,16 @@ class XAudio2AudioPlayer(AbstractAudioPlayer):
         self._pyglet_source_exhausted = False
         self.driver._xa2_driver.return_voice(self._xa2_source_voice, self._audio_data_in_use)
         self._audio_data_in_use = deque()
+
         self._xa2_source_voice = self.driver._xa2_driver.get_source_voice(self.source.audio_format, self)
+        self._xa2_source_voice.volume = self.player.volume
+        self._xa2_source_voice.frequency = self.player.pitch
+        if self._xa2_source_voice.is_emitter:
+            self._xa2_source_voice.position = _convert_coordinates(self.player.position)
+            self._xa2_source_voice.distance_scaler = self.player.min_distance
+            self._xa2_source_voice.cone_orientation = _convert_coordinates(self.player.cone_orientation)
+            self._xa2_source_voice.cone_outside_volume = self.player.cone_outer_gain
+            self._set_cone_angles()
 
     def on_buffer_end(self, buffer_context_ptr: int) -> None:
         # Called from the XAudio2 thread.

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -317,7 +317,7 @@ class XAudio2Driver:
         for source_voice in self._emitting_voices:
             self.apply3d(source_voice)
 
-        # self._xaudio2.CommitChanges(0)
+        self._xaudio2.CommitChanges(0)
 
     def _calculate3d(self, listener, emitter):
         lib.X3DAudioCalculate(

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -140,7 +140,6 @@ class XAudio2Driver:
         self._xaudio2 = None
         self._dead = False
 
-        self.lock = threading.Lock()
         # A lock that will prevent XAudio2 from running any callbacks (processing audio at all)
         # while it is held. Must be acquired by audio players in certain situations in order to
         # ensure that the following, very unlikely, sequence of events does not happen:
@@ -150,9 +149,10 @@ class XAudio2Driver:
         #   and the main thread runs
         # - the main thread runs a critical operation on the player such as `delete` to completion
         # - the callback is resumed and breaks as the audio player is deleted.
+        self.lock = threading.Lock()
         self._engine_callback = XA2EngineCallback(self.lock)
 
-        self._emitting_voices = []  # Contains all of the emitting source voices.
+        self._emitting_voices = []  # Contains all playing source voices with an emitter.
         self._voice_pool = defaultdict(list)
         self._in_use = {}  # All voices currently in use, mapped to their audio player.
 
@@ -315,34 +315,29 @@ class XAudio2Driver:
     def _calculate_3d_sources(self, dt):
         """We calculate the 3d emitters and sources every 15 fps, committing everything after deferring all changes."""
         for source_voice in self._emitting_voices:
-            self.apply3d(source_voice)
+            self.apply3d(source_voice, 1)
 
         self._xaudio2.CommitChanges(0)
 
-    def _calculate3d(self, listener, emitter):
+    def apply3d(self, source_voice, commit):
+        """Calculates and sets output matrix and frequency ratio on the voice based on the listener and the voice's
+           emitter. Commit determines the operation set, whether the settings are applied immediately (0) or to
+           be committed together at a later time.
+        """
         lib.X3DAudioCalculate(
             self._x3d_handle,
-            listener,
-            emitter,
+            self._listener.listener,
+            source_voice._emitter,
             lib.default_dsp_calculation,
             self._dsp_settings,
         )
+        source_voice._voice.SetOutputMatrix(self._master_voice,
+                                            1,
+                                            self._mvoice_details.InputChannels,
+                                            self._dsp_settings.pMatrixCoefficients,
+                                            commit)
 
-    def _apply3d(self, voice, commit):
-        """Calculates the output channels based on the listener and emitter and default DSP settings.
-           Commit determines if the settings are applied immediately (0) or committed at once through the xaudio driver.
-        """
-        voice.SetOutputMatrix(self._master_voice,
-                              1,
-                              self._mvoice_details.InputChannels,
-                              self._dsp_settings.pMatrixCoefficients,
-                              commit)
-
-        voice.SetFrequencyRatio(self._dsp_settings.DopplerFactor, commit)
-
-    def apply3d(self, source_voice, commit=1):
-        self._calculate3d(self._listener.listener, source_voice._emitter)
-        self._apply3d(source_voice._voice, commit)
+        source_voice._voice.SetFrequencyRatio(self._dsp_settings.DopplerFactor, commit)
 
     def delete(self):
         self._delete_driver()
@@ -369,7 +364,6 @@ class XAudio2Driver:
         """
         if voice.is_emitter:
             self._emitting_voices.remove(voice)
-
         self._in_use.pop(voice)
 
         assert _debug(f"XA2AudioDriver: Resetting {voice}...")
@@ -403,7 +397,6 @@ class XAudio2Driver:
         voice.acquired(player.on_buffer_end, audio_format.sample_rate)
         if voice.is_emitter:
             self._emitting_voices.append(voice)
-
         self._in_use[voice] = player
 
         return voice

--- a/tests/integration/media/test_driver.py
+++ b/tests/integration/media/test_driver.py
@@ -22,6 +22,18 @@ class _FakeDispatchEvent:
 
 
 class MockPlayerWithMockTime(MockPlayer, _FakeDispatchEvent):
+    volume = 1.0
+    min_distance = 1.0
+    max_distance = 100000000.
+
+    position = (0, 0, 0)
+    pitch = 1.0
+
+    cone_orientation = (0, 0, 1)
+    cone_inner_angle = 360.
+    cone_outer_angle = 360.
+    cone_outer_gain = 1.
+
     def __init__(self, event_loop):
         super().__init__(event_loop)
         self.last_seek_time = 0.0


### PR DESCRIPTION
These commits will ensure that - when `XAudio2AudioPlayer`s get a new voice from the driver by getting cleared, they'll also set all player properties on it. Most noticeable is a discrepancy in volume, easily shown through
```py
import pyglet

player = pyglet.media.Player()
player.volume = 0.1
player.loop = True
player.queue(pyglet.media.synthesis.Sine(0.4))
player.play()

pyglet.app.run()
```
where the volume snaps to the default of 1.0 for every other loop.

3d calculations are applied immediately to prevent very short bursts from a misplaced and not updated voice (Tested only via the soundspace example)