### PR TITLE
Add `items` to `pyglet.Options`

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -231,16 +231,16 @@ class Options:
 
     .. versionadded:: 2.0.5"""
 
-    def get(self, item: Any, default: Any = None) -> Any:
+    def get(self, item: str, default: Any = None) -> Any:
         return self.__dict__.get(item, default)
 
-    def items(self) -> ItemsView[Any, Any]:
+    def items(self) -> ItemsView[str, Any]:
         return self.__dict__.items()
 
-    def __getitem__(self, item: Any) -> Any:
+    def __getitem__(self, item: str) -> Any:
         return self.__dict__[item]
 
-    def __setitem__(self, key: Any, value: Any) -> None:
+    def __setitem__(self, key: str, value: Any) -> None:
         assert key in self.__annotations__, f"Invalid option name: '{key}'"
         assert type(value).__name__ == self.__annotations__[key], f"Invalid type: '{type(value)}' for '{key}'"
         self.__dict__[key] = value

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ItemsView
 
 #: The release version
 version = "2.0.15"
@@ -233,6 +233,9 @@ class Options:
 
     def get(self, item: Any, default: Any = None) -> Any:
         return self.__dict__.get(item, default)
+
+    def items(self) -> ItemsView[Any, Any]:
+        return self.__dict__.items()
 
     def __getitem__(self, item: Any) -> Any:
         return self.__dict__[item]


### PR DESCRIPTION
`python3 -m pyglet.info` currently raises an exception as it cannot find `items()`
Additionally, i changed the key type from `Any` to `str`.

It might be beneficial to add more methods mocking the dict API on top of Options. `keys` or `values` are closely related to `items` and left out, and it's not unlikely there are projects out there that utilize `update`.
