### PR TITLE
Update unittests.yml

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     name: Python ${{ matrix.python-version }} OSX
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove Python 3.8 and 3.9 on OSX due to lack of availability on arm64 runners.