### PR TITLE
Fix name error on Windows when using WIC on Pyglet 1.5

### DIFF
--- a/pyglet/image/codecs/wic.py
+++ b/pyglet/image/codecs/wic.py
@@ -398,11 +398,6 @@ class IWICImagingFactory(com.pIUnknown):
 
 _factory = IWICImagingFactory()
 
-try:
-    ole32.CoInitializeEx(None, COINIT_MULTITHREADED)
-except OSError as err:
-    warnings.warn(str(err))
-
 ole32.CoCreateInstance(CLSID_WICImagingFactory,
                        None,
                        CLSCTX_INPROC_SERVER,


### PR DESCRIPTION
As of 1.5.28 you can't use the WIC codec without a NameError as an area of code wasn't removed during a backport; this removes it.