### PR TITLE
Fix `BufferObject.delete` by casting to GLuint

### DIFF
--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -165,7 +165,7 @@ class BufferObject(AbstractBuffer):
         glUnmapBuffer(GL_ARRAY_BUFFER)
 
     def delete(self):
-        glDeleteBuffers(1, self.id)
+        glDeleteBuffers(1, GLuint(self.id))
         self.id = None
 
     def __del__(self):


### PR DESCRIPTION
Fixes another `delete` oversight (of the methods introduced/modified in https://github.com/pyglet/pyglet/pull/988/) uncovered in https://github.com/pyglet/pyglet/issues/1031.
The below testing script runs without errors, so i hope that's the last of it.
```py
import gc

import pyglet


VTX_SRC = """
#version 400

in vec3 translate;
out vec3 texture_coords;

void main() {
	texture_coords = translate;
}
"""

FRAG_SRC = """
#version 400

in vec3 texture_coords;
out vec4 frag_out;

void main() {
	frag_out = vec4(1.0, 1.0, 1.0, 1.0);
}
"""

def make_things():
	vshdr = pyglet.graphics.shader.Shader(VTX_SRC, "vertex")
	fshdr = pyglet.graphics.shader.Shader(FRAG_SRC, "fragment")
	prg = pyglet.graphics.shader.ShaderProgram(vshdr, fshdr)

	vao = pyglet.graphics.VertexArray()

	vbo = pyglet.graphics.BufferObject(4096)
	vbo.set_data(b"\x00" * 4096)

	tex = pyglet.image.CheckerImagePattern().create_image(64, 64).create_texture(pyglet.image.Texture)

	rbuf = pyglet.image.Renderbuffer(640, 480, pyglet.gl.GL_RGBA8)

	fbuf = pyglet.image.Framebuffer()

	return (vshdr, fshdr, prg, vao, vbo, tex, rbuf, fbuf)


if __name__ == "__main__":
	for i in make_things():
		i.delete()

	q = make_things()
	del q
	gc.collect()
```