### PR TITLE
Fix uniforms in pyglet.graphics.shader

### DIFF
--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -322,12 +322,13 @@ class _UniformArray:
 
 
 class _Uniform:
-    __slots__ = 'type', 'size', 'location', 'length', 'count', 'get', 'set'
+    __slots__ = 'type', 'size', 'location', 'length', 'count', 'get', 'set', 'program'
 
     def __init__(self, program, uniform_type, size, location, dsa):
         self.type = uniform_type
         self.size = size
         self.location = location
+        self.program = program
 
         gl_type, gl_setter_legacy, gl_setter_dsa, length = _uniform_setters[uniform_type]
         gl_setter = gl_setter_dsa if dsa else gl_setter_legacy


### PR DESCRIPTION
Fixing a bug in Pyglet where the `Uniform` object doesn't have the reference to the `ShaderProgram` it belongs to.

This causes problems when we try to write a numpy array to the uniform object.

When we try to assign to a uniform from Numpy array, it throws an error without this patch:
```
        self.program["thresholds"] = np.array([self.threshold1, self.threshold2, 0])
```

Where `thresholds` is defined like this in the shader source code:
```
uniform float thresholds[3];
```