### PR TITLE
update to add radius property get and set to Arc class

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -569,6 +569,19 @@ class Arc(ShapeBase):
         self._vertex_list.position[:] = vertices
 
     @property
+    def radius(self):
+        """The radius of the arc.
+
+        :type: float
+        """
+        return self._radius
+
+    @radius.setter
+    def radius(self, value):
+        self._radius = value
+        self._update_vertices()
+    
+    @property
     def angle(self):
         """The angle of the arc.
 


### PR DESCRIPTION
Arc class in shape.py was missing property getter and setter for radius, resulting in an AttributeError when attempting to update radius.