### PR TITLE
Backport media thread join exception catch from 2.0 (9db3971)

### DIFF
--- a/pyglet/media/mediathreads.py
+++ b/pyglet/media/mediathreads.py
@@ -91,7 +91,11 @@ class MediaThread:
         with self._condition:
             self._stopped = True
             self._condition.notify()
-        self._thread.join()
+        try:
+            self._thread.join()
+        except RuntimeError:
+            # Ignore on unclean shutdown
+            pass
 
     def sleep(self, timeout):
         """Wait for some amount of time, or until notified.


### PR DESCRIPTION
An error is thrown commonly on application shutdown while the audio player is unloading on 1.5; this just simply backports the exception catching from 2.0.