### PR TITLE
Xaudio2 fixes + test fix

### DIFF
--- a/pyglet/media/drivers/xaudio2/lib_xaudio2.py
+++ b/pyglet/media/drivers/xaudio2/lib_xaudio2.py
@@ -263,7 +263,7 @@ class IXAudio2Voice(com.pInterface):
         ('GetFilterParameters',
          com.VOIDMETHOD(POINTER(XAUDIO2_FILTER_PARAMETERS))),
         ('SetOutputFilterParameters',
-         com.STDMETHOD(c_void_p, POINTER(XAUDIO2_FILTER_PARAMETERS, UINT32))),
+         com.STDMETHOD(c_void_p, POINTER(XAUDIO2_FILTER_PARAMETERS), UINT32)),
         ('GetOutputFilterParameters',
          com.VOIDMETHOD(c_void_p, POINTER(XAUDIO2_FILTER_PARAMETERS))),
         ('SetVolume',

--- a/tests/integration/media/test_driver.py
+++ b/tests/integration/media/test_driver.py
@@ -76,35 +76,35 @@ def get_drivers():
         from pyglet.media.drivers import silent
         drivers.append(silent)
         ids.append('Silent')
-    except:
+    except ImportError:
         pass
 
     try:
         from pyglet.media.drivers import pulse
         drivers.append(pulse)
         ids.append('PulseAudio')
-    except:
+    except ImportError:
         pass
 
     try:
         from pyglet.media.drivers import openal
         drivers.append(openal)
         ids.append('OpenAL')
-    except:
+    except ImportError:
         pass
 
     try:
         from pyglet.media.drivers import directsound
         drivers.append(directsound)
         ids.append('DirectSound')
-    except:
+    except ImportError:
         pass
 
     try:
         from pyglet.media.drivers import xaudio2
         drivers.append(xaudio2)
         ids.append('XAudio2')
-    except:
+    except ImportError:
         pass
 
 


### PR DESCRIPTION
Fix an issue with invalid POINTER call in the defined attributes. This caused XAudio2 to not be loaded in the latest version.

Also this will change the test files to do an `except ImportError` instead of a catch all. This way any errors loading the library files will be caught.