### PR TITLE
Inline matrix operations for small speedup

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -533,7 +533,7 @@ class Mat3(tuple):
         f = a31 * a12 - a11 * a32 # -
         g = a12 * a23 - a22 * a13 # +
         h = a21 * a13 - a11 * a23 # -
-        i = a21 * a12 - a11 * a22 # +
+        i = a11 * a22 - a21 * a12 # +
 
         # Calculate determinant
         det = a11 * a + a21 * d + a31 * g
@@ -542,9 +542,10 @@ class Mat3(tuple):
             _warnings.warn("Unable to calculate inverse of singular Matrix")
             return self
 
-        # get determinant inverse
+        # get determinant reciprocal
         rep = 1.0 / det
 
+        # get inverse: A^-1 = def(A)^-1 * adj(A)
         return Mat3((
             a * rep, b * rep, c * rep,
             d * rep, e * rep, f * rep,

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -517,6 +517,41 @@ class Mat3(tuple):
     def __neg__(self) -> Mat3:
         return Mat3(-v for v in self)
 
+    def __invert__(self) -> Mat3:
+        # extract the elements in row-column form. (matrix is stored column first)
+        a11, a12, a13, a21, a22, a23, a31, a32, a33 = self
+
+        # Calculate Adj(self) values column-row order
+        # | a d g |
+        # | b e h |
+        # | c f i |
+        a = a22 * a33 - a32 * a23 # +
+        b = a31 * a23 - a21 * a33 # -
+        c = a21 * a32 - a22 * a31 # +
+        d = a32 * a13 - a12 * a33 # -
+        e = a11 * a33 - a31 * a13 # +
+        f = a31 * a12 - a11 * a32 # -
+        g = a12 * a23 - a22 * a13 # +
+        h = a21 * a13 - a11 * a23 # -
+        i = a21 * a12 - a11 * a22 # +
+
+        # Calculate determinant
+        det = a11 * a + a21 * d + a31 * g
+
+        if det == 0:
+            _warnings.warn("Unable to calculate inverse of singular Matrix")
+            return self
+
+        # get determinant inverse
+        rep = 1.0 / det
+
+        return Mat3((
+            a * rep, b * rep, c * rep,
+            d * rep, e * rep, f * rep,
+            g * rep, h * rep, i * rep,
+        ))
+
+
     def __round__(self, ndigits: _typing.Optional[int] = None) -> Mat3:
         return Mat3(round(v, ndigits) for v in self)
 

--- a/tests/unit/test_math.py
+++ b/tests/unit/test_math.py
@@ -133,6 +133,13 @@ def test_mat4_inversion(mat4):
     assert round(mat4 @ inverse_2, 9) == Mat4()
 
 
+def test_mat3_inversion(mat3):
+    # TODO: add long hand inversion for mat3
+    inverse_2 = ~mat3
+    # Confirm that Matrix @ its inverse == identity Matrix:
+    assert round(mat3 @ inverse_2, 9) ==  Mat3()
+
+
 def test_mat3_associative_mul():
     swap_xy = Mat3((0,1,0, 1,0,0, 0,0,1))
     scale_x = Mat3((2,0,0, 0,1,0, 0,0,1))


### PR DESCRIPTION
As the title says. In every case, the `sumprod` operation is slower than simply inlining the methods. I had the patience to write them all out.

Also adds inverse to Mat3