### PR TITLE
Added a None check to ShapeBase.delete

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -362,8 +362,9 @@ class ShapeBase(ABC):
         as the Python garbage collector will not necessarily call the
         finalizer as soon as the sprite falls out of scope.
         """
-        self._vertex_list.delete()
-        self._vertex_list = None
+        if self._vertex_list is not None:
+            self._vertex_list.delete()
+            self._vertex_list = None
 
     @property
     def x(self):


### PR DESCRIPTION
ShapeBase.delete was not checking if self._vertex_list was not None before calling self._vertex_list.delete(). This could occasionally result in AttributeError: 'NoneType' object has no attribute 'delete'