### PR TITLE
Add positional parameter support for match statement

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -38,6 +38,7 @@ class Vec2:
     """A two-dimensional vector represented as an X Y coordinate pair."""
 
     __slots__ = 'x', 'y'
+    __match_args__ = 'x', 'y'
 
     def __init__(self, x: float = 0.0, y: float = 0.0) -> None:
         self.x = x
@@ -222,6 +223,7 @@ class Vec3:
     """A three-dimensional vector represented as X Y Z coordinates."""
 
     __slots__ = 'x', 'y', 'z'
+    __match_args__ = 'x', 'y', 'z'
 
     def __init__(self, x: float = 0.0, y: float = 0.0, z: float = 0.0) -> None:
         self.x = x
@@ -375,6 +377,7 @@ class Vec4:
     """A four-dimensional vector represented as X Y Z W coordinates."""
 
     __slots__ = 'x', 'y', 'z', 'w'
+    __match_args__ = 'x', 'y', 'z', 'w'
 
     def __init__(self, x: float = 0.0, y: float = 0.0, z: float = 0.0, w: float = 0.0) -> None:
         self.x = x


### PR DESCRIPTION
Adding the __match_args__ class attribute to vector classes. This adds support to use them in a match statement using positional arguments.

Example:
```
match Vec2(4, 2):
  case Vec2(0, 0):
    print("Match position 0, 0")
  case Vec2(x, y):
    print(f"Match at position {x}, {y}")
```