### PR TITLE
Fix bugs in PygletTextView_Implementation and CocoaAlternateEventLoop

### DIFF
--- a/pyglet/app/cocoa.py
+++ b/pyglet/app/cocoa.py
@@ -79,6 +79,10 @@ class CocoaAlternateEventLoop(EventLoop):
     working properly after X returns. This event loop differs in that it uses the built-in NSApplication event
     loop. We tie our schedule into it via timer.
     """
+    def __init__(self):
+        super().__init__()
+        self.platform_event_loop = None
+
     def run(self, interval=1/60):
         if not interval:
             self.clock.schedule(self._redraw_windows)
@@ -109,12 +113,14 @@ class CocoaAlternateEventLoop(EventLoop):
         interrupted (see :py:meth:`sleep`).
         """
         self.has_exit = True
-        self.platform_event_loop.notify()
+        if self.platform_event_loop is not None:
+            self.platform_event_loop.notify()
 
         self.is_running = False
         self.dispatch_event('on_exit')
 
-        self.platform_event_loop.nsapp_stop()
+        if self.platform_event_loop is not None:
+            self.platform_event_loop.nsapp_stop()
 
 class CocoaPlatformEventLoop(PlatformEventLoop):
 

--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -25,10 +25,6 @@ class PygletTextView_Implementation:
         self.empty_string = CFSTR("")
         return self
 
-    @PygletTextView.method('v')
-    def dealloc(self):
-        self.empty_string.release()
-
     # Other functions still seem to work?
     @PygletTextView.method('v@')
     def keyDown_(self, nsevent):

--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -4,7 +4,7 @@ from pyglet.window import key
 
 from pyglet.libs.darwin.cocoapy import ObjCClass, ObjCSubclass, ObjCInstance
 from pyglet.libs.darwin.cocoapy import PyObjectEncoding, send_super
-from pyglet.libs.darwin.cocoapy import CFSTR, cfstring_to_string
+from pyglet.libs.darwin.cocoapy import CFSTR, cfstring_to_string, cf
 
 NSArray = ObjCClass('NSArray')
 NSApplication = ObjCClass('NSApplication')
@@ -24,6 +24,10 @@ class PygletTextView_Implementation:
         self.setFieldEditor_(False)
         self.empty_string = CFSTR("")
         return self
+
+    @PygletTextView.method('v')
+    def dealloc(self):
+        cf.CFRelease(self.empty_string)
 
     # Other functions still seem to work?
     @PygletTextView.method('v@')


### PR DESCRIPTION
Here are two small bugfixes to Cocoa-related code, in separate commits.
* The fix for the first one follows some changes in #790. While the fix is fairly small, I have included reproduction steps much further down for completeness.
* The second issue occurred while running `python -m pyglet.info` to file an Issue. I assume the `AttributeError`, as seen below, is caused by calling `CocoaAlternateEventLoop.exit()` before `CocoaAlternateEventLoop.run()`.

```
Traceback (most recent call last):
  File "/Users/steve/git/pyglet/pyglet/info.py", line 178, in _try_dump
    func()
  File "/Users/steve/git/pyglet/pyglet/info.py", line 79, in dump_window
    window.close()
  File "/Users/steve/git/pyglet/pyglet/window/cocoa/__init__.py", line 244, in close
    super(CocoaWindow, self).close()
  File "/Users/steve/git/pyglet/pyglet/window/__init__.py", line 666, in close
    app.event_loop.dispatch_event('on_window_close', self)
  File "/Users/steve/git/pyglet/pyglet/event.py", line 392, in dispatch_event
    raise e
  File "/Users/steve/git/pyglet/pyglet/event.py", line 387, in dispatch_event
    if getattr(self, event_type)(*args):
  File "/Users/steve/git/pyglet/pyglet/app/base.py", line 286, in on_window_close
    self.exit()
  File "/Users/steve/git/pyglet/pyglet/app/cocoa.py", line 112, in exit
    self.platform_event_loop.notify()
AttributeError: 'CocoaAlternateEventLoop' object has no attribute 'platform_event_loop'
```

Since I skipped opening an issue:

**System Information:**
truncated `python -m pyglet.info`
```
❯ python -m pyglet.info
Platform
------------------------------------------------------------------------------
platform:  macOS-13.6.3-arm64-arm-64bit
release:   22.6.0
machine:   arm64

Python
------------------------------------------------------------------------------
implementation: CPython
sys.version: 3.10.11 (main, May 19 2023, 20:26:42) [Clang 14.0.3 (clang-1403.0.22.14.1)]
sys.maxint: 9223372036854775807
objc.__version__: 10.1
os.getcwd(): /Users/steve/git/pyglet

pyglet
------------------------------------------------------------------------------
pyglet.version: 2.0.12
```

**How To Reproduce**
Run this and click the button in the window that pops up.
```python
import pyrender
from PySide6.QtWidgets import QApplication, QPushButton


def render():
    pyrender.OffscreenRenderer(400, 400)


app = QApplication()

button = QPushButton("Press Me!")
button.clicked.connect(render)
button.show()

app.exec()
```

The resulting traceback should look like:
```
Exception ignored on calling ctypes callback function: <function ObjCSubclass.method.<locals>.decorator.<locals>.objc_method at 0x11f0c43a0>
Traceback (most recent call last):
  File "/Users/steve/git/pyglet/pyglet/libs/darwin/cocoapy/runtime.py", line 1251, in objc_method
    result = f(py_self, *args)
  File "/Users/steve/git/pyglet/pyglet/window/cocoa/pyglet_textview.py", line 30, in dealloc
    self.empty_string.release()
AttributeError: 'int' object has no attribute 'release'
```