### PR TITLE
Add RGB support to label init

### DIFF
--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -412,6 +412,9 @@ class Label(DocumentLabel):
                 Optional graphics shader to use. Will affect all glyphs.
         """
         doc = decode_text(text)
+        r, g, b, *a = color
+        rgba = r, g, b, a[0] if a else 255
+
         super().__init__(doc, x, y, z, width, height, anchor_x, anchor_y, rotation,
                          multiline, dpi, batch, group, program, init_document=False)
 
@@ -421,7 +424,7 @@ class Label(DocumentLabel):
             "bold": bold,
             "italic": italic,
             "stretch": stretch,
-            "color": color,
+            "color": rgba,
             "align": align,
         })
 

--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -351,7 +351,7 @@ class Label(DocumentLabel):
             multiline: bool = False, dpi: int | None = None,
             font_name: str | None = None, font_size: int | None = None,
             bold: bool | str = False, italic: bool | str = False, stretch: bool | str = False,
-            color: tuple[int, int, int, int] = (255, 255, 255, 255),
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
             align: ContentVAlign = "left",
             batch: Batch | None = None, group: Group | None = None,
             program: ShaderProgram | None = None,
@@ -373,7 +373,8 @@ class Label(DocumentLabel):
             stretch:
                  Stretch font style.
             color:
-                Font colour, as RGBA components in range [0, 255].
+                Font color as RGBA or RGB components, each within
+                ``0 <= component <= 255``.
             x:
                 X coordinate of the label.
             y:


### PR DESCRIPTION
Closes #944

### Changes

1. Add RGB support to label
2. Add new-style type annotations
3. Update docstring