### PR TITLE
Controller rework to use Vec2s

### DIFF
--- a/doc/programming_guide/input.rst
+++ b/doc/programming_guide/input.rst
@@ -112,6 +112,14 @@ following analog controls are available:
           - float
           - -1~1
 
+        * - dpadx
+          - float
+          - -1~1
+
+        * - dpady
+          - float
+          - -1~1
+
         * - lefttrigger
           - float
           - 0~1
@@ -149,14 +157,7 @@ The following digital controls are available:
           - pressing in on the left analog stick
         * - rightstick
           - pressing in on the right analog stick
-        * - dpleft
-          -
-        * - dpright
-          -
-        * - dpup
-          -
-        * - dpdown
-          -
+
 
 These values can be read in two ways. First, you can just query them manually
 in your game loop. All control names listed above are properties on the
@@ -191,27 +192,27 @@ event types:
           - :py:class:`~pyglet.input.Controller`, `str`
 
         * - on_stick_motion
-          - controller, stick_name, x_value, y_value
-          - :py:class:`~pyglet.input.Controller`, `str`, `float`, `float`
+          - controller, stick_name, vector
+          - :py:class:`~pyglet.input.Controller`, `str`, :py:class:`~pyglet.math.Vec2`
 
         * - on_dpad_motion
           - controller, left, right, up, down
-          - :py:class:`~pyglet.input.Controller`, `bool`, `bool`, `bool`, `bool`
+          - :py:class:`~pyglet.input.Controller`, :py:class:`~pyglet.math.Vec2`
 
         * - on_trigger_motion
           - controller, trigger_name, value
           - :py:class:`~pyglet.input.Controller`, `str`, `float`
 
 
-Analog events can be handled like this::
+Analog (and Dpad) events can be handled like this::
 
     @controller.event
-    def on_stick_motion(controller, name, x_value, y_value):
+    def on_stick_motion(controller, name, vector):
 
         if name == "leftstick":
-            # Do something with the x/y_values
+            # Do something with the 2D vector
         elif name == "rightstick":
-            # Do something with the x/y_values
+            # Do something with the 2D vector
 
     @controller.event
     def on_trigger_motion(controller, name, value):
@@ -220,6 +221,10 @@ Analog events can be handled like this::
             # Do something with the value
         elif name == "righttrigger":
             # Do something with the value
+
+    @controller.event
+    def on_dpad_motion(controller, vector):
+        # Do something with the 2D vector
 
 Digital events can be handled like this::
 
@@ -238,18 +243,6 @@ Digital events can be handled like this::
         elif button_name == 'b':
             # do something else
 
-Finally, the directional pad event can be handled like this::
-
-    @controller.event
-    def on_dpad_motion(controller, dpleft, dpright, dpup, dpdown):
-        if dpup:
-            # move up
-        if dpdown:
-            # move down
-        if dpleft:
-            # move left
-        if dpright:
-            # move right
 
 Rumble
 ^^^^^^

--- a/examples/input/controller.py
+++ b/examples/input/controller.py
@@ -1,5 +1,6 @@
 import pyglet
 
+from pyglet.math import Vec2
 from pyglet.shapes import Circle, Rectangle, Arc
 
 
@@ -19,7 +20,7 @@ class ControllerDisplay:
     def __init__(self, batch):
 
         self.label = pyglet.text.Label("No Controller connected.", x=10, y=window.height - 20,
-                                      multiline=True, width=720, batch=batch)
+                                       multiline=True, width=720, batch=batch)
 
         self.left_trigger = Rectangle(70, 310, 40, 10, batch=batch)
         self.right_trigger = Rectangle(610, 310, 40, 10, batch=batch)
@@ -59,25 +60,16 @@ class ControllerDisplay:
         if button := self.buttons.get(button_name, None):
             button.visible = False
 
-    def on_dpad_motion(self, controller, dpleft, dpright, dpup, dpdown):
-        position = [280, 185]
-        if dpup:
-            position[1] += 25
-        if dpdown:
-            position[1] -= 25
-        if dpleft:
-            position[0] -= 25
-        if dpright:
-            position[0] += 25
-        self.d_pad.position = position
+    def on_dpad_motion(self, controller, vector):
+        self.d_pad.position = Vec2(280, 185) + vector.normalize() * 25
 
-    def on_stick_motion(self, controller, stick, xvalue, yvalue):
+    def on_stick_motion(self, controller, stick, vector):
         if stick == "leftstick":
-            self.left_stick.position = 180+xvalue*50, 240+yvalue*50
-            self.left_stick_label.text = f"({round(xvalue, 1)}, {round(yvalue, 1)})"
+            self.left_stick.position = Vec2(180, 240) + vector * 50
+            self.left_stick_label.text = f"({round(vector.x, 1)}, {round(vector.y, 1)})"
         elif stick == "rightstick":
-            self.right_stick.position = 540+xvalue*50, 240+yvalue*50
-            self.right_stick_label.text = f"({round(xvalue, 1)}, {round(yvalue, 1)})"
+            self.right_stick.position = Vec2(540, 240) + vector * 50
+            self.right_stick_label.text = f"({round(vector.x, 1)}, {round(vector.y, 1)})"
 
     def on_trigger_motion(self, controller, trigger, value):
         if trigger == "lefttrigger":

--- a/pyglet/input/win32/xinput.py
+++ b/pyglet/input/win32/xinput.py
@@ -4,6 +4,7 @@ import threading
 
 import pyglet
 
+from pyglet.math import Vec2
 from pyglet.libs.win32 import com
 from pyglet.event import EventDispatcher
 from pyglet.libs.win32.types import *
@@ -573,22 +574,24 @@ class XInputController(Controller):
             def on_change(value):
                 normalized_value = value * scale + bias
                 setattr(self, name, normalized_value)
-                self.dispatch_event('on_stick_motion', self, "leftstick", self.leftx, self.lefty)
+                self.dispatch_event('on_stick_motion', self, "leftstick", Vec2(self.leftx, self.lefty))
 
         elif name in ("rightx", "righty"):
             @control.event
             def on_change(value):
                 normalized_value = value * scale + bias
                 setattr(self, name, normalized_value)
-                self.dispatch_event('on_stick_motion', self, "rightstick", self.rightx, self.righty)
+                self.dispatch_event('on_stick_motion', self, "rightstick", Vec2(self.rightx, self.righty))
 
     def _add_button(self, control, name):
 
         if name in ("dpleft", "dpright", "dpup", "dpdown"):
             @control.event
             def on_change(value):
-                setattr(self, name, value)
-                self.dispatch_event('on_dpad_motion', self, self.dpleft, self.dpright, self.dpup, self.dpdown)
+                target, bias = {'dpleft': ('dpadx', -1.0), 'dpright': ('dpadx', 1.0),
+                                'dpdown': ('dpady', -1.0), 'dpup': ('dpady', 1.0)}[name]
+                setattr(self, target, bias * value)
+                self.dispatch_event('on_dpad_motion', self, Vec2(self.dpadx, self.dpady))
         else:
             @control.event
             def on_change(value):

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -107,6 +107,9 @@ class Vec2:
         else:
             return self.__add__(_typing.cast(Vec2, other))
 
+    def __lt__(self, other: Vec2) -> bool:
+        return abs(self) < abs(other)
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Vec2) and self.x == other.x and self.y == other.y
 
@@ -298,6 +301,9 @@ class Vec3:
         else:
             return self.__add__(_typing.cast(Vec3, other))
 
+    def __lt__(self, other: Vec3) -> bool:
+        return abs(self) < abs(other)
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Vec3) and self.x == other.x and self.y == other.y and self.z == other.z
 
@@ -438,6 +444,9 @@ class Vec4:
             return self
         else:
             return self.__add__(_typing.cast(Vec4, other))
+
+    def __lt__(self, other: Vec4) -> bool:
+        return abs(self) < abs(other)
 
     def __eq__(self, other: object) -> bool:
         return (


### PR DESCRIPTION
To make things easier for end users, stick and dpad events now return `Vec2` types. This still allows easy reading of individual axis, but now provides all of the Vec2 helper methods. For example, normalized diagonals from DPad events.
The `controller.py` example illustrates this. 