### PR TITLE
Fix "more" button outline in soundspace example

### DIFF
--- a/examples/media/soundspace/soundspace.py
+++ b/examples/media/soundspace/soundspace.py
@@ -353,6 +353,7 @@ class MoreHandle(Handle):
         else:
             self._circ.position = x, z
             self._outline.position = x, z
+            self._outline.thickness = 1.0 / self.win.zoom
             r = self.radius - 0.1
             self._line0._width = 1.0 / self.win.zoom
             _update_line(self._line0, x - r, z, x + r, z)


### PR DESCRIPTION
They turned into large blobs around this commit: 6d671c9e8503367b0f845f844a9d592735ad68af
I have to admit i didn't exactly think too deeply as to why this fixes it, but it does. The outline arc is now also in line with the `1 / zoom` thickness setting on the lines and slider box.