### PR TITLE
Doc and typing improvements for pyglet.libs.darwin

### DIFF
--- a/pyglet/libs/__init__.py
+++ b/pyglet/libs/__init__.py
@@ -1,1 +1,9 @@
+"""Platform-specific support components.
 
+These consist of:
+
+#. :py:mod:`ctypes` bindings for datastructures and functions
+#. Pythonic wrappers around these
+
+Some or all of these may be auto-generated bindings.
+"""

--- a/pyglet/libs/__init__.py
+++ b/pyglet/libs/__init__.py
@@ -2,8 +2,18 @@
 
 These consist of:
 
-#. :py:mod:`ctypes` bindings for datastructures and functions
-#. Pythonic wrappers around these
+1. ctypes bindings for datastructures and functions
+2. pyglet-specific wrapper functions around raw ctypes calls
+3. vendored libraries in original or modified forms
 
-Some or all of these may be auto-generated bindings.
+When documenting these modules:
+
+1. Use minimal formatting in any docstrings
+2. Leave licenses at the tops of files in place
+
+Simple docstrings with minimal formatting are best because:
+
+1. No web doc is built for pyglet.lib
+2. The docstrings will be used to debug complex platform issues
+3. IDEs mangle formatting in any hover tooltips while debugging
 """

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -508,18 +508,23 @@ def get_object_class(obj: c_void_p) -> c_void_p:
 
 
 def get_metaclass(name: str | bytes) -> c_void_p:
-    """Get a pointer to the metaclass for a given class name.
+    """Get a pointer to the metaclass for a given ObjectiveC class name.
 
     .. _objc_getMetaClass: https://developer.apple.com/documentation/objectivec/1418721-objc_getmetaclass/
+    .. sealiesoftware_objc_metaclass: https://www.sealiesoftware.com/blog/archive/2009/04/14/objc_explain_Classes_and_metaclasses.html
 
-    See Apple's developer documentation for `objc_getMetaClass`_.
+    See the following to learn more:
+
+    * Apple's developer documentation for `objc_getMetaClass`_.
+    * `Sealie Software's explanation of ObjectiveC metaclasses <sealiesoftware_objc_metaclass>`_
 
     Args:
         name:
             The name of an ObjectiveC class as a :py:class:`bytes`
             or a :py:class:`str`.
     Returns:
-         A void pointer to the ObjectiveC metaclass.
+         A void pointer to the ObjectiveC metaclass for the given
+         class name.
     """
     return c_void_p(objc.objc_getMetaClass(ensure_bytes(name)))
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -628,7 +628,11 @@ def should_use_fpret(restype: Type[_CData]) -> bool:
 # the arguments of the message only.
 # Note: kwarg 'argtypes' required if using args, or will fail on ARM64.
 
-def send_message(receiver, selName, *args, **kwargs):
+def send_message(
+        receiver: str | _CData,
+        selName: str | bytes,
+        *args, **kwargs
+) -> _CData:
     if isinstance(receiver, str):
         receiver = get_class(receiver)
     selector = get_selector(selName)

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -105,7 +105,7 @@ objc.class_copyMethodList.argtypes = [c_void_p, POINTER(c_uint)]
 objc.class_copyPropertyList.restype = POINTER(c_void_p)
 objc.class_copyPropertyList.argtypes = [c_void_p, POINTER(c_uint)]
 
-# Protocol ** class_copyProtocoltist(Class cls, unsigned int *outCount)
+# Protocol ** class_copyProtocolList(Class cls, unsigned int *outCount)
 # Returns an array of pointers of type Protocol* describing protocols.
 # The array has *outCount pointers followed by a NULL terminator.
 # You must free() the returned array.

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -488,7 +488,19 @@ def get_class(name: bytes | str) -> c_void_p:
     return c_void_p(objc.objc_getClass(ensure_bytes(name)))
 
 
-def get_object_class(obj):
+def get_object_class(obj: c_void_p) -> c_void_p:
+    """Get the ObjectiveC class for an object.
+
+    .. _object_GetClass: https://developer.apple.com/documentation/objectivec/1418629-object_getclass/
+
+    See Apple's developer documentation for `object_GetClass`.
+
+    Args:
+        obj:
+            A pointer to the object.
+    Returns:
+         A void pointer to the ObjectiveC class object.
+    """
     return c_void_p(objc.object_getClass(obj))
 
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -37,7 +37,7 @@ from contextlib import contextmanager
 
 from ctypes import *
 from ctypes import util
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Sequence
 
 from .cocoatypes import *
 
@@ -645,7 +645,7 @@ def send_message(
         selector_name: str | bytes,
         *args,
         restype: Type[_CTypesResType] = c_void_p,
-        argtypes: list[Type] | None = None,
+        argtypes: Sequence[Type] | None = None,
         **_ # For compatibility with the pre-annotation signature
 ) -> _CTypesResType | None:
     """Send an ObjectiveC message and return the result's value.
@@ -671,6 +671,7 @@ def send_message(
 
     To learn more about ObjectiveC's message sending, see:
 
+    * https://docs.python.org/3.8/library/ctypes.html#calling-variadic-functions
     * The x86_should_use_stret function in this file
     * The should_use_fpret function in this file
     * Apple's developer documentation on objc_msgSend:
@@ -683,8 +684,8 @@ def send_message(
         selector_name:
             A selector name as Python string or bytes object
         *args:
-            ctypes objects to send as the messsage arguments. These
-            must match the types in ``argtypes``.
+            ctypes objects to send as the message arguments. These must
+            match the types in ``argtypes`` if they're specified.
         restype:
             A ctypes representation of the message result's expected
             return type.
@@ -705,7 +706,7 @@ def send_message(
     # Shared preprocessing & default filling
     if isinstance(receiver, str):
         receiver = get_class(receiver)
-    if argtypes is None:
+    if not argtypes:  # Skips casting for empty tuples
         argtypes = []
     selector = get_selector(selector_name)
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -497,7 +497,7 @@ def get_object_class(obj: c_void_p) -> c_void_p:
 
     Args:
         obj:
-            A pointer to the object.
+            A void pointer to an ObjectiveC object.
     Returns:
          A void pointer to the ObjectiveC class object.
     """

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -637,6 +637,63 @@ def send_message(
         argtypes: List[Type[_CData]] | None = None,
         **kwargs  # Backward-compatibility with old function signature
 ) -> _T_CData:
+    """Send a message to a class name or instance and return the result.
+
+    .. warning:: On ARM64 systems, ``argtypes`` is mandatory!
+
+                 Omitting it will cause this function to fail. It is
+                 strongly encouraged to provide this as all Macs new
+                 will be ARM64-based for the foreseeable future.
+
+    By default, all arguments and return values are assumed to be
+    :py:class:`~ctypes.c_void_p`. This includes:
+
+    #. All ``args``
+    #. The ``restype`` keyword argument
+    #. All ``argtypes``
+
+    You can specify a different expected message result type by passing
+    a :py:mod:`ctypes` type via the ``restype`` keyword argument. This
+    function will select the best known message sending approach based
+    on ``restype``'s :py:func:`ctypes.sizeof` value, floating point
+    attributes, and the current platform.
+
+    ``args`` must be a list of values to pass to ObjectiveC code. All
+    must match any provided ``argtypes``. If specifiec, ``argtypes``
+    must be a list of :py:mod:`ctypes` types. ``argtypes`` is mandatory
+    on recent ARM64 Macs.
+
+    .. _objc_msgSend: https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend
+
+    To learn more about ObjectiveC's message sending functions, see the
+    following:
+
+    * :py:func:`.x86_should_use_stret`
+    * :py:func:`.should_use_fpret`
+    * Apple's developer documentation on `objc_msgSend`_
+
+    Args:
+        receiver:
+            A string or :py:class:`~ctypes.c_void_p` pointer to an
+            ObjectiveC class.
+        selector_name:
+            A selector name as a string or :py:attr:`bytes`.
+        *args:
+            Arguments matching ``argtypes``.
+        restype:
+            A :py:mod:`ctypes` representation of the message result's
+            expected return type.
+        argtypes:
+            A :py:class:`list` of :py:mod:`ctypes` types for each of
+            the arguments in ``args``.
+        **kwargs:
+            Unused backward compatibility argument kept to avoid
+            breaking with older versions of the function.
+
+    Returns:
+       The result of the message, if any.
+
+    """
 
     # print('send_message', receiver, selector_name, args, restype, argtypes, kwargs)
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -524,7 +524,18 @@ def get_metaclass(name: str | bytes) -> c_void_p:
     return c_void_p(objc.objc_getMetaClass(ensure_bytes(name)))
 
 
-def get_superclass_of_object(obj):
+def get_superclass_of_object(obj: c_void_p) -> c_void_p:
+    """Get a pointer to the ObjectiveC superclass of an object.
+
+    Args:
+        obj:
+            A pointer to an ObjectiveC object.
+
+    Returns:
+        A void pointer to the ObjectiveC superclass of the passed
+        object.
+
+    """
     cls = c_void_p(objc.object_getClass(obj))
     return c_void_p(objc.class_getSuperclass(cls))
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -504,7 +504,20 @@ def get_object_class(obj: c_void_p) -> c_void_p:
     return c_void_p(objc.object_getClass(obj))
 
 
-def get_metaclass(name):
+def get_metaclass(name: str | bytes) -> c_void_p:
+    """Get a pointer to the metaclass for a given class name.
+
+    .. _objc_getMetaClass: https://developer.apple.com/documentation/objectivec/1418721-objc_getmetaclass/
+
+    See Apple's developer documentation for `objc_getMetaClass`_.
+
+    Args:
+        name:
+            The name of an ObjectiveC class as a :py:class:`bytes`
+            or a :py:class:`str`.
+    Returns:
+         A void pointer to the ObjectiveC metaclass.
+    """
     return c_void_p(objc.objc_getMetaClass(ensure_bytes(name)))
 
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -571,7 +571,7 @@ def x86_should_use_stret(restype: Type[_CData]) -> bool:
     return True
 
 
-def should_use_fpret(restype: Type) -> bool:
+def should_use_fpret(restype: Type[_CData]) -> bool:
     """``True`` when a message type seems to need a float-specific function.
 
     .. _objc_msgSend_fpret: https://developer.apple.com/documentation/objectivec/1456697-objc_msgsend_fpret

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -37,7 +37,7 @@ from contextlib import contextmanager
 
 from ctypes import *
 from ctypes import util
-from typing import Any
+from typing import Any, Type
 
 from .cocoatypes import *
 
@@ -542,9 +542,28 @@ def x86_should_use_stret(restype):
     return True
 
 
-# http://www.sealiesoftware.com/blog/archive/2008/11/16/objc_explain_objc_msgSend_fpret.html
-def should_use_fpret(restype):
-    """Determine if objc_msgSend_fpret is required to return a floating point type."""
+def should_use_fpret(restype: Type) -> bool:
+    """``True`` when a message type seems to need a float-specific function.
+
+    .. _objc_msgSend_fpret: https://developer.apple.com/documentation/objectivec/1456697-objc_msgsend_fpret
+
+    On Macs running on x86 or amd64 processors, ObjectiveC messages
+    returning non-integer data types may need to be sent using
+    `objc_msgSend_fpret`_. This function returns ``True`` if the
+    current processor and platform features indicate this is the case.
+
+    To learn more, see:
+
+    * Apple's developer documentation on `objc_msgSend_fpret`_
+    * `Sealie Software's explanation of the above <http://www.sealiesoftware.com/blog/archive/2008/11/16/objc_explain_objc_msgSend_fpret.html>`_
+
+    Args:
+        restype: A :py:mod:`ctypes` type.
+
+    Returns:
+        ``True`` if `objc_msgSend_fpret`_ should be used, ``False``
+        otherwise.
+    """
     if not __i386__:
         # Unneeded on non-intel processors
         return False

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -633,13 +633,6 @@ def should_use_fpret(restype: Type) -> bool:
 _CTypesResType = TypeVar('_CTypesResType')
 
 
-# By default, assumes that restype is c_void_p
-# and that all arguments are wrapped inside c_void_p.
-# Use the restype and argtypes keyword arguments to
-# change these values.  restype should be a ctypes type
-# and argtypes should be a list of ctypes types for
-# the arguments of the message only.
-# Note: kwarg 'argtypes' required if using args, or will fail on ARM64.
 def send_message(
         receiver: str | c_void_p,
         selector_name: str | bytes,

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -456,7 +456,19 @@ def ensure_bytes(x: bytes | str) -> bytes:
 
 ######################################################################
 
-def get_selector(name):
+def get_selector(name: str | bytes) -> c_void_p:
+    """Return a void pointer for a named ObjectiveC selector.
+
+    .. _sel_registerName:  https://developer.apple.com/documentation/objectivec/1418557-sel_registername
+
+    See Apple's developer documentation on `sel_registerName`_.
+
+    Args:
+        name: A name as :py:class:`bytes` or a :py:class:`str`.
+
+    Returns:
+        A void pointer for the selector.
+    """
     return c_void_p(objc.sel_registerName(ensure_bytes(name)))
 
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -480,7 +480,9 @@ def get_class(name: bytes | str) -> c_void_p:
     See Apple's developer documentation for `objc_getClass`_.
 
      Args:
-        name: A name as :py:class:`bytes` or a :py:class:`str`.
+        name:
+            A name of an ObjectiveC class as :py:class:`bytes` or a
+            :py:class:`str`.
 
     Returns:
         A void pointer for the selector.

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -472,7 +472,19 @@ def get_selector(name: str | bytes) -> c_void_p:
     return c_void_p(objc.sel_registerName(ensure_bytes(name)))
 
 
-def get_class(name):
+def get_class(name: bytes | str) -> c_void_p:
+    """Get a void pointer to an ObjectiveC class of a given name.
+
+    .. objc_getClass: https://developer.apple.com/documentation/objectivec/1418952-objc_getclass
+
+    See Apple's developer documentation for `objc_getClass`_.
+
+     Args:
+        name: A name as :py:class:`bytes` or a :py:class:`str`.
+
+    Returns:
+        A void pointer for the selector.
+    """
     return c_void_p(objc.objc_getClass(ensure_bytes(name)))
 
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -497,7 +497,7 @@ def get_class(name: bytes | str) -> c_void_p | None:
 def get_object_class(obj: c_void_p) -> c_void_p | None:
     """Get the ObjectiveC class for an object or None if it's nil.
 
-    See Apple's developer documentation for `object_GetClass`.
+    See Apple's developer documentation for ``object_GetClass``.
     https://developer.apple.com/documentation/objectivec/1418629-object_getclass/
 
     Args:

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -630,12 +630,12 @@ def should_use_fpret(restype: Type[_CData]) -> bool:
 
 def send_message(
         receiver: str | _CData,
-        selName: str | bytes,
+        selector_name: str | bytes,
         *args, **kwargs
 ) -> _CData:
     if isinstance(receiver, str):
         receiver = get_class(receiver)
-    selector = get_selector(selName)
+    selector = get_selector(selector_name)
     restype = kwargs.get('restype', c_void_p)
     # print('send_message', receiver, selName, args, kwargs)
     argtypes = kwargs.get('argtypes', [])

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -28,6 +28,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
 
 import sys
 import platform
@@ -36,6 +37,7 @@ from contextlib import contextmanager
 
 from ctypes import *
 from ctypes import util
+from typing import Any
 
 from .cocoatypes import *
 
@@ -432,7 +434,21 @@ OBJC_ASSOCIATION_RETAIN = 0x0301  # Strong reference to the associated object. T
 OBJC_ASSOCIATION_COPY = 0x0303  # Specifies that the associated object is copied. The association is made atomically.
 
 
-def ensure_bytes(x):
+def ensure_bytes(x: bytes | str) -> bytes:
+    """Attempt to encode an object as :py:class:`bytes`.
+
+    If it is already :py:class:`bytes`, it will be returned as-is.
+    Otherwise, this function attempt to convert ``x`` by assuming it
+    has a string-like :py:meth:`~str.encode` method supporting
+    ``'ascii'`` as an argument.
+
+    Args:
+        x: A :py:class:`bytes` or object with a string-like
+         :py:meth:`~str.encode` method.
+
+    Returns:
+        :py:class:`bytes`
+    """
     if isinstance(x, bytes):
         return x
     return x.encode('ascii')

--- a/pyglet/libs/darwin/coreaudio.py
+++ b/pyglet/libs/darwin/coreaudio.py
@@ -9,6 +9,7 @@ This includes:
 """
 from ctypes import c_void_p, c_int, c_bool, Structure, c_uint32, util, cdll, c_uint, c_double, POINTER, c_int64, \
     CFUNCTYPE
+from typing import Final
 
 from pyglet.libs.darwin import CFURLRef
 
@@ -137,6 +138,7 @@ def c_literal(mnemonic: str) -> int:
     return num
 
 
+# Non-error file & format constants
 kAudioFilePropertyMagicCookieData = c_literal('mgic')
 kExtAudioFileProperty_FileDataFormat = c_literal('ffmt')
 kExtAudioFileProperty_ClientDataFormat = c_literal('cfmt')
@@ -151,12 +153,28 @@ kAudioFormatFlagsNativeEndian = 0
 kAudioFormatFlagsCanonical = kAudioFormatFlagIsFloat | kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsPacked
 kAudioQueueProperty_MagicCookie = c_literal('aqmc')
 
+
 # ERRORS:
+
+# General System errors
 kAudio_UnimplementedError = -4
 kAudio_FileNotFoundError = -43
 kAudio_ParamError = -50
 kAudio_MemFullError = -108
 
+
+# All error constants below correspond to identically named errors in
+# Apple's audiotoolbox. The doc for each is at URLs ending with the same
+# names. For example, kAudioFileUnspecifiedError's documentation is at:
+# https://developer.apple.com/documentation/audiotoolbox/
+
+# General file read errors
+kAudioFileNotOpenError = -38
+kAudioFileEndOfFileError = -39
+kAudioFilePositionError = -40
+kAudioFileFileNotFoundError = -43
+
+# File access mnemonic codes                    # Hex       , Base 10
 kAudioFileUnspecifiedError = c_literal('wht?')  # 0x7768743F, 2003334207
 kAudioFileUnsupportedFileTypeError = c_literal('typ?')  # 0x7479703F, 1954115647
 kAudioFileUnsupportedDataFormatError = c_literal('fmt?')  # 0x666D743F, 1718449215
@@ -164,19 +182,21 @@ kAudioFileUnsupportedPropertyError = c_literal('pty?')  # 0x7074793F, 1886681407
 kAudioFileBadPropertySizeError = c_literal('!siz')  # 0x2173697A,  561211770
 kAudioFilePermissionsError = c_literal('prm?')  # 0x70726D3F, 1886547263
 kAudioFileNotOptimizedError = c_literal('optm')  # 0x6F70746D, 1869640813
-# file format specific error codes
+
+# Format-specific error codes                    # Hex       , Base 10
 kAudioFileInvalidChunkError = c_literal('chk?')  # 0x63686B3F, 1667787583
 kAudioFileDoesNotAllow64BitDataSizeError = c_literal('off?')  # 0x6F66663F, 1868981823
 kAudioFileInvalidPacketOffsetError = c_literal('pck?')  # 0x70636B3F, 1885563711
 kAudioFileInvalidFileError = c_literal('dta?')  # 0x6474613F, 1685348671
-kAudioFileOperationNotSupportedError = c_literal('op?')  # 0x6F703F3F
-# general file error codes
-kAudioFileNotOpenError = -38
-kAudioFileEndOfFileError = -39
-kAudioFilePositionError = -40
-kAudioFileFileNotFoundError = -43
+kAudioFileOperationNotSupportedError = c_literal('op?')  # 0x6F703F3F, 1869627199
 
-err_str_db = {
+
+# Maps kAudio errors -> error text
+err_str_db: Final[dict[int, str]] = {
+    kAudioFileNotOpenError: "The file is closed.",
+    kAudioFileEndOfFileError: "End of file.",
+    kAudioFilePositionError: "Invalid file position.",
+    kAudioFileFileNotFoundError: "File not found.",
     kAudioFileUnspecifiedError: "An unspecified error has occurred.",
     kAudioFileUnsupportedFileTypeError: "The file type is not supported.",
     kAudioFileUnsupportedDataFormatError: "The data format is not supported by this file type.",
@@ -189,10 +209,6 @@ err_str_db = {
     kAudioFileInvalidPacketOffsetError: "A packet offset was past the end of the file, or not at the end of the file when a VBR format was written, or a corrupt packet size was read when the packet table was built.",
     kAudioFileInvalidFileError: "The file is malformed, or otherwise not a valid instance of an audio file of its type.",
     kAudioFileOperationNotSupportedError: "The operation cannot be performed.",
-    kAudioFileNotOpenError: "The file is closed.",
-    kAudioFileEndOfFileError: "End of file.",
-    kAudioFilePositionError: "Invalid file position.",
-    kAudioFileFileNotFoundError: "File not found.",
 }
 
 

--- a/pyglet/libs/darwin/coreaudio.py
+++ b/pyglet/libs/darwin/coreaudio.py
@@ -1,10 +1,15 @@
-"""Bindings, constants, and helpers for Mac's `CoreAudio <https://developer.apple.com/documentation/coreaudio>`_.
+"""Bindings, constants, and helpers for Mac's CoreAudio
 
-This includes:
+Relevant Apple documentation is located at:
 
-* Python access to structs as :py:mod:`ctypes`-based bindings
-* four-character constants used in CoreAudio
-* Error checking
+* https://developer.apple.com/documentation/audiotoolbox/
+* https://developer.apple.com/documentation/coreaudio
+
+This module includes:
+
+* ctypes structs and function bindings
+* Constants for audio file read and decoding
+* Error checking helpers
 
 """
 from ctypes import c_void_p, c_int, c_bool, Structure, c_uint32, util, cdll, c_uint, c_double, POINTER, c_int64, \

--- a/pyglet/libs/darwin/coreaudio.py
+++ b/pyglet/libs/darwin/coreaudio.py
@@ -108,12 +108,32 @@ ca.AudioFileClose.argtypes = [AudioFileID]
 kCFAllocatorDefault = None
 
 
-def c_literal(literal):
-    """Example 'xyz' -> 7895418.
-    Used for some CoreAudio constants."""
+def c_literal(mnemonic: str) -> int:
+    """Pack a tiny ASCII string into a 32-bit int.
+
+    Example: 'xyz' -> 0x78797a (Base 10: 7895418)
+
+    Although many CoreAudio constants use this function, the only
+    consistent rule seems to be a max of 4 ASCII characters to fit
+    into a 32-bit int.
+
+    Otherwise, error code constants may follow a loose convention:
+
+    * '?' at the start error codes for unsupported actions
+      Example: c_literal('?wht') # as in "what?"
+
+    * '!' at the end of error codes for unintelligible data
+      Example: c_literal('?siz') # "this data is the wrong size!"
+
+    Args:
+        mnemonic:
+            Up to 4 ASCII characters to shift left
+    Returns:
+        A 32-bit int equivalent of the string.
+    """
     num = 0
-    for idx, char in enumerate(literal):
-        num |= ord(char) << (len(literal) - idx - 1) * 8
+    for idx, char in enumerate(mnemonic):
+        num |= ord(char) << (len(mnemonic) - idx - 1) * 8
     return num
 
 

--- a/pyglet/libs/darwin/coreaudio.py
+++ b/pyglet/libs/darwin/coreaudio.py
@@ -1,3 +1,12 @@
+"""Bindings, constants, and helpers for Mac's `CoreAudio <https://developer.apple.com/documentation/coreaudio>`_.
+
+This includes:
+
+* Python access to structs as :py:mod:`ctypes`-based bindings
+* four-character constants used in CoreAudio
+* Error checking
+
+"""
 from ctypes import c_void_p, c_int, c_bool, Structure, c_uint32, util, cdll, c_uint, c_double, POINTER, c_int64, \
     CFUNCTYPE
 

--- a/pyglet/libs/darwin/coreaudio.py
+++ b/pyglet/libs/darwin/coreaudio.py
@@ -212,6 +212,23 @@ err_str_db: Final[dict[int, str]] = {
 }
 
 
-def err_check(err):
+class CoreAudioException(Exception):
+    """A stub to mark a problem as a CoreAudio issue.
+
+    Ideally, there would be appropriate subclasses of typical
+    Python exceptions for specific issues, For example:
+
+    * kAudio_FileNotFoundError -> OSError (The typical Python file read error
+    * kAudioFileInvalidChunkError -> ValueError (Invalid data)
+    """
+    ...
+
+
+def err_check(err: int) -> None:
+    """Raise an exception of somethings wrong, otherwise return None.
+
+    Raises:
+         CoreAudioException
+    """
     if err != 0:
-        raise Exception(err, err_str_db.get(err, "Unknown Error"))
+        raise CoreAudioException(err, err_str_db.get(err, "Unknown Error"))

--- a/pyglet/libs/darwin/quartzkey.py
+++ b/pyglet/libs/darwin/quartzkey.py
@@ -1,13 +1,40 @@
+"""Macintosh key scancode constants.
+
+.. _SDL_Quartzkeys.h: https://github.com/libsdl-org/SDL-1.2/blob/main/src/video/quartz/SDL_QuartzKeys.h
+.. _Inside_Macintosh_diagram: http://boredzo.org/blog/wp-content/uploads/2007/05/imtx-virtual-keycodes.png
+.. _Event.h_Mac_10_6: https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h
+
+
+Aside from a few changes, this module is based on SDL 1.X's
+`src/video/quartz/SDL_QuartzKeys.h <SDL_Quartzkeys.h` circa 2006.
+See the following to learn more:
+
+* `Inside Macintosh's keycode diagram <Inside_Macintosh_diagram>`_
+* The key code values (but not names) in `Mac OS X 10.6's Events.h <Event.h_Mac_10_6>_
+
+Changes include renaming the following:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Pyglet name
+     - Old name
+
+   * - ``QZ_ROPTION``
+     - ``QZ_RALT``
+
+   * - ``QZ_LOPTION``
+     - ``QZ_LALT``
+
+   * - ``QZ_RCOMMAND``
+     - ``QZ_RMETA``
+
+   * - ``QZ_LCOMMAND``
+     - ``QZ_LMETA``
+
+"""
 from pyglet.window import key
 
-# From SDL: src/video/quartz/SDL_QuartzKeys.h
-# These are the Macintosh key scancode constants -- from Inside Macintosh
-# http://boredzo.org/blog/wp-content/uploads/2007/05/imtx-virtual-keycodes.png
-# Renamed QZ_RALT, QZ_LALT to QZ_ROPTION, QZ_LOPTION
-# and QZ_RMETA, QZ_LMETA to QZ_RCOMMAND, QZ_LCOMMAND.
-#
-# See also:
-# /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Headers/Events.h
 
 QZ_ESCAPE = 0x35
 QZ_F1 = 0x7A

--- a/pyglet/libs/darwin/quartzkey.py
+++ b/pyglet/libs/darwin/quartzkey.py
@@ -1,41 +1,33 @@
 """Macintosh key scancode constants.
 
-.. _SDL_Quartzkeys.h: https://github.com/libsdl-org/SDL-1.2/blob/main/src/video/quartz/SDL_QuartzKeys.h
-.. _Inside_Macintosh_diagram: http://boredzo.org/blog/wp-content/uploads/2007/05/imtx-virtual-keycodes.png
-.. _Event.h_Mac_10_6: https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h
+For a quick visual reference, see Inside Macintosh's keycode diagram:
+http://boredzo.org/blog/wp-content/uploads/2007/05/imtx-virtual-keycodes.png
 
+For clarity, a few constants use custom pyglet-specific names.
+These include:
+================ ======================
+New pyglet name  Name in referenced .h
+================ ======================
+QZ_LCOMMAND      QZ_LMETA
+QZ_LOPTION       QZ_LALT
+QZ_ROPTION       QZ_RALT
+QZ_RCOMMAND      QZ_RMETA
 
-Aside from a few changes, this module is based on SDL 1.X's
-`src/video/quartz/SDL_QuartzKeys.h <SDL_Quartzkeys.h` circa 2006.
-See the following to learn more:
+This module was originally created by consulting a 2006 version of
+SDL 1.X's SDL_Quartzkeys.h. Although some names are pyglet-specific,
+all values are the same as those in Mac OS X 10.6's Events.h.
 
-* `Inside Macintosh's keycode diagram <Inside_Macintosh_diagram>`_
-* The key code values (but not names) in `Mac OS X 10.6's Events.h <Event.h_Mac_10_6>_
+To learn more, please see:
 
-Changes include renaming the following:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Pyglet name
-     - Old name
-
-   * - ``QZ_ROPTION``
-     - ``QZ_RALT``
-
-   * - ``QZ_LOPTION``
-     - ``QZ_LALT``
-
-   * - ``QZ_RCOMMAND``
-     - ``QZ_RMETA``
-
-   * - ``QZ_LCOMMAND``
-     - ``QZ_LMETA``
+* SDL 1.2's SDL_Quartzkeys.h https://github.com/libsdl-org/SDL-1.2/blob/main/src/video/quartz/SDL_QuartzKeys.h
+* Event.h from Mac OS X 10.6 https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h
 
 """
 from pyglet.window import key
 
-
+# These values and most of their names are taken from SDL 1.X's
+# SQL_Quartzkeys.h. Changed names are listed in the top-level
+# docstring and marked with comments below.
 QZ_ESCAPE = 0x35
 QZ_F1 = 0x7A
 QZ_F2 = 0x78
@@ -134,11 +126,11 @@ QZ_KP2 = 0x54
 QZ_KP3 = 0x55
 QZ_KP_ENTER = 0x4C
 QZ_LCTRL = 0x3B
-QZ_LOPTION = 0x3A
-QZ_LCOMMAND = 0x37
+QZ_LOPTION = 0x3A  # Originally QZ_LMETA
+QZ_LCOMMAND = 0x37  # Originally QZ_LALT
 QZ_SPACE = 0x31
-QZ_RCOMMAND = 0x36
-QZ_ROPTION = 0x3D
+QZ_RCOMMAND = 0x36  # Originally QZ_RALT
+QZ_ROPTION = 0x3D  # Originally QZ_RMETA
 QZ_RCTRL = 0x3E
 QZ_FUNCTION = 0x3F
 QZ_LEFT = 0x7B


### PR DESCRIPTION
TL;DR:
1. I had less free time & access to real-world test hardware than expected
2. It seems worth PRing now because:
   * arcane code first written in 2011 is now legible
   * I don't want to block people
3. This still hasn't been tested on real hardware yet


### Current changes

#### (1/4) Turn prior feedback from @caffeinepills into committed code

I've included some older Disocrd feedback by:

1. Explaining the doc situation for `pyglet.lib`:
     * These modules don't get web doc built
     * Docstrings should favor immediate human readability
6. Removing hard-to-read Sphinx formatting from my previous drafts
7. Removing overly clever attempts to type annotate `ctypes` items

#### (2/4) Partly document and annotate `pyglet.libs.darwin.cocoapy.runtime`

TL;DR: Doc, annotations, and signature upgrade make some code legible

1. Added docstrings and comments with links to Apple documentation
2. Annotated some signatures in `pyglet.libs.darwin.runtime`
3. Backward-compatible changes to `send_message`:
   * Decipher near-hieroglyphic signature
   * Match the Python doc's variadic function call specification by allowing arbitrary sequences for `argtypes`
   * Use type-annotated keyword arguments with defaults instead of ``kwargs.get``
   * Limited use of `TypeVar` for the result response type

`mypy` isn't perfectly happy, but that seems okay. It's unhappy with other things too.

 #### (3/4) Comments, annotations, and a bonus Exception type for `coreaudio.py`

1. Add cross-references to apple doc
2. Add annotations and docstrings
3. Reorder some constants for clarity
4. Cleaner spacing
5. Bonus: Add `CoreAudioException`
    * We have very vague exceptions
    * We should fix that
    * This is a step towards it, but I can revert it for now if you'd like
 
### (4/4) Quartzkeys doc

Mostly just organization and aesthetics