### PR TITLE
input.controller: Properly handle inverted axis as dpad

### DIFF
--- a/pyglet/input/controller.py
+++ b/pyglet/input/controller.py
@@ -55,7 +55,7 @@ def create_guid(bus: int, vendor: int, product: int, version: int, name: str, si
 class Relation:
     __slots__ = 'control_type', 'index', 'sign'
 
-    def __init__(self, control_type, index, sign):
+    def __init__(self, control_type, index, sign=Sign.DEFAULT):
         self.control_type = control_type
         self.index = index
         self.sign = sign


### PR DESCRIPTION
When dpads are bound to axis controls (like hats), two opposing directions share the same physical control.
They therefore share the same Control event. Rather than dispatching two events for every direction pushed, this PR dynamically sets the correct operator and actuation limits to use. The same event is used, and the correct comparisons are made for cases where the binding is inverted or set to negative.