### PR TITLE
Add multiline shape

### DIFF
--- a/doc/modules/shapes.rst
+++ b/doc/modules/shapes.rst
@@ -111,3 +111,9 @@ pyglet.shapes
 
 .. autoclass:: Polygon
   :show-inheritance:
+
+
+.. autoclass:: MultiLine
+  :show-inheritance:
+
+  .. autoattribute:: thickness

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -45,6 +45,9 @@ class ShapesDemo(pyglet.window.Window):
 
         self.box = shapes.Box(60, 40, 200, 100, thickness=2, color=(244, 55, 55), batch=self.batch)
 
+        coordinates = [[450, 400], [475, 450], [525, 450], [550, 400]]
+        self.multiLine = shapes.MultiShape(*coordinates, closed=True, batch=self.batch)
+
     def on_draw(self):
         """Clear the screen and draw shapes"""
         self.clear()
@@ -70,6 +73,8 @@ class ShapesDemo(pyglet.window.Window):
 
         self.ellipse.b = abs(math.sin(self.time) * 100)
         self.sector.angle = (self.time * 30) % 360.0
+
+        self.multiLine.rotation = self.time * -15
 
 
 if __name__ == "__main__":

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -21,7 +21,8 @@ from pyglet.shapes import *
     (BorderedRectangle, (0, 0, 30, 10)),
     (Triangle, (0, 0, 2, 2, 5, 5)),
     (Star, (1, 1, 20, 11, 5)),
-    (Polygon, ((0, 0), (1, 1), (2, 2)))
+    (Polygon, ((0, 0), (1, 1), (2, 2))),
+    (MultiLine, ((0, 0), (1, 1), (2, 2)))
 ])
 def shape_and_positionals(request):
     return request.param


### PR DESCRIPTION
General line shape consisting of multiple line segments by giving multiple point coordinates.

- Reuses _get_segement (also used in BezierCurve)
- Doesn't have contains implemented

Example:
![image](https://github.com/pyglet/pyglet/assets/107309423/c50538f5-b44a-4a7b-b95c-28faebbf6b69)
