### PR TITLE
Convert shapes to pyglet's new type annotation + docstring style

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -721,7 +721,16 @@ class Arc(ShapeBase):
 
 class BezierCurve(ShapeBase):
 
-    def __init__(self, *points, t=1.0, segments=100, thickness=1, color=(255, 255, 255, 255), batch=None, group=None):
+    def __init__(
+            self,
+            *points: tuple[float, float],
+            t: float = 1.0,
+            segments: int = 100,
+            thickness: int =1,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a Bézier curve.
 
         The curve's anchor point (x, y) defaults to its first control point.

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -671,50 +671,41 @@ class Arc(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def radius(self):
-        """The radius of the arc.
-
-        :type: float
-        """
+    def radius(self) -> float:
+        """Get/set the radius of the arc."""
         return self._radius
 
     @radius.setter
-    def radius(self, value):
+    def radius(self, value: float) -> None:
         self._radius = value
         self._update_vertices()
 
     @property
-    def thickness(self):
+    def thickness(self) -> float:
         return self._thickness
 
     @thickness.setter
-    def thickness(self, thickness):
+    def thickness(self, thickness: float) -> None:
         self._thickness = thickness
         self._update_vertices()
 
     @property
-    def angle(self):
-        """The angle of the arc.
-
-        :type: float
-        """
+    def angle(self) -> float:
+        """Get/set the angle of the arc in radians."""
         return self._angle
 
     @angle.setter
-    def angle(self, value):
+    def angle(self, value: float) -> None:
         self._angle = value
         self._update_vertices()
 
     @property
-    def start_angle(self):
-        """The start angle of the arc.
-
-        :type: float
-        """
+    def start_angle(self) -> float:
+        """Get/set the start angle of the arc in radians."""
         return self._start_angle
 
     @start_angle.setter
-    def start_angle(self, angle):
+    def start_angle(self, angle: float):
         self._start_angle = angle
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1673,7 +1673,7 @@ class Box(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
         x, y = self._x - self._anchor_x, self._y - self._anchor_y
@@ -1720,29 +1720,31 @@ class Box(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def width(self):
-        """The width of the Box.
+    def width(self) -> float:
+        """Get/set the width of the box.
 
-        :type: float
+        Setting the width will position the left and right sides
+        relative to the box's :py:attr:`.anchor_x` value.
         """
         return self._width
 
     @width.setter
-    def width(self, value):
+    def width(self, value: float) -> None:
         self._width = value
         self._update_vertices()
 
     @property
-    def height(self):
-        """The height of the Box.
+    def height(self) -> float:
+        """Get/set the height of the Box.
 
-        :type: float
+        Setting the height will set the bottom and top relative to the
+        box's :py:attr:`.anchor_y` value.
         """
         return self._height
 
     @height.setter
-    def height(self, value):
-        self._height = value
+    def height(self, value: float) -> None:
+        self._height = float(value)
         self._update_vertices()
 
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -258,7 +258,7 @@ class ShapeBase(ABC):
     the provided shapes as reference.
     """
 
-    _rgba = (255, 255, 255, 255)
+    _rgba: tuple[int, int, int, int] = (255, 255, 255, 255)
     _rotation: float = 0.0
     _visible = True
     _x: float = 0.0

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1628,32 +1628,41 @@ class BorderedRectangle(ShapeBase):
 
 
 class Box(ShapeBase):
-    def __init__(self, x, y, width, height, thickness=1, color=(255, 255, 255, 255), batch=None, group=None):
+
+    def __init__(
+            self,
+            x: float, y: float,
+            width: float, height: float,
+            thickness: float = 1.0,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create an unfilled rectangular shape, with optional thickness.
 
-        The box's anchor point defaults to the (x, y) coordinates,
-        which are at the bottom left.
+        The box's anchor point defaults to the ``(x, y)`` coordinates,
+        which are placed at the bottom left.
         Changing the thickness of the box will extend the walls inward;
         the outward dimesions will not be affected.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 The X coordinate of the box.
-            `y` : float
+            y:
                 The Y coordinate of the box.
-            `width` : float
+            width:
                 The width of the box.
-            `height` : float
+            height:
                 The height of the box.
-            `thickness` : float
+            thickness:
                 The thickness of the lines that make up the box.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the box, specified as a tuple
                 of 3 or 4 ints in the range of 0-255. RGB colors will
                 be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the box to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the box.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -345,11 +345,14 @@ class ShapeBase(ABC):
         self._rotation = rotation
         self._vertex_list.rotation[:] = (rotation,) * self._num_verts
 
-    def draw(self):
-        """Draw the shape at its current position.
+    def draw(self) -> None:
+        """Debug method to draw a single shape at its current position.
 
-        Using this method is not recommended. Instead, add the
-        shape to a `pyglet.graphics.Batch` for efficient rendering.
+        .. warning:: Avoid this inefficient method for everyday use!
+
+                     Instead, add shapes to a :class:`Batch`and call
+                     the batch's :meth:`~Batch.draw` method instead.
+
         """
         self._group.set_state_recursive()
         self._vertex_list.draw(self._draw_mode)

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1553,15 +1553,16 @@ class BorderedRectangle(ShapeBase):
         self._update_vertices()
 
     @property
-    def height(self):
-        """The height of the rectangle.
+    def height(self) -> float:
+        """Get/set the height of the bordered rectangle.
 
-        :type: float
+        The bottom and top of the rectangle will be positioned relative
+        to its :py:attr:`.anchor_y` value.
         """
         return self._height
 
     @height.setter
-    def height(self, value):
+    def height(self, value: float) -> None:
         self._height = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1232,7 +1232,7 @@ class Line(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         vec_ab = Vec2(self._x2 - self._x, self._y2 - self._y)
         vec_ba = Vec2(self._x - self._x2, self._y - self._y2)

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -2118,32 +2118,32 @@ class Star(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def outer_radius(self):
-        """The outer radius of the star."""
+    def outer_radius(self) -> float:
+        """Get/set outer radius of the star."""
         return self._outer_radius
 
     @outer_radius.setter
-    def outer_radius(self, value):
+    def outer_radius(self, value: float) -> None:
         self._outer_radius = value
         self._update_vertices()
 
     @property
-    def inner_radius(self):
-        """The inner radius of the star."""
+    def inner_radius(self) -> float:
+        """Get/set the inner radius of the star."""
         return self._inner_radius
 
     @inner_radius.setter
-    def inner_radius(self, value):
+    def inner_radius(self, value: float) -> None:
         self._inner_radius = value
         self._update_vertices()
 
     @property
-    def num_spikes(self):
+    def num_spikes(self) -> int:
         """Number of spikes of the star."""
         return self._num_spikes
 
     @num_spikes.setter
-    def num_spikes(self, value):
+    def num_spikes(self, value: int) -> None:
         self._num_spikes = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -2013,34 +2013,44 @@ class Triangle(ShapeBase):
 
 
 class Star(ShapeBase):
-    def __init__(self, x, y, outer_radius, inner_radius, num_spikes, rotation=0,
-                 color=(255, 255, 255, 255), batch=None, group=None) -> None:
+    def __init__(
+            self,
+            x: float, y: float,
+            outer_radius: float,
+            inner_radius: float,
+            num_spikes: int,
+            rotation: float = 0.0,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group = None
+    ) -> None:
         """Create a star.
 
-        The star's anchor point (x, y) defaults to the center of the star.
+        The star's anchor point ``(x, y)`` defaults to the on-screen
+        center of the star.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 The X coordinate of the star.
-            `y` : float
+            y:
                 The Y coordinate of the star.
-            `outer_radius` : float
+            outer_radius:
                 The desired outer radius of the star.
-            `inner_radius` : float
+            inner_radius:
                 The desired inner radius of the star.
-            `num_spikes` : float
+            num_spikes:
                 The desired number of spikes of the star.
-            `rotation` : float
+            rotation:
                 The rotation of the star in degrees. A rotation of 0 degrees
                 will result in one spike lining up with the X axis in
                 positive direction.
-            `color` : (int, int, int)
+            color:
                 The RGB or RGBA color of the star, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the star to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the star.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import math
 
 from abc import ABC, abstractmethod
+from typing import Sequence
 
 import pyglet
 
@@ -2149,21 +2150,29 @@ class Star(ShapeBase):
 
 
 class Polygon(ShapeBase):
-    def __init__(self, *coordinates, color=(255, 255, 255, 255), batch=None, group=None):
+    def __init__(
+            self,
+            *coordinates: tuple[float, float] | Sequence[float],
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a convex polygon.
 
         The polygon's anchor point defaults to the first vertex point.
 
-        :Parameters:
-            `coordinates` : List[[int, int]]
-                The coordinates for each point in the polygon.
-            `color` : (int, int, int, int)
+        Args:
+            coordinates:
+                The coordinates for each point in the polygon. Each one
+                must be able to unpack to a pair of float-like X and Y
+                values.
+            color:
                 The RGB or RGBA color of the polygon, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the polygon to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the polygon.
         """
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1598,23 +1598,29 @@ class BorderedRectangle(ShapeBase):
 
     @property
     def color(self):
-        """The rectangle's fill color.
+        """Get/set the bordered rectangle's interior fill color
 
-        This property sets the color of the inside of a bordered rectangle.
+        To set the color of the border outline, see
+        :py:attr:`.border_color`.
 
-        The color is specified as an RGB tuple of integers '(red, green, blue)'
-        or an RGBA tuple of integers '(red, green, blue, alpha)`. Setting the
-        alpha on this property will change the alpha of the entire shape,
-        including both the fill and the border.
+        The color may be specified as either of the following:
 
-        Each color component must be in the range 0 (dark) to 255 (saturated).
+        * An RGBA tuple of integers ``(red, green, blue, alpha)``
+        * An RGB tuple of integers ``(red, green, blue)``
 
-        :type: (int, int, int, int)
+        Setting the alpha through this property will change the alpha
+        of the entire shape, including both the fill and the border.
+
+        Each color component must be in the range 0 (dark) to 255
+        (saturated).
         """
         return self._rgba
 
     @color.setter
-    def color(self, values):
+    def color(
+            self,
+            values: tuple[int, int, int, int] | tuple[int, int, int]
+    ) -> None:
         r, g, b, *a = values
 
         if a:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -355,12 +355,15 @@ class ShapeBase(ABC):
         self._vertex_list.draw(self._draw_mode)
         self._group.unset_state_recursive()
 
-    def delete(self):
+    def delete(self) -> None:
         """Force immediate removal of the shape from video memory.
 
-        It is recommended to call this whenever you delete a shape,
-        as the Python garbage collector will not necessarily call the
-        finalizer as soon as the sprite falls out of scope.
+        You should usually call this whenever you delete a shape. Unless
+        you are using manual garbage collection, Python might not call
+        the finalizer as soon as the sprite falls out of scope.
+
+        Manual garbage collection is a very advanced technique. See
+        Python's :py:mod:`gc` module documentation to learn more.
         """
         if self._vertex_list is not None:
             self._vertex_list.delete()

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1427,27 +1427,27 @@ class BorderedRectangle(ShapeBase):
             batch: Batch | None = None,
             group: Group | None = None
     ):
-        """Create a rectangle or square.
+        """Create a bordered rectangle.
 
-        The rectangle's anchor point defaults to the (x, y) coordinates,
+        The rectangle's anchor point defaults to the ``(x, y)`` coordinates,
         which are at the bottom left.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 The X coordinate of the rectangle.
-            `y` : float
+            y:
                 The Y coordinate of the rectangle.
-            `width` : float
+            width:
                 The width of the rectangle.
-            `height` : float
+            height:
                 The height of the rectangle.
-            `border` : float
+            border:
                 The thickness of the border.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA fill color of the rectangle, specified
                 as a tuple of 3 or 4 ints in the range of 0-255. RGB
                 colors will be treated as having an opacity of 255.
-            `border_color` : (int, int, int, int)
+            border_color:
                 The RGB or RGBA fill color of the border, specified
                 as a tuple of 3 or 4 ints in the range of 0-255. RGB
                 colors will be treated as having an opacity of 255.
@@ -1456,9 +1456,9 @@ class BorderedRectangle(ShapeBase):
                 both this argument and `border_color`. If they do not,
                 a `ValueError` will be raised informing you of the
                 ambiguity.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the rectangle to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the rectangle.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -44,7 +44,7 @@ A simple example of drawing shapes::
 
 .. versionadded:: 1.5.4
 """
-
+from __future__ import annotations
 import math
 
 from abc import ABC, abstractmethod
@@ -1747,32 +1747,39 @@ class Box(ShapeBase):
 
 
 class Triangle(ShapeBase):
-    def __init__(self, x, y, x2, y2, x3, y3, color=(255, 255, 255, 255),
-                 batch=None, group=None):
+    def __init__(
+            self,
+            x: float, y: float,
+            x2: float, y2: float,
+            x3: float, y3: float,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a triangle.
 
         The triangle's anchor point defaults to the first vertex point.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 The first X coordinate of the triangle.
-            `y` : float
+            y:
                 The first Y coordinate of the triangle.
-            `x2` : float
+            x2:
                 The second X coordinate of the triangle.
-            `y2` : float
+            y2:
                 The second Y coordinate of the triangle.
-            `x3` : float
+            x3:
                 The third X coordinate of the triangle.
-            `y3` : float
+            y3:
                 The third Y coordinate of the triangle.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the triangle, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the triangle to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the triangle.
         """
         self._x = x
@@ -1793,7 +1800,7 @@ class Triangle(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         return _sat([(self._x, self._y), (self._x2, self._y2), (self._x3, self._y3)], point)
 
@@ -1820,54 +1827,42 @@ class Triangle(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def x2(self):
-        """Second X coordinate of the shape.
-
-        :type: int or float
-        """
+    def x2(self) -> float:
+        """Get/set the X coordinate of the triangle's 2nd vertex."""
         return self._x + self._x2
 
     @x2.setter
-    def x2(self, value):
+    def x2(self, value: float) -> None:
         self._x2 = value
         self._update_vertices()
 
     @property
-    def y2(self):
-        """Second Y coordinate of the shape.
-
-        :type: int or float
-        """
+    def y2(self) -> float:
+        """Get/set the Y coordinate of the triangle's 2nd vertex."""
         return self._y + self._y2
 
     @y2.setter
-    def y2(self, value):
+    def y2(self, value: float) -> None:
         self._y2 = value
         self._update_vertices()
 
     @property
-    def x3(self):
-        """Third X coordinate of the shape.
-
-        :type: int or float
-        """
+    def x3(self) -> float:
+        """Get/set the X coordinate of the triangle's 3rd vertex."""
         return self._x + self._x3
 
     @x3.setter
-    def x3(self, value):
+    def x3(self, value: float) -> None:
         self._x3 = value
         self._update_vertices()
 
     @property
-    def y3(self):
-        """Third Y coordinate of the shape.
-
-        :type: int or float
-        """
+    def y3(self) -> float:
+        """Get/set the Y value of the triangle's 3rd vertex."""
         return self._y + self._y3
 
     @y3.setter
-    def y3(self, value):
+    def y3(self, value: float) -> None:
         self._y3 = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1162,7 +1162,7 @@ class Sector(ShapeBase):
 
     @property
     def angle(self) -> float:
-        """Get/set the angle of the sector in degrees."""
+        """Get/set the angle of the sector in radians."""
         return self._angle
 
     @angle.setter
@@ -1172,7 +1172,7 @@ class Sector(ShapeBase):
 
     @property
     def start_angle(self) -> float:
-        """Get/set the start angle of the sector in degrees."""
+        """Get/set the start angle of the sector in radians."""
         return self._start_angle
 
     @start_angle.setter

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1566,24 +1566,28 @@ class BorderedRectangle(ShapeBase):
         self._update_vertices()
 
     @property
-    def border_color(self):
-        """The rectangle's border color.
+    def border_color(self) -> tuple[int, int, int, int]:
+        """Get/set the bordered rectangle's border color.
 
-        This property sets the color of the border of a bordered rectangle.
+        To set the color of the interior fill, see :py:attr:`.color`.
 
-        The color is specified as an RGB tuple of integers '(red, green, blue)'
-        or an RGBA tuple of integers '(red, green, blue, alpha)`. Setting the
-        alpha on this property will change the alpha of the entire shape,
-        including both the fill and the border.
+        You can set the border color to either of the following:
+
+        * An RGBA tuple of integers ``(red, green, blue, alpha)``
+        * An RGB tuple of integers ``(red, green, blue)``
+
+        Setting the alpha on this property will change the alpha of
+        the entire shape, including both the fill and the border.
 
         Each color component must be in the range 0 (dark) to 255 (saturated).
-
-        :type: (int, int, int, int)
         """
         return self._border_rgba
 
     @border_color.setter
-    def border_color(self, values):
+    def border_color(
+            self,
+            values: tuple[int, int, int, int] | tuple[int, int, int]
+    ):
         r, g, b, *a = values
 
         if a:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1527,16 +1527,17 @@ class BorderedRectangle(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def border(self):
-        """The border width of the rectangle.
+    def border(self) -> float:
+        """The border thickness of the bordered rectangle.
 
-        :return: float
+        This extends inward from the edge of the rectangle toward the
+        center.
         """
         return self._border
 
     @border.setter
-    def border(self, width):
-        self._border = width
+    def border(self, thickness: float) -> None:
+        self._border = thickness
         self._update_vertices()
 
     @property

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1105,7 +1105,7 @@ class Sector(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
         angle = math.atan2(point[1] - self._y + self._anchor_y, point[0] - self._x + self._anchor_x)

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -816,37 +816,32 @@ class BezierCurve(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def points(self):
-        """Control points of the curve.
-
-        :type: List[[int, int]]
-        """
+    def points(self) -> list[tuple[float, float]]:
+        """Get/set the control points of the curve."""
         return self._points
 
     @points.setter
-    def points(self, value):
+    def points(self, value: list[tuple[float, float]]):
         self._points = value
         self._update_vertices()
 
     @property
-    def t(self):
-        """Draw `100*t` percent of the curve.
-
-        :type: float
-        """
+    def t(self) -> float:
+        """Get/set the t in ``100*t`` percent of the curve to draw."""
         return self._t
 
     @t.setter
-    def t(self, value):
+    def t(self, value: float) -> None:
         self._t = value
         self._update_vertices()
 
     @property
-    def thickness(self):
+    def thickness(self) -> float:
+        """Get/set the line thickness for the bezier curve."""
         return self._thickness
 
     @thickness.setter
-    def thickness(self, thickness):
+    def thickness(self, thickness: float) -> None:
         self._thickness = thickness
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -564,35 +564,35 @@ class Arc(ShapeBase):
 
         The Arc's anchor point (x, y) defaults to its center.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 X coordinate of the circle.
-            `y` : float
+            y:
                 Y coordinate of the circle.
-            `radius` : float
+            radius:
                 The desired radius.
-            `segments` : int
+            segments:
                 You can optionally specify how many distinct line segments
                 the arc should be made from. If not specified it will be
                 automatically calculated using the formula:
                 `max(14, int(radius / 1.25))`.
-            `angle` : float
+            angle:
                 The angle of the arc, in radians. Defaults to tau (pi * 2),
                 which is a full circle.
-            `start_angle` : float
+            start_angle:
                 The start angle of the arc, in radians. Defaults to 0.
-            `closed` : bool
+            closed:
                 If True, the ends of the arc will be connected with a line.
                 defaults to False.
-            `thickness` : float
+            thickness:
                 The desired thickness or width of the line used for the arc.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the arc, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the circle to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the circle.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -735,25 +735,25 @@ class BezierCurve(ShapeBase):
 
         The curve's anchor point (x, y) defaults to its first control point.
 
-        :Parameters:
-            `points` : List[[int, int]]
+        Args:
+            points:
                 Control points of the curve. Points can be specified as multiple
                 lists or tuples of point pairs. Ex. (0,0), (2,3), (1,9)
-            `t` : float
+            t:
                 Draw `100*t` percent of the curve. 0.5 means the curve
                 is half drawn and 1.0 means draw the whole curve.
-            `segments` : int
+            segments:
                 You can optionally specify how many line segments the
                 curve should be made from.
-            `thickness` : float
+            thickness:
                 The desired thickness or width of the line used for the curve.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the curve, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the curve to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the curve.
         """
         self._points = list(points)

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1055,8 +1055,17 @@ class Ellipse(ShapeBase):
 
 class Sector(ShapeBase):
 
-    def __init__(self, x, y, radius, segments=None, angle=math.tau, start_angle=0,
-                 color=(255, 255, 255, 255), batch=None, group=None):
+    def __init__(
+            self,
+            x: float, y: float,
+            radius: float,
+            segments: int | None = None,
+            angle: float = math.tau,
+            start_angle: float = 0.0,
+            color: tuple[int, int, int, int] | tuple[int, int, it] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a Sector of a circle.
 
         By default, ``(x, y)`` is used as:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -278,7 +278,7 @@ class ShapeBase(ABC):
         if self._vertex_list is not None:
             self._vertex_list.delete()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         """Test whether a point is inside a shape."""
         raise NotImplementedError(f"The `in` operator is not supported for {self.__class__.__name__}")
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -259,7 +259,7 @@ class ShapeBase(ABC):
     """
 
     _rgba = (255, 255, 255, 255)
-    _rotation = 0
+    _rotation: float = 0.0
     _visible = True
     _x: float = 0.0
     _y: float = 0.0
@@ -323,20 +323,29 @@ class ShapeBase(ABC):
 
     @property
     def rotation(self) -> float:
-        """Clockwise rotation of the shape in degrees.
+        """Get/set the shape's clockwise rotation in degrees.
 
-        It will be rotated about its (anchor_x, anchor_y) position,
-        which defaults to the first vertex point of the shape.
+        All shapes rotate around their :attr:`.anchor_position`.
+        For most shapes, this defaults to both:
 
-        For most shapes, this is the lower left corner. The shapes
-        below default to the points their ``radius`` values are
-        measured from:
+        * The shape's first vertex of the shape
+        * The lower left corner
 
-            * :py:class:`.Circle`
-            * :py:class:`.Ellipse`
-            * :py:class:`.Arc`
-            * :py:class:`.Sector`
-            * :py:class:`.Star`
+        Shapes with a ``radius`` property rotate around the
+        point the radius is measured from. This will be either
+        their center or the center of the circle they're cut from:
+
+        These shapes rotate around their center:
+
+        * :py:class:`.Circle`
+        * :py:class:`.Ellipse`
+        * :py:class:`.Star`
+
+        These shapes rotate around the point of their angles:
+
+        * :py:class:`.Arc`
+        * :py:class:`.Sector`
+
         """
         return self._rotation
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1188,30 +1188,38 @@ class Sector(ShapeBase):
 
 
 class Line(ShapeBase):
-    def __init__(self, x, y, x2, y2, width=1, color=(255, 255, 255, 255), batch=None, group=None):
+
+    def __init__(
+            self,
+            x: float, y: float, x2: float, y2: float,
+            width: float = 1.0,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a line.
 
         The line's anchor point defaults to the center of the line's
         width on the X axis, and the Y axis.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 The first X coordinate of the line.
-            `y` : float
+            y:
                 The first Y coordinate of the line.
-            `x2` : float
+            x2:
                 The second X coordinate of the line.
-            `y2` : float
+            y2:
                 The second Y coordinate of the line.
-            `width` : float
+            width:
                 The desired width of the line.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the line, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the line to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the line.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1054,38 +1054,42 @@ class Ellipse(ShapeBase):
 
 
 class Sector(ShapeBase):
+
     def __init__(self, x, y, radius, segments=None, angle=math.tau, start_angle=0,
                  color=(255, 255, 255, 255), batch=None, group=None):
         """Create a Sector of a circle.
 
-                The sector's anchor point (x, y) defaults to the center of the circle.
+        By default, ``(x, y)`` is used as:
 
-                :Parameters:
-                    `x` : float
-                        X coordinate of the sector.
-                    `y` : float
-                        Y coordinate of the sector.
-                    `radius` : float
-                        The desired radius.
-                    `segments` : int
-                        You can optionally specify how many distinct triangles
-                        the sector should be made from. If not specified it will
-                        be automatically calculated using the formula:
-                        `max(14, int(radius / 1.25))`.
-                    `angle` : float
-                        The angle of the sector, in radians. Defaults to tau (pi * 2),
-                        which is a full circle.
-                    `start_angle` : float
-                        The start angle of the sector, in radians. Defaults to 0.
-                    `color` : (int, int, int, int)
-                        The RGB or RGBA color of the circle, specified as a
-                        tuple of 3 or 4 ints in the range of 0-255. RGB colors
-                        will be treated as having an opacity of 255.
-                    `batch` : `~pyglet.graphics.Batch`
-                        Optional batch to add the sector to.
-                    `group` : `~pyglet.graphics.Group`
-                        Optional parent group of the sector.
-                """
+        * The sector's anchor point
+        * The center of the circle the sector is cut from
+
+        :Parameters:
+            `x` : float
+                X coordinate of the sector.
+            `y` : float
+                Y coordinate of the sector.
+            `radius` : float
+                The desired radius.
+            `segments` : int
+                You can optionally specify how many distinct triangles
+                the sector should be made from. If not specified it will
+                be automatically calculated using the formula:
+                `max(14, int(radius / 1.25))`.
+            `angle` : float
+                The angle of the sector, in radians. Defaults to tau (pi * 2),
+                which is a full circle.
+            `start_angle` : float
+                The start angle of the sector, in radians. Defaults to 0.
+            `color` : (int, int, int, int)
+                The RGB or RGBA color of the circle, specified as a
+                tuple of 3 or 4 ints in the range of 0-255. RGB colors
+                will be treated as having an opacity of 255.
+            `batch` : `~pyglet.graphics.Batch`
+                Optional batch to add the sector to.
+            `group` : `~pyglet.graphics.Group`
+                Optional parent group of the sector.
+        """
         self._x = x
         self._y = y
         self._radius = radius

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -955,24 +955,25 @@ class Ellipse(ShapeBase):
     ):
         """Create an ellipse.
 
-        The ellipse's anchor point (x, y) defaults to the center of the ellipse.
+        The ellipse's anchor point ``(x, y)`` defaults to the center of
+        the ellipse.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 X coordinate of the ellipse.
-            `y` : float
+            y:
                 Y coordinate of the ellipse.
-            `a` : float
+            a:
                 Semi-major axes of the ellipse.
-            `b`: float
+            b:
                 Semi-minor axes of the ellipse.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the ellipse, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the circle to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the circle.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1321,29 +1321,36 @@ class Line(ShapeBase):
 
 
 class Rectangle(ShapeBase):
-    def __init__(self, x, y, width, height, color=(255, 255, 255, 255),
-                 batch=None, group=None):
+
+    def __init__(
+            self,
+            x: float, y: float,
+            width: float, height: float,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a rectangle or square.
 
-        The rectangle's anchor point defaults to the (x, y) coordinates,
-        which are at the bottom left.
+        The rectangle's anchor point defaults to the ``(x, y)``
+        coordinates, which are at the bottom left.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 The X coordinate of the rectangle.
-            `y` : float
+            y:
                 The Y coordinate of the rectangle.
-            `width` : float
+            width:
                 The width of the rectangle.
-            `height` : float
+            height:
                 The height of the rectangle.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the circle, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the rectangle to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the rectangle.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1064,30 +1064,30 @@ class Sector(ShapeBase):
         * The sector's anchor point
         * The center of the circle the sector is cut from
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 X coordinate of the sector.
-            `y` : float
+            y:
                 Y coordinate of the sector.
-            `radius` : float
+            radius:
                 The desired radius.
-            `segments` : int
+            segments:
                 You can optionally specify how many distinct triangles
                 the sector should be made from. If not specified it will
                 be automatically calculated using the formula:
                 `max(14, int(radius / 1.25))`.
-            `angle` : float
+            angle:
                 The angle of the sector, in radians. Defaults to tau (pi * 2),
                 which is a full circle.
-            `start_angle` : float
+            start_angle:
                 The start angle of the sector, in radians. Defaults to 0.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the circle, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the sector to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the sector.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -2226,24 +2226,37 @@ class Polygon(ShapeBase):
 
 
 class MultiLine(ShapeBase):
-    def __init__(self, *coordinates, closed=False, thickness=1, color=(255, 255, 255, 255), batch=None, group=None):
-        """Create multiple connected lines from a sequence of coordinates
+
+    def __init__(
+            self,
+            *coordinates: tuple[float, float] | Sequence[float],
+            closed: bool = False,
+            thickness: float = 1.0,
+            color: tuple[int, int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
+        """Create multiple connected lines from a series of coordinates.
+
         The shape's anchor point defaults to the first vertex point.
-        :Parameters:
-            `coordinates` : List[[int, int]]
-                The coordinates for each point in the shape.
-            `closed` : bool
-                If True, the first and last coordinate will be connected with a line.
-                defaults to False.
-            `thickness` : float
+
+        Args:
+            coordinates:
+                The coordinates for each point in the shape. Each must
+                unpack like a tuple consisting of an X and Y float-like
+                value.
+            closed:
+                Set this to ``True`` to add a line connecting the first
+                and last points. The default is ``False``
+            thickness:
                 The desired thickness or width used for the line segments.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the shape, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the shape to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the shape.
         """
         # len(self._coordinates) = the number of vertices in the shape.

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -258,7 +258,9 @@ class ShapeBase(ABC):
     the provided shapes as reference.
     """
 
-    _rgba: tuple[int, int, int, int] = (255, 255, 255, 255)
+    # _rgba and any class attribute set to None is untyped because
+    # doing so doesn't require None-handling from some type checkers.
+    _rgba = (255, 255, 255, 255)
     _rotation: float = 0.0
     _visible: bool = True
     _x: float = 0.0
@@ -267,9 +269,9 @@ class ShapeBase(ABC):
     _anchor_y: float = 0.0
     _batch = None
     _group = None
-    _num_verts = 0
+    _num_verts: int = 0
     _vertex_list = None
-    _draw_mode = GL_TRIANGLES
+    _draw_mode: int = GL_TRIANGLES
     group_class = _ShapeGroup
 
     def __del__(self):

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1417,8 +1417,16 @@ class Rectangle(ShapeBase):
 
 
 class BorderedRectangle(ShapeBase):
-    def __init__(self, x, y, width, height, border=1, color=(255, 255, 255),
-                 border_color=(100, 100, 100), batch=None, group=None):
+
+    def __init__(
+            self,
+            x: float, y: float, width: float, height: float,
+            border: float = 1.0,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255),
+            border_color: tuple[int, int, int, int] | tuple[int, int, int] = (100, 100, 100),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a rectangle or square.
 
         The rectangle's anchor point defaults to the (x, y) coordinates,

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -511,12 +511,19 @@ class ShapeBase(ABC):
         self._update_vertices()
 
     @property
-    def group(self):
-        """User assigned :class:`Group` object."""
+    def group(self) -> Group:
+        """Get/set the shape's :class:`Group`.
+
+        .. warning:: This breaks when :py:attr:`.batch` is ``None``!
+
+        You can migrate a shape from one group to another by setting
+        this property, but it can be an expensive (slow) operation. This
+        will also trigger a batch migration.
+        """
         return self._group.parent
 
     @group.setter
-    def group(self, group):
+    def group(self, group: Group) -> None:
         if self._group.parent == group:
             return
         self._group = self.group_class(self._group.blend_src,
@@ -527,12 +534,20 @@ class ShapeBase(ABC):
                             self._batch)
 
     @property
-    def batch(self):
-        """User assigned :class:`Batch` object."""
+    def batch(self) -> Batch | None:
+        """Get/set the :class:`Batch` for this shape.
+
+        .. warning:: Setting this to ``None`` currently breaks things!
+
+                     Known issues include :py:attr:`.group` breaking.
+
+        You can migrate a shape from one batch to another by setting
+        this property, but it can be an expensive (slow) operation.
+        """
         return self._batch
 
     @batch.setter
-    def batch(self, batch):
+    def batch(self, batch: Batch | None) -> None:
         if self._batch == batch:
             return
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -987,7 +987,7 @@ class Ellipse(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
         # Since directly testing whether a point is inside an ellipse is more

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -260,7 +260,7 @@ class ShapeBase(ABC):
 
     _rgba: tuple[int, int, int, int] = (255, 255, 255, 255)
     _rotation: float = 0.0
-    _visible = True
+    _visible: bool = True
     _x: float = 0.0
     _y: float = 0.0
     _anchor_x: float = 0.0

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -826,7 +826,7 @@ class BezierCurve(ShapeBase):
 
     @property
     def points(self) -> list[tuple[float, float]]:
-        """Get/set the control points of the curve."""
+        """Get/set the control points of the Bézier curve."""
         return self._points
 
     @points.setter
@@ -846,7 +846,7 @@ class BezierCurve(ShapeBase):
 
     @property
     def thickness(self) -> float:
-        """Get/set the line thickness for the bezier curve."""
+        """Get/set the line thickness for the Bézier curve."""
         return self._thickness
 
     @thickness.setter

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -477,36 +477,50 @@ class ShapeBase(ABC):
         self._update_color()
 
     @property
-    def opacity(self):
-        """Blend opacity.
+    def opacity(self) -> int:
+        """Get/set the blend opacity of the shape.
 
-        This property sets the alpha component of the color of the shape.
-        With the default blend mode (see the constructor), this allows the
-        shape to be drawn with fractional opacity, blending with the
-        background.
+        .. tip:: To toggle visibility on/off, :py:attr:`.visible` may be
+                 more efficient!
 
-        An opacity of 255 (the default) has no effect.  An opacity of 128
-        will make the shape appear translucent.
+        Opacity is implemented as the alpha component of a shape's
+        :py:attr:`.color`. When part of a group with a default blend
+        mode of ``(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)``, opacities
+        below ``255`` draw with fractional opacity over the background:
 
-        :type: int
+        .. list-table:: Example Values & Effects
+           :header-rows: 1
+
+           * - Opacity
+             - Effect
+
+           * - ``255`` (Default)
+             - Shape is fully opaque
+
+           * - ``128``
+             - Shape looks translucent
+
+           * - ``0``
+             - Invisible
+
         """
         return self._rgba[3]
 
     @opacity.setter
-    def opacity(self, value):
+    def opacity(self, value: int) -> None:
         self._rgba = (*self._rgba[:3], value)
         self._update_color()
 
     @property
-    def visible(self):
-        """True if the shape will be drawn.
+    def visible(self) -> bool:
+        """Get/set whether the shape will be drawn at all.
 
-        :type: bool
+        For absolute showing / hiding, this is
         """
         return self._visible
 
     @visible.setter
-    def visible(self, value):
+    def visible(self, value: bool) -> None:
         self._visible = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -893,7 +893,7 @@ class Circle(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         return math.dist((self._x - self._anchor_x, self._y - self._anchor_y), point) < self._radius
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -852,8 +852,16 @@ class BezierCurve(ShapeBase):
 
 
 class Circle(ShapeBase):
-    def __init__(self, x, y, radius, segments=None, color=(255, 255, 255, 255),
-                 batch=None, group=None):
+
+    def __init__(
+            self,
+            x: float, y: float,
+            radius: float,
+            segments: int | None = None,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create a circle.
 
         The circle's anchor point (x, y) defaults to the center of the circle.

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1540,15 +1540,16 @@ class BorderedRectangle(ShapeBase):
         self._update_vertices()
 
     @property
-    def width(self):
-        """The width of the rectangle.
+    def width(self) -> float:
+        """Get/set width of the bordered rectangle.
 
-        :type: float
+        The new left and right of the rectangle will be set relative to
+        its :py:attr:`.anchor_x` value.
         """
         return self._width
 
     @width.setter
-    def width(self, value):
+    def width(self, value: float):
         self._width = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1390,28 +1390,30 @@ class Rectangle(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def width(self):
-        """The width of the rectangle.
+    def width(self) -> float:
+        """Get/set width of the rectangle.
 
-        :type: float
+        The new left and right of the rectangle will be set relative to
+        its :py:attr:`.anchor_x` value.
         """
         return self._width
 
     @width.setter
-    def width(self, value):
+    def width(self, value: float) -> None:
         self._width = value
         self._update_vertices()
 
     @property
-    def height(self):
-        """The height of the rectangle.
+    def height(self) -> float:
+        """Get/set the height of the rectangle.
 
-        :type: float
+        The bottom and top of the rectangle will be positioned relative
+        to its :py:attr:`.anchor_y` value.
         """
         return self._height
 
     @height.setter
-    def height(self, value):
+    def height(self, value: float) -> None:
         self._height = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -929,15 +929,12 @@ class Circle(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def radius(self):
-        """The radius of the circle.
-
-        :type: float
-        """
+    def radius(self) -> float:
+        """Gets/set radius of the circle."""
         return self._radius
 
     @radius.setter
-    def radius(self, value):
+    def radius(self, value: float) -> None:
         self._radius = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -2318,11 +2318,12 @@ class MultiLine(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def thickness(self):
+    def thickness(self) -> float:
+        """Get/set the line thickness of the multi-line."""
         return self._thickness
 
     @thickness.setter
-    def thickness(self, thickness):
+    def thickness(self, thickness: float) -> None:
         self._thickness = thickness
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1148,41 +1148,36 @@ class Sector(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def angle(self):
-        """The angle of the sector.
-
-        :type: float
-        """
+    def angle(self) -> float:
+        """Get/set the angle of the sector in degrees."""
         return self._angle
 
     @angle.setter
-    def angle(self, value):
+    def angle(self, value: float) -> None:
         self._angle = value
         self._update_vertices()
 
     @property
-    def start_angle(self):
-        """The start angle of the sector.
-
-        :type: float
-        """
+    def start_angle(self) -> float:
+        """Get/set the start angle of the sector in degrees."""
         return self._start_angle
 
     @start_angle.setter
-    def start_angle(self, angle):
+    def start_angle(self, angle: float) -> None:
         self._start_angle = angle
         self._update_vertices()
 
     @property
-    def radius(self):
-        """The radius of the sector.
+    def radius(self) -> float:
+        """Get/set the radius of the sector.
 
-        :type: float
+        By default, this is in screen pixels. Your drawing / GL settings
+        may alter how this is drawn.
         """
         return self._radius
 
     @radius.setter
-    def radius(self, value):
+    def radius(self, value: float) -> None:
         self._radius = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1027,28 +1027,22 @@ class Ellipse(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def a(self):
-        """The semi-major axes of the ellipse.
-
-        :type: float
-        """
+    def a(self) -> float:
+        """Get/set the semi-major axes of the ellipse."""
         return self._a
 
     @a.setter
-    def a(self, value):
+    def a(self, value: float) -> None:
         self._a = value
         self._update_vertices()
 
     @property
-    def b(self):
-        """The semi-minor axes of the ellipse.
-
-        :type: float
-        """
+    def b(self) -> float:
+        """Get/set the semi-minor axes of the ellipse."""
         return self._b
 
     @b.setter
-    def b(self, value):
+    def b(self, value: float) -> None:
         self._b = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -866,25 +866,25 @@ class Circle(ShapeBase):
 
         The circle's anchor point (x, y) defaults to the center of the circle.
 
-        :Parameters:
-            `x` : float
+        Args:
+            x:
                 X coordinate of the circle.
-            `y` : float
+            y:
                 Y coordinate of the circle.
-            `radius` : float
+            radius:
                 The desired radius.
-            `segments` : int
+            segments:
                 You can optionally specify how many distinct triangles
                 the circle should be made from. If not specified it will
                 be automatically calculated using the formula:
                 `max(14, int(radius / 1.25))`.
-            `color` : (int, int, int, int)
+            color:
                 The RGB or RGBA color of the circle, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the circle to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the circle.
         """
         self._x = x

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1558,7 +1558,7 @@ class BorderedRectangle(ShapeBase):
         return self._width
 
     @width.setter
-    def width(self, value: float):
+    def width(self, value: float) -> None:
         self._width = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -261,10 +261,10 @@ class ShapeBase(ABC):
     _rgba = (255, 255, 255, 255)
     _rotation = 0
     _visible = True
-    _x = 0
-    _y = 0
-    _anchor_x = 0
-    _anchor_y = 0
+    _x: float = 0.0
+    _y: float = 0.0
+    _anchor_x: float = 0.0
+    _anchor_y: float = 0.0
     _batch = None
     _group = None
     _num_verts = 0
@@ -367,88 +367,116 @@ class ShapeBase(ABC):
             self._vertex_list = None
 
     @property
-    def x(self):
-        """X coordinate of the shape.
+    def x(self) -> float:
+        """Get/set the X coordinate of the shape's :attr:`.position`.
 
-        :type: int or float
+        #. To update both :attr:`.x` and :attr:`.y`, use
+           :attr:`.position` instead.
+        #. Shapes may vary slightly in how they use :attr:`.position`
+
+        See :attr:`.position` to learn more.
         """
         return self._x
 
     @x.setter
-    def x(self, value):
+    def x(self, value: float) -> None:
         self._x = value
         self._update_translation()
 
     @property
-    def y(self):
-        """Y coordinate of the shape.
+    def y(self) -> float:
+        """Get/set the Y coordinate of the shape's :attr:`.position`.
 
-        :type: int or float
+        This property has the following pitfalls:
+
+        #. To update both :attr:`.x` and :attr:`.y`, use
+           :attr:`.position` instead.
+        #. Shapes may vary slightly in how they use :attr:`.position`
+
+        See :attr:`.position` to learn more.
         """
         return self._y
 
     @y.setter
-    def y(self, value):
+    def y(self, value: float) -> None:
         self._y = value
         self._update_translation()
 
     @property
-    def position(self):
-        """The (x, y) coordinates of the shape, as a tuple.
+    def position(self) -> tuple[float, float]:
+        """Get/set the ``(x, y)`` coordinates of the shape.
 
-        :Parameters:
-            `x` : int or float
-                X coordinate of the sprite.
-            `y` : int or float
-                Y coordinate of the sprite.
+        .. tip:: This is more efficient than setting :attr:`.x` and
+                 :attr:`.y`separately!
+
+        All shapes default to rotating around their position. However,
+        the way they do so varies.
+
+        Shapes with a ``radius`` property will use this as their
+        center:
+
+        * :py:class:`.Circle`
+        * :py:class:`.Ellipse`
+        * :py:class:`.Arc`
+        * :py:class:`.Sector`
+        * :py:class:`.Star`
+
+        Others default to using it as their lower left corner.
         """
         return self._x, self._y
 
     @position.setter
-    def position(self, values):
+    def position(self, values: tuple[float, float]) -> None:
         self._x, self._y = values
         self._update_translation()
 
     @property
-    def anchor_x(self):
-        """The X coordinate of the anchor point
+    def anchor_x(self) -> float:
+        """Get/set the X coordinate of the anchor point.
 
-        :type: int or float
+        If you need to set both this and :attr:`.anchor_x`, use
+        :attr:`.anchor_position` instead.
         """
         return self._anchor_x
 
     @anchor_x.setter
-    def anchor_x(self, value):
+    def anchor_x(self, value: float) -> None:
         self._anchor_x = value
         self._update_vertices()
 
     @property
-    def anchor_y(self):
-        """The Y coordinate of the anchor point
+    def anchor_y(self) -> float:
+        """Get/set the Y coordinate of the anchor point.
 
-        :type: int or float
+        If you need to set both this and :attr:`.anchor_x`, use
+        :attr:`.anchor_position` instead.
         """
         return self._anchor_y
 
     @anchor_y.setter
-    def anchor_y(self, value):
+    def anchor_y(self, value: float) -> None:
         self._anchor_y = value
         self._update_vertices()
 
     @property
-    def anchor_position(self):
-        """The (x, y) coordinates of the anchor point, as a tuple.
+    def anchor_position(self) -> tuple[float, float]:
+        """Get/set the anchor's ``(x, y)`` offset from :attr:`.position`
 
-        :Parameters:
-            `x` : int or float
-                X coordinate of the anchor point.
-            `y` : int or float
-                Y coordinate of the anchor point.
+        This defines the point a shape rotates around. By default, it is
+        ``(0.0, 0.0)``. However:
+
+        * Its behavior may vary between shape classes.
+        * On many shapes, you can set the anchor or its components
+          (:attr:`.anchor_x` and :attr:`.anchor_y`) to custom values.
+
+        Since all anchor updates recalculate a shape's vertices on the
+        CPU, this property is faster than updating :attr:`.anchor_x` and
+        :attr:`.anchor_y` separately.
         """
         return self._anchor_x, self._anchor_y
 
     @anchor_position.setter
-    def anchor_position(self, values):
+    def anchor_position(self, values: tuple[float, float]) -> None:
         self._anchor_x, self._anchor_y = values
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1489,7 +1489,7 @@ class BorderedRectangle(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
         x, y = self._x - self._anchor_x, self._y - self._anchor_y

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1285,37 +1285,32 @@ class Line(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
-    def width(self):
+    def width(self) -> float:
+        """Get/set the line's thickness."""
         return self._width
 
     @width.setter
-    def width(self, width):
+    def width(self, width: float) -> None:
         self._width = width
         self._update_vertices()
 
     @property
-    def x2(self):
-        """Second X coordinate of the shape.
-
-        :type: int or float
-        """
+    def x2(self) -> float:
+        """Get/set the 2nd X coordinate of the line."""
         return self._x2
 
     @x2.setter
-    def x2(self, value):
+    def x2(self, value: float) -> None:
         self._x2 = value
         self._update_vertices()
 
     @property
-    def y2(self):
-        """Second Y coordinate of the shape.
-
-        :type: int or float
-        """
+    def y2(self) -> float:
+        """Get/set the 2nd Y coordinate of the line."""
         return self._y2
 
     @y2.setter
-    def y2(self, value):
+    def y2(self, value: float) -> None:
         self._y2 = value
         self._update_vertices()
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -453,20 +453,25 @@ class ShapeBase(ABC):
         self._update_vertices()
 
     @property
-    def color(self):
-        """The shape color.
+    def color(self) -> tuple[int, int, int, int]:
+        """Get/set the shape's color.
 
-        This property sets the color of the shape.
+        The color may set to:
 
-        The color is specified as an RGB tuple of integers '(red, green, blue)'.
-        Each color component must be in the range 0 (dark) to 255 (saturated).
+        * An RGBA tuple of integers ``(red, green, blue, alpha)``
+        * An RGB tuple of integers ``(red, green, blue)``
 
-        :type: (int, int, int)
+        If an RGB color is set, the current alpha will be preserved.
+        Otherwise, the new alpha value will be used for the shape. Each
+        color component must be in the range 0 (dark) to 255 (saturated).
         """
         return self._rgba
 
     @color.setter
-    def color(self, values):
+    def color(
+            self,
+            values: tuple[int, int, int, int] | tuple[int, int, int]
+    ) -> None:
         r, g, b, *a = values
 
         if a:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1362,7 +1362,7 @@ class Rectangle(ShapeBase):
 
         self._create_vertex_list()
 
-    def __contains__(self, point):
+    def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
         point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
         x, y = self._x - self._anchor_x, self._y - self._anchor_y

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -943,8 +943,16 @@ class Circle(ShapeBase):
 
 
 class Ellipse(ShapeBase):
-    def __init__(self, x, y, a, b, segments=None, color=(255, 255, 255, 255),
-                 batch=None, group=None):
+
+    def __init__(
+            self,
+            x: float, y: float,
+            a: float, b: float,
+            segments: int | None = None,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create an ellipse.
 
         The ellipse's anchor point (x, y) defaults to the center of the ellipse.

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -547,8 +547,19 @@ class ShapeBase(ABC):
 
 class Arc(ShapeBase):
 
-    def __init__(self, x, y, radius, segments=None, angle=math.tau, start_angle=0,
-                 closed=False, thickness=1, color=(255, 255, 255, 255), batch=None, group=None):
+    def __init__(
+            self,
+            x: float, y: float,
+            radius: float,
+            segments: int | None = None,
+            angle: float = math.tau,
+            start_angle: float = 0.0,
+            closed: bool = False,
+            thickness: float = 1.0,
+            color=(255, 255, 255, 255),
+            batch: Batch | None = None,
+            group: Group | None = None
+    ):
         """Create an Arc.
 
         The Arc's anchor point (x, y) defaults to its center.


### PR DESCRIPTION
TL;DR: Help with #1084 by addressing shapes.

### Changes

1. Move typing from docstrings to signatures:
   * Use the pipe syntax since it's been approved and somewhat tested on 3.8 with `from __future__ import annotations`
   * Place some annotations on default class attributes, but not all
   * Add comments explaining why
2. Convert docstrings to new formats
3. Add improvements for clarity and usability:
   1. Fix outdated references to blend modes and opacity in `__init__` doc
   2. Document broken `ShapeBase.group` behavior when `self.batch == None`
   3. Attempt to clarify rotation and anchor behavior
   4. Add cross-references
   5. Use `.. warning::` and :.. tip::` directives
   6. Use more flexible typing on `Polygon` and `MultiLine` types since they seem to target advanced users
 