### PR TITLE
add Rounded Rectangle

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -68,7 +68,7 @@ from __future__ import annotations
 import math
 
 from abc import ABC, abstractmethod
-from typing import Sequence, TYPE_CHECKING
+from typing import Sequence, TYPE_CHECKING, Union, Tuple
 
 import pyglet
 
@@ -1934,6 +1934,192 @@ class Box(ShapeBase):
     @thickness.setter
     def thickness(self, thickness: float) -> None:
         self._thickness = thickness
+        self._update_vertices()
+
+
+_RadiusT = Union[float, Tuple[float, float]]
+
+
+class RoundedRectangle(pyglet.shapes.ShapeBase):
+
+    def __init__(
+            self,
+            x: float, y: float,
+            width: float, height: float,
+            radius: _RadiusT | tuple[_RadiusT, _RadiusT, _RadiusT, _RadiusT],
+            segments: int | tuple[int, int, int, int] | None = None,
+            color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
+            batch: pyglet.graphics.Batch | None = None,
+            group: pyglet.graphics.Group | None = None
+    ):
+        """Create a rectangle with rounded corners.
+
+        The rectangle's anchor point defaults to the ``(x, y)``
+        coordinates, which are at the bottom left.
+
+        Args:
+            x:
+                The X coordinate of the rectangle.
+            y:
+                The Y coordinate of the rectangle.
+            width:
+                The width of the rectangle.
+            height:
+                The height of the rectangle.
+            radius:
+                Specifies the radii used for the rounded corners clockwise:
+                bottom-left, top-left, top-right, bottom-right.
+                Elements of the list can be numbers or tuples of two numbers to specify different x,y dimensions.
+                One value will define all corner radii to be of this value.
+            segments:
+                You can optionally specify how many distinct triangles
+                the rounded corner should be made from. If not specified it will
+                be automatically calculated using the formula:
+                `max(14, int(radius / 1.25))`.
+            color:
+                The RGB or RGBA color of the rectangle, specified as a
+                tuple of 3 or 4 ints in the range of 0-255. RGB colors
+                will be treated as having an opacity of 255.
+            batch:
+                Optional batch to add the rectangle to.
+            group:
+                Optional parent group of the rectangle.
+        """
+        self._x = x
+        self._y = y
+        self._width = width
+        self._height = height
+        self._set_radius(radius)
+        self._set_segments(segments)
+
+        self._num_verts = (sum(self._segments) + 4) * 3
+        self._rotation = 0
+
+        r, g, b, *a = color
+        self._rgba = r, g, b, a[0] if a else 255
+
+        program = get_default_shader()
+        self._batch = batch or pyglet.graphics.Batch()
+        self._group = self.group_class(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, program, group)
+
+        self._create_vertex_list()
+
+    def _set_radius(
+            self,
+            radius: _RadiusT | tuple[_RadiusT, _RadiusT, _RadiusT, _RadiusT]
+    ) -> None:
+        if isinstance(radius, (int, float)):
+            self._radius = ((radius, radius),) * 4
+        elif len(radius) == 2:
+            self._radius = (radius,) * 4
+        else:
+            assert len(radius) == 4
+            self._radius = []
+            for value in radius:
+                if isinstance(value, (int, float)):
+                    self._radius.append((value, value))
+                else:
+                    assert len(value) == 2
+                    self._radius.append(value)
+
+    def _set_segments(self, segments: int | tuple[int, int, int, int] | None) -> None:
+        if segments is None:
+            self._segments = [int(max(a, b) / 1.25) for a, b in self._radius]
+        elif isinstance(segments, int):
+            self._segments = (segments,) * 4
+        else:
+            self._segments = segments
+
+    def __contains__(self, point: tuple[float, float]) -> bool:
+        assert len(point) == 2
+        point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
+        x, y = self._x - self._anchor_x, self._y - self._anchor_y
+        return x < point[0] < x + self._width and y < point[1] < y + self._height
+
+    def _create_vertex_list(self):
+        self._vertex_list = self._group.program.vertex_list(
+            self._num_verts, self._draw_mode, self._batch, self._group,
+            position=('f', self._get_vertices()),
+            colors=('Bn', self._rgba * self._num_verts),
+            translation=('f', (self._x, self._y) * self._num_verts))
+
+    def _get_vertices(self):
+        if not self._visible:
+            return (0, 0) * self._num_verts
+        else:
+            x = -self._anchor_x
+            y = -self._anchor_y
+
+            points = []
+            # arc_x, arc_y, start_angle
+            arc_positions = [
+                # bottom-left
+                (x + self._radius[0][0],
+                 y + self._radius[0][1], math.pi),
+                # bottom-right
+                (x + self._width - self._radius[3][0],
+                 y + self._radius[3][1], math.pi * 3 / 2),
+                # top-right
+                (x + self._width - self._radius[2][0],
+                 y + self._height - self._radius[2][1], 0),
+                # top-left
+                (x + self._radius[1][0],
+                 y + self._height - self._radius[1][1], math.pi / 2),
+            ]
+
+            for (rx, ry), (arc_x, arc_y, arc_start), segments in zip(self._radius, arc_positions, self._segments):
+                tau_segs = math.pi / 2 / segments
+                points += [(arc_x + rx * math.cos(i * tau_segs + arc_start),
+                            arc_y + ry * math.sin(i * tau_segs + arc_start)) for i in range(segments + 1)]
+
+            center_x = self._width / 2
+            center_y = self._height / 2
+            vertices = []
+            for i, point in enumerate(points):
+                triangle = center_x, center_y, *points[i - 1], *point
+                vertices.extend(triangle)
+
+            return vertices
+
+    def _update_vertices(self):
+        self._vertex_list.position[:] = self._get_vertices()
+
+    @property
+    def width(self) -> float:
+        """Get/set width of the rectangle.
+
+        The new left and right of the rectangle will be set relative to
+        its :py:attr:`.anchor_x` value.
+        """
+        return self._width
+
+    @width.setter
+    def width(self, value: float) -> None:
+        self._width = value
+        self._update_vertices()
+
+    @property
+    def height(self) -> float:
+        """Get/set the height of the rectangle.
+
+        The bottom and top of the rectangle will be positioned relative
+        to its :py:attr:`.anchor_y` value.
+        """
+        return self._height
+
+    @height.setter
+    def height(self, value: float) -> None:
+        self._height = value
+        self._update_vertices()
+
+    @property
+    def radius(self) -> tuple[tuple[float, float], tuple[float, float],
+                              tuple[float, float], tuple[float, float]]:
+        return self._radius
+
+    @radius.setter
+    def radius(self, value: _RadiusT | tuple[_RadiusT, _RadiusT, _RadiusT, _RadiusT]):
+        self._set_radius(value)
         self._update_vertices()
 
 

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -81,7 +81,6 @@ from pyglet.math import Vec2
 if TYPE_CHECKING:
     from pyglet.graphics.shader import ShaderProgram
 
-
 vertex_source = """#version 150 core
     in vec2 position;
     in vec2 translation;
@@ -149,12 +148,12 @@ def _point_in_polygon(polygon, point) -> bool:
     while i < len(polygon) - 1:
         i = i + 1
         if ((polygon[i][1] > point[1]) != (polygon[j][1] > point[1])) and (
-            point[0]
-            < (
-                (polygon[j][0] - polygon[i][0]) * (point[1] - polygon[i][1])
-                / (polygon[j][1] - polygon[i][1])
-            )
-            + polygon[i][0]
+                point[0]
+                < (
+                        (polygon[j][0] - polygon[i][0]) * (point[1] - polygon[i][1])
+                        / (polygon[j][1] - polygon[i][1])
+                )
+                + polygon[i][0]
         ):
             odd = not odd
         j = i
@@ -2055,22 +2054,22 @@ class RoundedRectangle(pyglet.shapes.ShapeBase):
             arc_positions = [
                 # bottom-left
                 (x + self._radius[0][0],
-                 y + self._radius[0][1], math.pi),
-                # bottom-right
-                (x + self._width - self._radius[3][0],
-                 y + self._radius[3][1], math.pi * 3 / 2),
-                # top-right
-                (x + self._width - self._radius[2][0],
-                 y + self._height - self._radius[2][1], 0),
+                 y + self._radius[0][1], math.pi*3/2),
                 # top-left
                 (x + self._radius[1][0],
-                 y + self._height - self._radius[1][1], math.pi / 2),
+                 y + self._height - self._radius[1][1], math.pi),
+                # top-right
+                (x + self._width - self._radius[2][0],
+                 y + self._height - self._radius[2][1], math.pi/2),
+                # bottom-right
+                (x + self._width - self._radius[3][0],
+                 y + self._radius[3][1], 0),
             ]
 
             for (rx, ry), (arc_x, arc_y, arc_start), segments in zip(self._radius, arc_positions, self._segments):
-                tau_segs = math.pi / 2 / segments
-                points += [(arc_x + rx * math.cos(i * tau_segs + arc_start),
-                            arc_y + ry * math.sin(i * tau_segs + arc_start)) for i in range(segments + 1)]
+                tau_segs = -math.pi / 2 / segments
+                points.extend([(arc_x + rx * math.cos(i * tau_segs + arc_start),
+                                arc_y + ry * math.sin(i * tau_segs + arc_start)) for i in range(segments + 1)])
 
             center_x = self._width / 2
             center_y = self._height / 2
@@ -2114,7 +2113,7 @@ class RoundedRectangle(pyglet.shapes.ShapeBase):
 
     @property
     def radius(self) -> tuple[tuple[float, float], tuple[float, float],
-                              tuple[float, float], tuple[float, float]]:
+    tuple[float, float], tuple[float, float]]:
         return self._radius
 
     @radius.setter


### PR DESCRIPTION
I have created a `pyglet.shapes.RoundedRectangle` class for rectangle with rounded corners.

There is an example:
```py
import pyglet

window = pyglet.window.Window(300, 300)
rect = pyglet.shapes.RoundedRectangle(100, 125, 100, 50, radius=(10, 20, 5, 7))

@window.event
def on_draw():
    window.clear()
    rect.draw()

pyglet.app.run()
```
![Снимок экрана 2024-06-24 173428](https://github.com/pyglet/pyglet/assets/117400843/9cd39ceb-f56d-440d-8a27-0b584ba5895a)
