### PR TITLE
Fix a rarely-failing audio time test

### DIFF
--- a/tests/unit/media/test_player.py
+++ b/tests/unit/media/test_player.py
@@ -356,9 +356,10 @@ class PlayerTestCase(unittest.TestCase):
 
         self.reset_mocks()
         self.player.play()
+        self.assertGreaterEqual(self.player.time, 0.5)
         self.assertAlmostEqual(
-            self.player.time, 0.5, places=2,
-            msg='While playing, player should return time from driver player'
+            self.player.time, 0.5, delta=0.01,
+            msg='Player time should have advanced during pause'
         )
         self.assert_driver_player_started()
         self.assert_no_new_driver_player_created()


### PR DESCRIPTION
Calling into the low-level player mock's `stop` method takes a whole 0.5ms on my system; possibly more on a GH runner which might have caused the failure in https://github.com/pyglet/pyglet/actions/runs/8690122582/job/23829296366?pr=1090

Not entirely sure what to do with it, now it basically just verifies the high-level player's time (from its `PlaybackTimer`) didn't advance too much.

- This test had an outdated message in which it was expecting the audio backend time from accessing `player.time`.
- Changed failure metric from rounded comparison to delta comparison.
- Set delta to `0.01`. With a 2-place-rounding and comparison value of `0.5` previously the delta would theoretically have been `0.0049̅`.