### PR TITLE
Sprite Improvements and Adjustments

### DIFF
--- a/doc/modules/sprite.rst
+++ b/doc/modules/sprite.rst
@@ -4,35 +4,12 @@ pyglet.sprite
 .. automodule:: pyglet.sprite
 
 .. autoclass:: Sprite
+  :members:
+  :undoc-members:
 
-  .. rubric:: Methods
-
-  .. automethod:: delete
-  .. automethod:: draw
-  .. automethod:: update
-
-  .. rubric:: Events
-
-  .. automethod:: on_animation_end
-
-  .. rubric:: Attributes
-
-  .. autoattribute:: batch
-  .. autoattribute:: color
-  .. autoattribute:: group
-  .. autoattribute:: height
-  .. autoattribute:: image
-  .. autoattribute:: opacity
-  .. autoattribute:: position
-  .. autoattribute:: rotation
-  .. autoattribute:: scale
-  .. autoattribute:: scale_x
-  .. autoattribute:: scale_y
-  .. autoattribute:: visible
-  .. autoattribute:: width
-  .. autoattribute:: x
-  .. autoattribute:: y
+.. autoclass:: AdvancedSprite
 
 .. autoclass:: SpriteGroup
   :members:
   :undoc-members:
+

--- a/examples/sprite/depth_sprite.py
+++ b/examples/sprite/depth_sprite.py
@@ -46,7 +46,7 @@ class DepthSpriteGroup(pyglet.sprite.SpriteGroup):
         self.program.stop()
 
 
-class DepthSprite(pyglet.sprite.AdvancedSprite):
+class DepthSprite(pyglet.sprite.Sprite):
     group_class = DepthSpriteGroup
 
 

--- a/examples/sprite/sprite_batching.py
+++ b/examples/sprite/sprite_batching.py
@@ -1,5 +1,6 @@
-import pyglet
 import random
+
+import pyglet
 
 window = pyglet.window.Window(vsync=False)
 
@@ -29,19 +30,21 @@ for i in range(1000):
                                   x=random.randint(0, window.width),
                                   y=random.randint(0, window.height),
                                   batch=batch)  # specify the batch to enter the sprites in.
-    
+
     # Randomize scale.
     sprite.scale = random.choice(scales)
-    
+
     # Random color multiplier.
     sprite.color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
-    
+
     # Add sprites to keep in memory, like a list. Otherwise they will get GC'd when out of scope.
-    sprites.append(sprite)  
+    sprites.append(sprite)
+
 
 @window.event
 def on_draw():
     window.clear()
     batch.draw()
-    
+
+
 pyglet.app.run()

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -408,9 +408,9 @@ class Sprite(event.EventDispatcher):
     def program(self, program: ShaderProgram) -> None:
         if self._program == program:
             return
+        self._program = program
         self._group = self.get_sprite_group()
         self._batch.migrate(self._vertex_list, GL_TRIANGLES, self._group, self._batch)
-        self._program = program
 
     @property
     def batch(self) -> Batch:
@@ -450,6 +450,7 @@ class Sprite(event.EventDispatcher):
     def group(self, group: Group) -> None:
         if self._user_group == group:
             return
+        self._user_group = group
         self._group = self.get_sprite_group()
         if self._batch is not None:
             self._batch.migrate(self._vertex_list, GL_TRIANGLES, self._group, self._batch)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,11 @@ ignore = [
     "Q000",  # double quotes
 ]
 
-isort = { known-first-party = [
-  "pyglet"
-], required-imports = [
-  "from __future__ import annotations",
-] }
-
 exclude = ["venv/*", ".venv/*", "build/*", "doc/*", ".github/*"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pyglet"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
I've run into various issues with trying to make custom sprites, particularly with custom groups.

Here are my proposed changes:
- Merge AdvancedSprite to Sprite and deprecate it. Allow program in the initial Sprite class.
- Add `get_sprite_group` to Sprite to allow users to change initialization of a custom SpriteGroup without having to overwrite multiple functions.
- Add `blend_mode` property to allow sprites to change the default blend modes.
- Use `_user_group` to specify the intended group rather than relying on `group.parent` which may cause confusion with deeper nested groups.
- Update docs and typing.

Open to any feedback, particularly around the `get_sprite_group` function naming.