### PR TITLE
Stub file for package to workaround IDE inspections

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -6,7 +6,7 @@ More information is available at http://www.pyglet.org
 import os
 import sys
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 #: The release version
 version = '2.0.14'
@@ -196,16 +196,15 @@ if compat_platform == 'cygwin':
     # DirectSound support.
     import ctypes
 
-    ctypes.windll = ctypes.cdll
-    ctypes.oledll = ctypes.cdll
+    ctypes.windll = ctypes.cdll  # type: ignore
+    ctypes.oledll = ctypes.cdll  # type: ignore
     ctypes.WINFUNCTYPE = ctypes.CFUNCTYPE
-    ctypes.HRESULT = ctypes.c_long
-
+    ctypes.HRESULT = ctypes.c_long  # type: ignore
 
 # Call tracing
 # ------------
 
-_trace_filename_abbreviations = {}
+_trace_filename_abbreviations: Dict[str, str] = {}
 _trace_thread_count = 0
 _trace_args = options['debug_trace_args']
 _trace_depth = options['debug_trace_depth']
@@ -301,7 +300,7 @@ def _install_trace():
 class _ModuleProxy:
     _module = None
 
-    def __init__(self, name):
+    def __init__(self, name: str):
         self.__dict__['_module_name'] = name
 
     def __getattr__(self, name):
@@ -333,8 +332,7 @@ class _ModuleProxy:
             setattr(module, name, value)
 
 
-# Lazily load all modules, except if performing
-# type checking or code inspection.
+# Lazily load all modules, except if performing type checking or code inspection.
 if TYPE_CHECKING:
     from . import app
     from . import canvas
@@ -357,27 +355,26 @@ if TYPE_CHECKING:
     from . import text
     from . import window
 else:
-    app = _ModuleProxy('app')
-    canvas = _ModuleProxy('canvas')
-    clock = _ModuleProxy('clock')
-    customtypes = _ModuleProxy('customtypes')
-    event = _ModuleProxy('event')
-    font = _ModuleProxy('font')
-    gl = _ModuleProxy('gl')
-    graphics = _ModuleProxy('graphics')
-    gui = _ModuleProxy('gui')
-    image = _ModuleProxy('image')
-    input = _ModuleProxy('input')
-    lib = _ModuleProxy('lib')
-    math = _ModuleProxy('math')
-    media = _ModuleProxy('media')
-    model = _ModuleProxy('model')
-    resource = _ModuleProxy('resource')
-    sprite = _ModuleProxy('sprite')
-    shapes = _ModuleProxy('shapes')
-    text = _ModuleProxy('text')
-    window = _ModuleProxy('window')
-
+    app = _ModuleProxy('app')  # type: ignore
+    canvas = _ModuleProxy('canvas')  # type: ignore
+    clock = _ModuleProxy('clock')  # type: ignore
+    customtypes = _ModuleProxy('customtypes')  # type: ignore
+    event = _ModuleProxy('event')  # type: ignore
+    font = _ModuleProxy('font')  # type: ignore
+    gl = _ModuleProxy('gl')  # type: ignore
+    graphics = _ModuleProxy('graphics')  # type: ignore
+    gui = _ModuleProxy('gui')  # type: ignore
+    image = _ModuleProxy('image')  # type: ignore
+    input = _ModuleProxy('input')  # type: ignore
+    lib = _ModuleProxy('lib')  # type: ignore
+    math = _ModuleProxy('math')  # type: ignore
+    media = _ModuleProxy('media')  # type: ignore
+    model = _ModuleProxy('model')  # type: ignore
+    resource = _ModuleProxy('resource')  # type: ignore
+    sprite = _ModuleProxy('sprite')  # type: ignore
+    shapes = _ModuleProxy('shapes')  # type: ignore
+    text = _ModuleProxy('text')  # type: ignore
+    window = _ModuleProxy('window')  # type: ignore
 
 # Call after creating proxies:
 if options['debug_trace']:

--- a/pyglet/__init__.pyi
+++ b/pyglet/__init__.pyi
@@ -1,0 +1,13 @@
+from typing import Any, Tuple, Dict
+
+from . import app as app, canvas as canvas, clock as clock, customtypes as customtypes, font as font, gl as gl, \
+     graphics as graphics, gui as gui, image as image, input as input, math as math, media as media, model as model, \
+     resource as resource, shapes as shapes, sprite as sprite, text as text, window as window
+
+version: str
+MIN_PYTHON_VERSION: Tuple[int, int]
+MIN_PYTHON_VERSION_STR: str
+compat_platform: str
+env: str
+value: str
+options: Dict[str, Any]


### PR DESCRIPTION
Due to our use of lazy loading, it brings up a few issues with some IDE's, mostly PyCharm, which is unfortunately behind in a lot of modern typing/inspection features. VSCode seems to handle all scenarios properly without a stub file. I'm not sure why, but it most likely takes the `TYPE_CHECKING` block that's in the `__init__.py` for proper typing. While PyCharm seems to give the stub file priority over it's own inspections/typing.

For example, while PyCharm can handle `pyglet.app.` to get completion, it can't handle `from pyglet import app` as seen here:
 
![image](https://github.com/pyglet/pyglet/assets/17804711/55bf130d-37b8-4580-aa59-52dc03b72965)

Furthermore when you want to use the "Jump to" feature (ctrl click) to go to the module file, it will just jump to variable where `_ModuleProxy` was defined. Even with `import pyglet; pyglet.app` and `from pyglet import app` trying to jump to `app` will just take you to the `pyglet.__init__.py`.

With the stubfile, I no longer get these two issues. VSCode still seems to behave properly as well.

PyCharm:
![image](https://github.com/pyglet/pyglet/assets/17804711/ecf20352-16e3-44b8-871d-7d19b35bdf27)

The only caveat is I have to add `# type: ignore` on the module definitions to make it ignore errors otherwise it will produce an inspection error such as: `Expected type 'sprite.py', got '_ModuleProxy' instead`. MyPy seems to not complain about it without the `# type: ignore`, and neither does pylance/pyright. So it seems like it's strictly a PyCharm inspection problem when it comes to types, however this could also affect smaller IDE's. Those are the only two I've tested. 

Due to the popularity of PyCharm, I think this may be worth to add just to improve user usage, even if it's not technically our issue. 

Feel free to add onto this or deny it, but I think it's the only solution to https://github.com/pyglet/pyglet/issues/942 .

Just my perspective, but in the couple years I've been using PyCharm, I can't think of a time they've improved inspections or typing. (I've reported quite a few that sit open, marked as reproduced, to this day) So this might be the better route than just waiting for PyCharm to update while some users suffer.

We can always remove it in the future when most IDE's catch up to eachother.