### PR TITLE
Fix ShapeBase.group setter to only migrate batch when batch is not None

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -615,8 +615,11 @@ class ShapeBase(ABC):
                                        self._group.blend_dest,
                                        self._group.program,
                                        group)
-        self._batch.migrate(self._vertex_list, self._draw_mode, self._group,
-                            self._batch)
+        if self._batch:
+            self._batch.migrate(self._vertex_list,
+                                self._draw_mode,
+                                self._group,
+                                self._batch)
 
     @property
     def batch(self) -> Batch | None:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -599,11 +599,11 @@ class ShapeBase(ABC):
     def group(self) -> Group:
         """Get/set the shape's :class:`Group`.
 
-        .. warning:: This breaks when :py:attr:`.batch` is ``None``!
-
         You can migrate a shape from one group to another by setting
-        this property, but it can be an expensive (slow) operation. This
-        will also trigger a batch migration.
+        this property. Note that it can be an expensive (slow) operation.
+
+        If :py:attr:`.batch` isn't ``None``, setting this property will
+        also trigger a batch migration.
         """
         return self._group.parent
 


### PR DESCRIPTION
TL;DR: Make `ShapeBase.group`'s setter act like `Sprite.group`'s

Follow-up to #1088 based on dicussion with ballman and Ben.

### Changes

1. Only migrate when `self._batch` isn't None
2. Update docstrings to account for this