### PR TITLE
Fix all pyglet.math issues pyright detects + improve swizzle tests

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -272,12 +272,12 @@ class Vec2(_typing.NamedTuple):
         """
         # Note: double-unroll assumes this isn't prohibitively expensive for perf
         try:
-            min_x, min_y, min_z = min_val  # type: ignore
+            min_x, min_y = min_val  # type: ignore
         except TypeError:
             min_x = min_val
             min_y = min_val
         try:
-            max_x, max_y, max_z = max_val  # type: ignore
+            max_x, max_y = max_val  # type: ignore
         except TypeError:
             max_x = max_val
             max_y = max_val

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -354,9 +354,17 @@ class Vec3(_typing.NamedTuple):
 
     def __rmul__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:
-            return Vec3(self[0] * scalar[0], self[1] * scalar[1], self[2] * scalar[2])
+            return Vec3(
+                self[0] * scalar[0],  # type: ignore
+                self[1] * scalar[1],  # type: ignore
+                self[2] * scalar[2]  # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] * scalar, self[1] * scalar, self[2] * scalar)
+            return Vec3(
+                 self[0] * scalar,  # type: ignore
+                 self[1] * scalar,  # type: ignore
+                 self[2] * scalar  # type: ignore
+            )
 
     def __truediv__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -90,9 +90,15 @@ class Vec2(_typing.NamedTuple):
 
     def __floordiv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
-            return Vec2(self.x // scalar[0], self.y // scalar[1])
+            return Vec2(
+                self.x // scalar[0],  # type: ignore
+                self.y // scalar[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] // scalar, self[1] // scalar)
+            return Vec2(
+                self[0] // scalar,  # type: ignore
+                self[1] // scalar  # type: ignore
+            )
 
     def __rfloordiv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -120,9 +120,15 @@ class Vec2(_typing.NamedTuple):
 
     def __mod__(self, other: tuple[float, float] | float) -> Vec2:
         try:
-            return Vec2(self[0] % other[0], self[1] % other[1])
+            return Vec2(
+                self[0] % other[0],  # type: ignore
+                self[1] % other[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] % other, self[1] % other)
+            return Vec2(
+                self[0] % other,  # type: ignore
+                self[1] % other  # type: ignore
+            )
 
     def __pow__(self, other: tuple[float, float] | float) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -54,9 +54,15 @@ class Vec2(_typing.NamedTuple):
 
     def __sub__(self, other: tuple[float, float] | float) -> Vec2:
         try:
-            return Vec2(self[0] - other[0], self[1] - other[1])
+            return Vec2(
+                self[0] - other[0],  # type: ignore
+                self[1] - other[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] - other, self[1] - other)
+            return Vec2(
+                self[0] - other,  # type: ignore
+                self[1] - other  # type: ignore
+            )
 
     def __rsub__(self, other: tuple[float, float] | float) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -338,14 +338,13 @@ class Vec2(_typing.NamedTuple):
             min_val: The minimum value(s)
             max_val: The maximum value(s)
         """
-        # Note: double-unroll assumes this isn't prohibitively expensive for perf
         try:
-            min_x, min_y = min_val  # type: ignore
+            min_x, min_y = min_val[0], min_val[1]  # type: ignore
         except TypeError:
             min_x = min_val
             min_y = min_val
         try:
-            max_x, max_y = max_val  # type: ignore
+            max_x, max_y = max_val[0], max_val[1]  # type: ignore
         except TypeError:
             max_x = max_val
             max_y = max_val
@@ -622,15 +621,14 @@ class Vec3(_typing.NamedTuple):
             min_val: The minimum value(s)
             max_val: The maximum value(s)
         """
-        # Note: double-unroll assumes this isn't prohibitively expensive for perf
         try:
-            min_x, min_y, min_z = min_val  # type: ignore
+            min_x, min_y, min_z = min_val[0], min_val[1], min_val[2]  # type: ignore
         except TypeError:
             min_x = min_val
             min_y = min_val
             min_z = min_val
         try:
-            max_x, max_y, max_z = max_val  # type: ignore
+            max_x, max_y, max_z = max_val[0], max_val[1], max_val[2]  # type: ignore
         except TypeError:
             max_x = max_val
             max_y = max_val
@@ -894,16 +892,15 @@ class Vec4(_typing.NamedTuple):
             min_val: The minimum value(s)
             max_val: The maximum value(s)
         """
-        # Note: double-unroll assumes this isn't prohibitively expensive for perf
         try:
-            min_x, min_y, min_z, min_w = min_val  # type: ignore
+            min_x, min_y, min_z, min_w = min_val[0], min_val[1], min_val[2], min_val[3]  # type: ignore
         except TypeError:
             min_x = min_val
             min_y = min_val
             min_z = min_val
             min_w = min_val
         try:
-            max_x, max_y, max_z, max_w = max_val  # type: ignore
+            max_x, max_y, max_z, max_w = max_val[0], max_val[1],  max_val[2], max_val[3]  # type: ignore
         except TypeError:
             max_x = max_val
             max_y = max_val

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -66,9 +66,15 @@ class Vec2(_typing.NamedTuple):
 
     def __mul__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
-            return Vec2(self[0] * scalar[0], self[1] * scalar[1])
+            return Vec2(
+                self[0] * scalar[0],  # type: ignore
+                self[1] * scalar[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] * scalar, self[1] * scalar)
+            return Vec2(
+                self[0] * scalar,  # type: ignore
+                self[1] * scalar  # type: ignore
+            )
 
     def __rmul__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -334,7 +334,7 @@ class Vec3(_typing.NamedTuple):
                 return self
             raise err
 
-    def __sub__(self, other: Vec3 | tuple[float, float] | float) -> Vec3:
+    def __sub__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
                 self[0] - other[0],  # type: ignore

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -461,15 +461,15 @@ class Vec3(_typing.NamedTuple):
     def __truediv__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                self[0] / other[0],  # type: ignore
-                self[1] / other[1],  # type: ignore
-                self[2] / other[2]  # type: ignore
+                self[0] / scalar[0],  # type: ignore
+                self[1] / scalar[1],  # type: ignore
+                self[2] / scalar[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] / other,  # type: ignore
-                 self[1] / other,  # type: ignore
-                 self[2] / other  # type: ignore
+                 self[0] / scalar,  # type: ignore
+                 self[1] / scalar,  # type: ignore
+                 self[2] / scalar  # type: ignore
             )
 
     def __rtruediv__(self, other: float | tuple[float, float, float]) -> Vec3:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -360,9 +360,17 @@ class Vec3(_typing.NamedTuple):
 
     def __truediv__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:
-            return Vec3(self[0] / scalar[0], self[1] / scalar[1], self[2] / scalar[2])
+            return Vec3(
+                self[0] / other[0],  # type: ignore
+                self[1] / other[1],  # type: ignore
+                self[2] / other[2]  # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] / scalar, self[1] / scalar, self[2] / scalar)
+            return Vec3(
+                 self[0] / other,  # type: ignore
+                 self[1] / other,  # type: ignore
+                 self[2] / other  # type: ignore
+            )
 
     def __rtruediv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -486,7 +486,7 @@ class Vec3(_typing.NamedTuple):
                   other / self[2]  # type: ignore
             )
 
-    def __rfloordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
+    def __floordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
                 self[0] // other[0],  # type: ignore
@@ -498,6 +498,20 @@ class Vec3(_typing.NamedTuple):
                  self[0] // other,  # type: ignore
                  self[1] // other,  # type: ignore
                  self[2] // other   # type: ignore
+            )
+
+    def __rfloordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
+        try:
+            return Vec3(
+                other[0] // self[0], # type: ignore
+                other[1] // self[1], # type: ignore
+                other[2] // self[2] # type: ignore
+            )
+        except TypeError:
+            return Vec3(
+                 other // self[0],  # type: ignore
+                 other // self[1],  # type: ignore
+                 other // self[2]  # type: ignore
             )
 
     def __abs__(self) -> Vec3:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -538,19 +538,19 @@ class Vec3(_typing.NamedTuple):
         """
         return self.x * other[0] + self.y * other[1] + self.z * other[2]
 
-    def lerp(self, other: Vec3, alpha: float) -> Vec3:
-        """Create a new Vec3 linearly interpolated between this vector and another Vec3.
+    def lerp(self, other: tuple[float, float, float], alpha: float) -> Vec3:
+        """Create a new Vec3 linearly interpolated between this vector and another Vec3-like.
 
         Args:
-          other: Another Vec3 instance.
+          other: Another Vec3 instance or tuple of 3 floats.
           alpha: The amount of interpolation between this vector, and the other
                  vector. This should be a value between 0.0 and 1.0. For example:
                  0.5 is the midway point between both vectors.
         """
         return Vec3(
-            self.x + (alpha * (other.x - self.x)),
-            self.y + (alpha * (other.y - self.y)),
-            self.z + (alpha * (other.z - self.z)),
+            self.x + (alpha * (other[0] - self.x)),
+            self.y + (alpha * (other[1] - self.y)),
+            self.z + (alpha * (other[2] - self.z)),
         )
 
     def distance(self, other: Vec3) -> float:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -737,17 +737,17 @@ class Vec4(_typing.NamedTuple):
     def __sub__(self, other: Vec4 | tuple[int, int] | float) -> Vec4:
         try:
             return Vec4(
-                other[0] - self[0],  # type: ignore
-                other[1] - self[1],  # type: ignore
-                other[2] - self[2],  # type: ignore
-                other[3] - self[3]  # type: ignore
+                 self[0] - other[0],  # type: ignore
+                 self[1] - other[1],  # type: ignore
+                 self[2] - other[2],  # type: ignore
+                 self[3] - other[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                other - self[0],  # type: ignore
-                other - self[1],  # type: ignore
-                other - self[2],  # type: ignore
-                other - self[3]  # type: ignore
+                self[0] - other,  # type: ignore
+                self[1] - other,  # type: ignore
+                self[2] - other,  # type: ignore
+                self[3] - other  # type: ignore
             )
 
     def __rsub__(self, other: Vec4 | tuple[int, int] | float) -> Vec4:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -186,9 +186,15 @@ class Vec2(_typing.NamedTuple):
 
     def __pow__(self, other: tuple[float, float] | float) -> Vec2:
         try:
-            return Vec2(self[0] ** other[0], self[1] ** other[1])
+            return Vec2(
+                self[0] ** other[0],  # type: ignore
+                self[1] ** other[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] ** other, self[1] ** other)
+            return Vec2(
+                self[0] ** other,  # type: ignore
+                self[1] ** other  # type: ignore
+            )
 
     def __lt__(self, other: float | tuple[float, float]) -> bool:
         return self[0] ** 2 + self[0] ** 2 < other[0] ** 2 + other[1] ** 2

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -518,16 +518,16 @@ class Vec3(_typing.NamedTuple):
         """
         return self[0] ** 2 + self[1] ** 2 + self[2] ** 2
 
-    def cross(self, other: Vec3) -> Vec3:
+    def cross(self, other: tuple[float, float, float]) -> Vec3:
         """Calculate the cross product of this vector and another 3D vector.
 
         Args:
-            other: Another Vec3 instance.
+            other: Another Vec3 or tuple of 3 floats.
         """
         return Vec3(
-            (self.y * other.z) - (self.z * other.y),
-            (self.z * other.x) - (self.x * other.z),
-            (self.x * other.y) - (self.y * other.x),
+            (self.y * other[2]) - (self.z * other[1]),
+            (self.z * other[0]) - (self.x * other[2]),
+            (self.x * other[1]) - (self.y * other[0]),
         )
 
     def dot(self, other: Vec3) -> float:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1,3 +1,10 @@
+# mypy: ignore-errors
+# Even when the notoriously picky pyright reports 0 errors, mypy will
+# incorrectly report plenty because:
+# 1. This file contains typing.NamedTuple subclasses
+# 2. The mypy stance on NamedTuple is "Duplicate of #5613, still low
+#    priority, better use dataclasses, as suggested above.", per
+#    https://github.com/python/mypy/issues/5944#issuecomment-441285456
 """Matrix and Vector math.
 
 .. WARNING! DO NOT TRY TO MAKE THIS FILE "PRETTIER"!

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -514,13 +514,13 @@ class Vec3(_typing.NamedTuple):
         """
         # Note: double-unroll assumes this isn't prohibitively expensive for perf
         try:
-            min_x, min_y, min_z = min_val
+            min_x, min_y, min_z = min_val  # type: ignore
         except TypeError:
             min_x = min_val
             min_y = min_val
             min_z = min_val
         try:
-            max_x, max_y, max_z = max_val
+            max_x, max_y, max_z = max_val  # type: ignore
         except TypeError:
             max_x = max_val
             max_y = max_val

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1043,7 +1043,8 @@ class Vec4(_typing.NamedTuple):
     def __getattr__(self, attrs: str) -> Vec2 | Vec3 | Vec4:
         try:
             # Allow swizzled getting of attrs
-            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}.get(len(attrs))
+            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}\
+                .get(len(attrs)) # type: ignore
             return vec_class(*(self['xyzw'.index(c)] for c in attrs))
         except (ValueError, TypeError) as err:
             msg = f"'Vec4' has no attribute: '{attrs}'."

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -370,11 +370,19 @@ class Vec3(_typing.NamedTuple):
         except TypeError:
             return Vec3(scalar / self[0], scalar / self[1], scalar / self[2])
 
-    def __floordiv__(self, scalar: float | tuple[float, float, float]) -> Vec3:
+    def __floordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
-            return Vec3(self[0] // scalar[0], self[1] // scalar[1], self[2] // scalar[2])
+            return Vec3(
+                self[0] // other[0],  # type: ignore
+                self[1] // other[1],  # type: ignore
+                self[2] // other[2]   # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] // scalar, self[1] // scalar, self[2] // scalar)
+            return Vec3(
+                 self[0] // other,  # type: ignore
+                 self[1] // other,  # type: ignore
+                 self[2] // other   # type: ignore
+            )
 
     def __rfloordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -406,7 +406,7 @@ class Vec3(_typing.NamedTuple):
         except TypeError:
             return Vec3(self[0] % other, self[1] % other, self[2] % other)
 
-    def __pow__(self, other: Vec3 | tuple[int, int, int] | float) -> Vec3:
+    def __pow__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(self[0] ** other[0], self[1] ** other[1], self[2] ** other[2])
         except TypeError:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -66,13 +66,11 @@ class Vec2(_typing.NamedTuple):
     def __add__(self, other: tuple[float, float] | float) -> Vec2:
         try:
             return Vec2(
-                self[0] + other[0],  # type: ignore
-                self[1] + other[1]   # type: ignore
+                self[0] + other[0], self[1] + other[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] + other,  # type: ignore
-                self[1] + other  # type: ignore
+                self[0] + other, self[1] + other  # type: ignore
             )
 
     def __radd__(self, other: tuple[float, float] | float) -> Vec2:
@@ -86,97 +84,81 @@ class Vec2(_typing.NamedTuple):
     def __sub__(self, other: tuple[float, float] | float) -> Vec2:
         try:
             return Vec2(
-                self[0] - other[0],  # type: ignore
-                self[1] - other[1]  # type: ignore
+                self[0] - other[0], self[1] - other[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] - other,  # type: ignore
-                self[1] - other  # type: ignore
+                self[0] - other, self[1] - other  # type: ignore
             )
 
     def __rsub__(self, other: tuple[float, float] | float) -> Vec2:
         try:
             return Vec2(
-                other[0] - self[0],  # type: ignore
-                other[1] - self[1]  # type: ignore
+                other[0] - self[0], other[1] - self[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                other - self[0],  # type: ignore
-                other - self[1]  # type: ignore
+                other - self[0], other - self[1]  # type: ignore
             )
 
     def __mul__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
             return Vec2(
-                self[0] * scalar[0],  # type: ignore
-                self[1] * scalar[1]  # type: ignore
+                self[0] * scalar[0], self[1] * scalar[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] * scalar,  # type: ignore
-                self[1] * scalar  # type: ignore
+                self[0] * scalar, self[1] * scalar  # type: ignore
             )
 
     def __rmul__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
             return Vec2(
-                self[0] * scalar[0],  # type: ignore
-                self[1] * scalar[1]  # type: ignore
+                self[0] * scalar[0], self[1] * scalar[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] * scalar,  # type: ignore
-                self[1] * scalar  # type: ignore
+                self[0] * scalar, self[1] * scalar  # type: ignore
             )
 
     def __truediv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
             return Vec2(
-                self[0] / scalar[0],  # type: ignore
-                self[1] / scalar[1]  # type: ignore
+                self[0] / scalar[0], self[1] / scalar[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] / scalar,  # type: ignore
-                self[1] / scalar  # type: ignore
+                self[0] / scalar, self[1] / scalar  # type: ignore
             )
 
     def __rtruediv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
             return Vec2(
-                scalar[0] / self[0],  # type: ignore
-                scalar[1] / self[1]  # type: ignore
+                scalar[0] / self[0], scalar[1] / self[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                scalar / self[0],  # type: ignore
-                scalar / self[1]  # type: ignore
+                scalar / self[0], scalar / self[1]  # type: ignore
             )
 
     def __floordiv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
             return Vec2(
-                self.x // scalar[0],  # type: ignore
-                self.y // scalar[1]  # type: ignore
+                self.x // scalar[0], self.y // scalar[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] // scalar,  # type: ignore
-                self[1] // scalar  # type: ignore
+                self[0] // scalar, self[1] // scalar  # type: ignore
             )
 
     def __rfloordiv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
             return Vec2(
-                scalar[0] // self[0],  # type: ignore
-                scalar[1] // self[1]  # type: ignore
+                scalar[0] // self[0], scalar[1] // self[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                scalar // self[0],  # type: ignore
-                scalar // self[1]  # type: ignore
+                scalar // self[0], scalar // self[1]  # type: ignore
             )
 
     def __abs__(self) -> Vec2:
@@ -200,25 +182,21 @@ class Vec2(_typing.NamedTuple):
     def __mod__(self, other: tuple[float, float] | float) -> Vec2:
         try:
             return Vec2(
-                self[0] % other[0],  # type: ignore
-                self[1] % other[1]  # type: ignore
+                self[0] % other[0], self[1] % other[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] % other,  # type: ignore
-                self[1] % other  # type: ignore
+                self[0] % other, self[1] % other  # type: ignore
             )
 
     def __pow__(self, other: tuple[float, float] | float) -> Vec2:
         try:
             return Vec2(
-                self[0] ** other[0],  # type: ignore
-                self[1] ** other[1]  # type: ignore
+                self[0] ** other[0], self[1] ** other[1]  # type: ignore
             )
         except TypeError:
             return Vec2(
-                self[0] ** other,  # type: ignore
-                self[1] ** other  # type: ignore
+                self[0] ** other, self[1] ** other  # type: ignore
             )
 
     def __lt__(self, other: tuple[float, float]) -> bool:
@@ -332,7 +310,6 @@ class Vec2(_typing.NamedTuple):
         return self
 
     if _typing.TYPE_CHECKING:
-
         @_typing.overload
         def clamp(self, min_val: float, max_val: float) -> Vec2:
             ...
@@ -374,8 +351,7 @@ class Vec2(_typing.NamedTuple):
             max_y = max_val
 
         return Vec2(
-            clamp(self[0], min_x, max_x), # type: ignore
-            clamp(self[1], min_y, max_y), # type: ignore
+            clamp(self[0], min_x, max_x), clamp(self[1], min_y, max_y),  # type: ignore
         )
 
     def dot(self, other: Vec2 | tuple[float, float]) -> float:
@@ -414,15 +390,11 @@ class Vec3(_typing.NamedTuple):
     def __add__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
-                self[0] + other[0],  # type: ignore
-                self[1] + other[1],  # type: ignore
-                self[2] + other[2]  # type: ignore
+                self[0] + other[0], self[1] + other[1], self[2] + other[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] + other,  # type: ignore
-                 self[1] + other,  # type: ignore
-                 self[2] + other  # type: ignore
+                self[0] + other, self[1] + other, self[2] + other  # type: ignore
             )
 
     def __radd__(self, other: Vec3 | float) -> Vec3:
@@ -436,113 +408,81 @@ class Vec3(_typing.NamedTuple):
     def __sub__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
-                self[0] - other[0],  # type: ignore
-                self[1] - other[1],  # type: ignore
-                self[2] - other[2]  # type: ignore
+                self[0] - other[0], self[1] - other[1], self[2] - other[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] - other,  # type: ignore
-                 self[1] - other,  # type: ignore
-                 self[2] - other  # type: ignore
+                self[0] - other, self[1] - other, self[2] - other  # type: ignore
             )
 
     def __rsub__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
-                other[0] - self[0], # type: ignore
-                other[1] - self[1], # type: ignore
-                other[2] - self[2] # type: ignore
+                other[0] - self[0], other[1] - self[1], other[2] - self[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 other - self[0],  # type: ignore
-                 other - self[1],  # type: ignore
-                 other - self[2]  # type: ignore
+                other - self[0], other - self[1], other - self[2]  # type: ignore
             )
 
     def __mul__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                self[0] * scalar[0],  # type: ignore
-                self[1] * scalar[1],  # type: ignore
-                self[2] * scalar[2]  # type: ignore
+                self[0] * scalar[0], self[1] * scalar[1], self[2] * scalar[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] * scalar,  # type: ignore
-                 self[1] * scalar,  # type: ignore
-                 self[2] * scalar  # type: ignore
+                self[0] * scalar, self[1] * scalar, self[2] * scalar  # type: ignore
             )
 
     def __rmul__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                self[0] * scalar[0],  # type: ignore
-                self[1] * scalar[1],  # type: ignore
-                self[2] * scalar[2]  # type: ignore
+                self[0] * scalar[0], self[1] * scalar[1], self[2] * scalar[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] * scalar,  # type: ignore
-                 self[1] * scalar,  # type: ignore
-                 self[2] * scalar  # type: ignore
+                self[0] * scalar, self[1] * scalar, self[2] * scalar  # type: ignore
             )
 
     def __truediv__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                self[0] / scalar[0],  # type: ignore
-                self[1] / scalar[1],  # type: ignore
-                self[2] / scalar[2]  # type: ignore
+                self[0] / scalar[0], self[1] / scalar[1], self[2] / scalar[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] / scalar,  # type: ignore
-                 self[1] / scalar,  # type: ignore
-                 self[2] / scalar  # type: ignore
+                self[0] / scalar, self[1] / scalar, self[2] / scalar  # type: ignore
             )
 
     def __rtruediv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                other[0] / self[0],  # type: ignore
-                other[1] / self[1],  # type: ignore
-                other[2] / self[2]  # type: ignore
+                other[0] / self[0], other[1] / self[1], other[2] / self[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                  other / self[0],  # type: ignore
-                  other / self[1],  # type: ignore
-                  other / self[2]  # type: ignore
+                other / self[0], other / self[1], other / self[2]  # type: ignore
             )
 
     def __floordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                self[0] // other[0],  # type: ignore
-                self[1] // other[1],  # type: ignore
-                self[2] // other[2]   # type: ignore
+                self[0] // other[0], self[1] // other[1], self[2] // other[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] // other,  # type: ignore
-                 self[1] // other,  # type: ignore
-                 self[2] // other   # type: ignore
+                self[0] // other, self[1] // other, self[2] // other  # type: ignore
             )
 
     def __rfloordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                other[0] // self[0], # type: ignore
-                other[1] // self[1], # type: ignore
-                other[2] // self[2] # type: ignore
+                other[0] // self[0], other[1] // self[1], other[2] // self[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 other // self[0],  # type: ignore
-                 other // self[1],  # type: ignore
-                 other // self[2]  # type: ignore
+                other // self[0], other // self[1], other // self[2]  # type: ignore
             )
 
     def __abs__(self) -> Vec3:
@@ -566,29 +506,21 @@ class Vec3(_typing.NamedTuple):
     def __mod__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
-                self[0] % other[0],  # type: ignore
-                self[1] % other[1],  # type: ignore
-                self[2] % other[2]   # type: ignore
+                self[0] % other[0], self[1] % other[1], self[2] % other[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] % other,  # type: ignore
-                 self[1] % other,  # type: ignore
-                 self[2] % other   # type: ignore
+                self[0] % other, self[1] % other, self[2] % other  # type: ignore
             )
 
     def __pow__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
-                self[0] ** other[0],  # type: ignore
-                self[1] ** other[1],  # type: ignore
-                self[2] ** other[2]   # type: ignore
+                self[0] ** other[0], self[1] ** other[1], self[2] ** other[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] ** other,  # type: ignore
-                 self[1] ** other,  # type: ignore
-                 self[2] ** other   # type: ignore
+                self[0] ** other, self[1] ** other, self[2] ** other  # type: ignore
             )
 
     def __lt__(self, other: tuple[float, float, float]) -> bool:
@@ -662,7 +594,6 @@ class Vec3(_typing.NamedTuple):
             return self
 
     if _typing.TYPE_CHECKING:
-
         @_typing.overload
         def clamp(self, min_val: float, max_val: float) -> Vec3:
             ...
@@ -706,9 +637,7 @@ class Vec3(_typing.NamedTuple):
             max_z = max_val
 
         return Vec3(
-            clamp(self[0], min_x, max_x), # type: ignore
-            clamp(self[1], min_y, max_y), # type: ignore
-            clamp(self[2], min_z, max_z), # type: ignore
+            clamp(self[0], min_x, max_x), clamp(self[1], min_y, max_y), clamp(self[2], min_z, max_z)  # type: ignore
         )
 
     def index(self, *args: _typing.Any) -> int:
@@ -744,17 +673,11 @@ class Vec4(_typing.NamedTuple):
     def __add__(self, other: Vec4 | tuple[float, float] | float) -> Vec4:
         try:
             return Vec4(
-                other[0] + self[0],  # type: ignore
-                other[1] + self[1],  # type: ignore
-                other[2] + self[2],  # type: ignore
-                other[3] + self[3]  # type: ignore
+                other[0] + self[0], other[1] + self[1], other[2] + self[2], other[3] + self[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                other + self[0],  # type: ignore
-                other + self[1],  # type: ignore
-                other + self[2],  # type: ignore
-                other + self[3]  # type: ignore
+                other + self[0], other + self[1], other + self[2], other + self[3]  # type: ignore
             )
 
     def __radd__(self, other: Vec4 | int) -> Vec4:
@@ -768,129 +691,81 @@ class Vec4(_typing.NamedTuple):
     def __sub__(self, other: Vec4 | tuple[int, int] | float) -> Vec4:
         try:
             return Vec4(
-                 self[0] - other[0],  # type: ignore
-                 self[1] - other[1],  # type: ignore
-                 self[2] - other[2],  # type: ignore
-                 self[3] - other[3]  # type: ignore
+                self[0] - other[0], self[1] - other[1], self[2] - other[2], self[3] - other[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] - other,  # type: ignore
-                self[1] - other,  # type: ignore
-                self[2] - other,  # type: ignore
-                self[3] - other  # type: ignore
+                self[0] - other, self[1] - other, self[2] - other, self[3] - other  # type: ignore
             )
 
     def __rsub__(self, other: Vec4 | tuple[int, int] | float) -> Vec4:
         try:
             return Vec4(
-                other[0] - self[0],  # type: ignore
-                other[1] - self[1],  # type: ignore
-                other[2] - self[2],  # type: ignore
-                other[3] - self[3]  # type: ignore
+                other[0] - self[0], other[1] - self[1], other[2] - self[2], other[3] - self[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                other - self[0],  # type: ignore
-                other - self[1],  # type: ignore
-                other - self[2],  # type: ignore
-                other - self[3]  # type: ignore
+                other - self[0], other - self[1], other - self[2], other - self[3]  # type: ignore
             )
 
     def __mul__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:
         try:
             return Vec4(
-                self[0] * scalar[0],  # type: ignore
-                self[1] * scalar[1],  # type: ignore
-                self[2] * scalar[2],  # type: ignore
-                self[3] * scalar[3]  # type: ignore
+                self[0] * scalar[0], self[1] * scalar[1], self[2] * scalar[2], self[3] * scalar[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] * scalar,  # type: ignore
-                self[1] * scalar,  # type: ignore
-                self[2] * scalar,  # type: ignore
-                self[3] * scalar  # type: ignore
+                self[0] * scalar, self[1] * scalar, self[2] * scalar, self[3] * scalar  # type: ignore
             )
 
     def __rmul__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:
         try:
             return Vec4(
-                self[0] * scalar[0],  # type: ignore
-                self[1] * scalar[1],  # type: ignore
-                self[2] * scalar[2],  # type: ignore
-                self[3] * scalar[3]  # type: ignore
+                self[0] * scalar[0], self[1] * scalar[1], self[2] * scalar[2], self[3] * scalar[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] * scalar,  # type: ignore
-                self[1] * scalar,  # type: ignore
-                self[2] * scalar,  # type: ignore
-                self[3] * scalar  # type: ignore
+                self[0] * scalar, self[1] * scalar, self[2] * scalar, self[3] * scalar  # type: ignore
             )
 
     def __truediv__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:
         try:
             return Vec4(
-                self[0] / scalar[0],  # type: ignore
-                self[1] / scalar[1],  # type: ignore
-                self[2] / scalar[2],  # type: ignore
-                self[3] / scalar[3]  # type: ignore
+                self[0] / scalar[0], self[1] / scalar[1], self[2] / scalar[2], self[3] / scalar[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] / scalar,  # type: ignore
-                self[1] / scalar,  # type: ignore
-                self[2] / scalar,  # type: ignore
-                self[3] / scalar  # type: ignore
+                self[0] / scalar, self[1] / scalar, self[2] / scalar, self[3] / scalar  # type: ignore
             )
 
     def __rtruediv__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:
         try:
             return Vec4(
-                scalar[0] / self[0],  # type: ignore
-                scalar[1] / self[1],  # type: ignore
-                scalar[2] / self[2],  # type: ignore
-                scalar[3] / self[3]   # type: ignore
+                scalar[0] / self[0], scalar[1] / self[1], scalar[2] / self[2], scalar[3] / self[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-               scalar / self[0],  # type: ignore
-               scalar / self[1],  # type: ignore
-               scalar / self[2],  # type: ignore
-               scalar / self[3]   # type: ignore
+                scalar / self[0], scalar / self[1], scalar / self[2], scalar / self[3]  # type: ignore
             )
 
     def __floordiv__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:
         try:
             return Vec4(
-                self[0] // scalar[0],  # type: ignore
-                self[1] // scalar[1],  # type: ignore
-                self[2] // scalar[2],  # type: ignore
-                self[3] // scalar[3]  # type: ignore
+                self[0] // scalar[0], self[1] // scalar[1], self[2] // scalar[2], self[3] // scalar[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] // scalar,  # type: ignore
-                self[1] // scalar,  # type: ignore
-                self[2] // scalar,  # type: ignore
-                self[3] // scalar  # type: ignore
+                self[0] // scalar, self[1] // scalar, self[2] // scalar, self[3] // scalar  # type: ignore
             )
 
     def __rfloordiv__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:
         try:
             return Vec4(
-                scalar[0] // self[0],  # type: ignore
-                scalar[1] // self[1],  # type: ignore
-                scalar[2] // self[2],  # type: ignore
-                scalar[3] // self[3]   # type: ignore
+                scalar[0] // self[0], scalar[1] // self[1], scalar[2] // self[2], scalar[3] // self[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                scalar // self[0],  # type: ignore
-                scalar // self[1],  # type: ignore
-                scalar // self[2],  # type: ignore
-                scalar // self[3]   # type: ignore
+                scalar // self[0], scalar // self[1], scalar // self[2], scalar // self[3]  # type: ignore
             )
 
     def __abs__(self) -> Vec4:
@@ -914,33 +789,21 @@ class Vec4(_typing.NamedTuple):
     def __mod__(self, other: Vec4 | tuple[int, int, int, int] | float) -> Vec4:
         try:
             return Vec4(
-                self[0] % other[0],  # type: ignore
-                self[1] % other[1],  # type: ignore
-                self[2] % other[2],  # type: ignore
-                self[3] % other[3]   # type: ignore
+                self[0] % other[0], self[1] % other[1], self[2] % other[2], self[3] % other[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] % other,  # type: ignore
-                self[1] % other,  # type: ignore
-                self[2] % other,  # type: ignore
-                self[3] % other   # type: ignore
+                self[0] % other, self[1] % other, self[2] % other, self[3] % other  # type: ignore
             )
 
     def __pow__(self, other: Vec4 | tuple[int, int, int, int] | float) -> Vec4:
         try:
             return Vec4(
-                self[0] ** other[0],  # type: ignore
-                self[1] ** other[1],  # type: ignore
-                self[2] ** other[2],  # type: ignore
-                self[3] ** other[3]   # type: ignore
+                self[0] ** other[0], self[1] ** other[1], self[2] ** other[2], self[3] ** other[3]  # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] ** other, # type: ignore
-                self[1] ** other, # type: ignore
-                self[2] ** other, # type: ignore
-                self[3] ** other # type: ignore
+                self[0] ** other, self[1] ** other, self[2] ** other, self[3] ** other  # type: ignore
             )
 
     def __lt__(self, other: Vec4) -> bool:
@@ -1048,10 +911,8 @@ class Vec4(_typing.NamedTuple):
             max_w = max_val
 
         return Vec4(
-            clamp(self[0], min_x, max_x), # type: ignore
-            clamp(self[1], min_y, max_y), # type: ignore
-            clamp(self[2], min_z, max_z), # type: ignore
-            clamp(self[3], min_w, max_w), # type: ignore
+            clamp(self[0], min_x, max_x), clamp(self[1], min_y, max_y),  # type: ignore
+            clamp(self[2], min_z, max_z), clamp(self[3], min_w, max_w),  # type: ignore
         )
 
     def dot(self, other: Vec4) -> float:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1043,10 +1043,9 @@ class Vec4(_typing.NamedTuple):
     def __getattr__(self, attrs: str) -> Vec2 | Vec3 | Vec4:
         try:
             # Allow swizzled getting of attrs
-            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}\
-                .get(len(attrs)) # type: ignore
+            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}[len(attrs)]
             return vec_class(*(self['xyzw'.index(c)] for c in attrs))
-        except (ValueError, TypeError) as err:
+        except (ValueError, KeyError, TypeError) as err:
             msg = f"'Vec4' has no attribute: '{attrs}'."
             raise AttributeError(msg) from err
 

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -37,6 +37,15 @@ class Vec2(_typing.NamedTuple):
 
     .. note:: The Python `len` operator returns the number of elements in
               the vector. For the vector length, use the `length()` method.
+
+    .. note:: Python's :py:func:`sum` requires the first item to be a ``Vec2``.
+
+              After that, you can mix ``Vec2``-like :py:class:`tuple`
+              and ``Vec2`` instances freely in the iterable.
+
+              If you do not, you will see a :py:class:`TypeError` about being
+              unable to add a :py:class:`tuple` and a :py:class:`int`.
+
     """
 
     x: float = 0.0

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -475,15 +475,15 @@ class Vec3(_typing.NamedTuple):
     def __rtruediv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                self[0] / other[0],  # type: ignore
-                self[1] / other[1],  # type: ignore
-                self[2] / other[2]   # type: ignore
+                other[0] / self[0],  # type: ignore
+                other[1] / self[1],  # type: ignore
+                other[2] / self[2]  # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] / other,  # type: ignore
-                 self[1] / other,  # type: ignore
-                 self[2] / other   # type: ignore
+                  other / self[0],  # type: ignore
+                  other / self[1],  # type: ignore
+                  other / self[2]  # type: ignore
             )
 
     def __rfloordiv__(self, other: float | tuple[float, float, float]) -> Vec3:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -60,9 +60,15 @@ class Vec2(_typing.NamedTuple):
 
     def __rsub__(self, other: tuple[float, float] | float) -> Vec2:
         try:
-            return Vec2(other[0] - self[0], other[1] - self[1])
+            return Vec2(
+                other[0] - self[0],  # type: ignore
+                other[1] - self[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(other - self[0], other - self[1])
+            return Vec2(
+                other - self[0],  # type: ignore
+                other - self[1]  # type: ignore
+            )
 
     def __mul__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -348,9 +348,17 @@ class Vec3(_typing.NamedTuple):
 
     def __mul__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:
-            return Vec3(self[0] * scalar[0], self[1] * scalar[1], self[2] * scalar[2])
+            return Vec3(
+                self[0] * scalar[0],  # type: ignore
+                self[1] * scalar[1],  # type: ignore
+                self[2] * scalar[2]  # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] * scalar, self[1] * scalar, self[2] * scalar)
+            return Vec3(
+                 self[0] * scalar,  # type: ignore
+                 self[1] * scalar,  # type: ignore
+                 self[2] * scalar  # type: ignore
+            )
 
     def __rmul__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -530,13 +530,13 @@ class Vec3(_typing.NamedTuple):
             (self.x * other[1]) - (self.y * other[0]),
         )
 
-    def dot(self, other: Vec3) -> float:
+    def dot(self, other: tuple[float, float, float]) -> float:
         """Calculate the dot product of this vector and another 3D vector.
 
         Args:
-            other: Another Vec3 instance.
+            other: Another Vec3 or tuple of 3 floats.
         """
-        return self.x * other.x + self.y * other.y + self.z * other.z
+        return self.x * other[0] + self.y * other[1] + self.z * other[2]
 
     def lerp(self, other: Vec3, alpha: float) -> Vec3:
         """Create a new Vec3 linearly interpolated between this vector and another Vec3.

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -364,24 +364,18 @@ class Vec3(_typing.NamedTuple):
         except TypeError:
             return Vec3(self[0] / scalar, self[1] / scalar, self[2] / scalar)
 
-    def __rtruediv__(self, scalar: float | tuple[float, float, float]) -> Vec3:
-        try:
-            return Vec3(scalar[0] / self[0], scalar[1] / self[1], scalar[2] / self[2])
-        except TypeError:
-            return Vec3(scalar / self[0], scalar / self[1], scalar / self[2])
-
-    def __floordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
+    def __rtruediv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
             return Vec3(
-                self[0] // other[0],  # type: ignore
-                self[1] // other[1],  # type: ignore
-                self[2] // other[2]   # type: ignore
+                self[0] / other[0],  # type: ignore
+                self[1] / other[1],  # type: ignore
+                self[2] / other[2]   # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] // other,  # type: ignore
-                 self[1] // other,  # type: ignore
-                 self[2] // other   # type: ignore
+                 self[0] / other,  # type: ignore
+                 self[1] / other,  # type: ignore
+                 self[2] / other   # type: ignore
             )
 
     def __rfloordiv__(self, other: float | tuple[float, float, float]) -> Vec3:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -553,13 +553,13 @@ class Vec3(_typing.NamedTuple):
             self.z + (alpha * (other[2] - self.z)),
         )
 
-    def distance(self, other: Vec3) -> float:
+    def distance(self, other: tuple[float, float, float]) -> float:
         """Calculate the distance between this vector and another 3D vector.
 
         Args:
             other: The point to calculate the distance to.
         """
-        return _math.sqrt(((other.x - self.x) ** 2) + ((other.y - self.y) ** 2) + ((other.z - self.z) ** 2))
+        return _math.sqrt(((other[0] - self.x) ** 2) + ((other[1] - self.y) ** 2) + ((other[2] - self.z) ** 2))
 
     def normalize(self) -> Vec3:
         """Return a normalized version of the vector.

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -408,9 +408,17 @@ class Vec3(_typing.NamedTuple):
 
     def __pow__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
         try:
-            return Vec3(self[0] ** other[0], self[1] ** other[1], self[2] ** other[2])
+            return Vec3(
+                self[0] ** other[0],  # type: ignore
+                self[1] ** other[1],  # type: ignore
+                self[2] ** other[2]   # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] ** other, self[1] ** other, self[2] ** other)
+            return Vec3(
+                 self[0] ** other,  # type: ignore
+                 self[1] ** other,  # type: ignore
+                 self[2] ** other   # type: ignore
+            )
 
     def __lt__(self, other: Vec3) -> bool:
         return self[0] ** 2 + self[1] ** 2 + self[2] ** 2 < other[0] ** 2 + other[1] ** 2 + other[2] ** 2

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -400,11 +400,19 @@ class Vec3(_typing.NamedTuple):
     def __trunc__(self) -> Vec3:
         return Vec3(_math.trunc(self[0]), _math.trunc(self[1]), _math.trunc(self[2]))
 
-    def __mod__(self, other: Vec3 | tuple[int, int, int] | float) -> Vec3:
+    def __mod__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
         try:
-            return Vec3(self[0] % other[0], self[1] % other[1], self[2] % other[2])
+            return Vec3(
+                self[0] % other[0],  # type: ignore
+                self[1] % other[1],  # type: ignore
+                self[2] % other[2]   # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] % other, self[1] % other, self[2] % other)
+            return Vec3(
+                 self[0] % other,  # type: ignore
+                 self[1] % other,  # type: ignore
+                 self[2] % other   # type: ignore
+            )
 
     def __pow__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -40,9 +40,15 @@ class Vec2(_typing.NamedTuple):
 
     def __add__(self, other: tuple[float, float] | float) -> Vec2:
         try:
-            return Vec2(self[0] + other[0], self[1] + other[1])
+            return Vec2(
+                self[0] + other[0],  # type: ignore
+                self[1] + other[1]   # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] + other, self[1] + other)
+            return Vec2(
+                self[0] + other,  # type: ignore
+                self[1] + other  # type: ignore
+            )
 
     def __radd__(self, other: tuple[float, float] | float) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -493,7 +493,7 @@ class Vec3(_typing.NamedTuple):
                 self[0] % other, self[1] % other, self[2] % other  # type: ignore
             )
 
-    def __pow__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
+    def __pow__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
                 self[0] ** other[0], self[1] ** other[1], self[2] ** other[2]  # type: ignore

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -72,9 +72,15 @@ class Vec2(_typing.NamedTuple):
 
     def __rmul__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
-            return Vec2(self[0] * scalar[0], self[1] * scalar[1])
+            return Vec2(
+                self[0] * scalar[0],  # type: ignore
+                self[1] * scalar[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] * scalar, self[1] * scalar)
+            return Vec2(
+                self[0] * scalar,  # type: ignore
+                self[1] * scalar  # type: ignore
+            )
 
     def __truediv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -334,7 +334,7 @@ class Vec2(_typing.NamedTuple):
             clamp(self[0], min_x, max_x), clamp(self[1], min_y, max_y),  # type: ignore
         )
 
-    def dot(self, other: Vec2 | tuple[float, float]) -> float:
+    def dot(self, other: tuple[float, float]) -> float:
         """Calculate the dot product of this vector and another 2D vector."""
         return self[0] * other[0] + self[1] * other[1]
 

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -363,9 +363,9 @@ class Vec2(_typing.NamedTuple):
     def __getattr__(self, attrs: str) -> Vec2 | Vec3 | Vec4:
         try:
             # Allow swizzled getting of attrs
-            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}.get(len(attrs))
+            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}[len(attrs)]
             return vec_class(*(self['xy'.index(c)] for c in attrs))
-        except (ValueError, TypeError) as err:
+        except (ValueError, KeyError, TypeError) as err:
             msg = f"'Vec2' has no attribute: '{attrs}'."
             raise AttributeError(msg) from err
 

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -196,7 +196,7 @@ class Vec2(_typing.NamedTuple):
                 self[1] ** other  # type: ignore
             )
 
-    def __lt__(self, other: float | tuple[float, float]) -> bool:
+    def __lt__(self, other: tuple[float, float]) -> bool:
         return self[0] ** 2 + self[0] ** 2 < other[0] ** 2 + other[1] ** 2
 
     @staticmethod

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -566,7 +566,7 @@ class Vec3(_typing.NamedTuple):
                  self[2] ** other   # type: ignore
             )
 
-    def __lt__(self, other: Vec3) -> bool:
+    def __lt__(self, other: tuple[float, float, float]) -> bool:
         return self[0] ** 2 + self[1] ** 2 + self[2] ** 2 < other[0] ** 2 + other[1] ** 2 + other[2] ** 2
 
     def length(self) -> float:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -334,11 +334,19 @@ class Vec3(_typing.NamedTuple):
                 return self
             raise err
 
-    def __sub__(self, other: Vec3 | tuple[int, int] | float) -> Vec3:
+    def __sub__(self, other: Vec3 | tuple[float, float] | float) -> Vec3:
         try:
-            return Vec3(self[0] - other[0], self[1] - other[1], self[2] - other[2])
+            return Vec3(
+                self[0] - other[0],  # type: ignore
+                self[1] - other[1],  # type: ignore
+                self[2] - other[2]  # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] - other, self[1] - other, self[2] - other)
+            return Vec3(
+                 self[0] - other,  # type: ignore
+                 self[1] - other,  # type: ignore
+                 self[2] - other  # type: ignore
+            )
 
     def __rsub__(self, other: Vec3 | tuple[int, int] | float) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -320,11 +320,19 @@ class Vec3(_typing.NamedTuple):
 
     __match_args__ = 'x', 'y', 'z'
 
-    def __add__(self, other: Vec3 | tuple[int, int] | float) -> Vec3:
+    def __add__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
-            return Vec3(self[0] + other[0], self[1] + other[1], self[2] + other[2])
+            return Vec3(
+                self[0] + other[0],  # type: ignore
+                self[1] + other[1],  # type: ignore
+                self[2] + other[2]  # type: ignore
+            )
         except TypeError:
-            return Vec3(self[0] + other, self[1] + other, self[2] + other)
+            return Vec3(
+                 self[0] + other,  # type: ignore
+                 self[1] + other,  # type: ignore
+                 self[2] + other  # type: ignore
+            )
 
     def __radd__(self, other: Vec3 | float) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -377,7 +377,7 @@ class Vec3(_typing.NamedTuple):
                 self[0] + other, self[1] + other, self[2] + other  # type: ignore
             )
 
-    def __radd__(self, other: Vec3 | float) -> Vec3:
+    def __radd__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return self.__add__(_typing.cast(Vec3, other))
         except TypeError as err:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -253,13 +253,19 @@ class Vec2(_typing.NamedTuple):
         """
         return Vec2(0.0 if self[0] < edge[0] else 1.0, 0.0 if self[1] < edge[1] else 1.0)
 
-    def reflect(self, vector: Vec2) -> Vec2:
+    def reflect(self, vector: tuple[float, float]) -> Vec2:
         """Create a new Vec2 reflected (ricochet) from the given normalized vector.
 
         Args:
-            vector: A normalized vector.
+            vector: A normalized Vec2 or Vec2-like tuple.
         """
-        return self - vector * 2 * vector.dot(self)
+        #Less unrolled equivalent of code below:
+        # return self - vector * 2 * vector.dot(self)
+        twice_dot_value = self.dot(vector) * 2
+        return Vec2(
+            self[0] - twice_dot_value * vector[0],
+            self[1] - twice_dot_value * vector[1]
+        )
 
     def rotate(self, angle: float) -> Vec2:
         """Create a new vector rotated by the angle. The length remains unchanged.

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -342,9 +342,17 @@ class Vec3(_typing.NamedTuple):
 
     def __rsub__(self, other: Vec3 | tuple[int, int] | float) -> Vec3:
         try:
-            return Vec3(other[0] - self[0], other[1] - self[1], other[2] - self[2])
+            return Vec3(
+                self[0] - other[0],  # type: ignore
+                self[1] - other[1],  # type: ignore
+                self[2] - other[2]  # type: ignore
+            )
         except TypeError:
-            return Vec3(other - self[0], other - self[1], other - self[2])
+            return Vec3(
+                 self[0] - other,  # type: ignore
+                 self[1] - other,  # type: ignore
+                 self[2] - other  # type: ignore
+            )
 
     def __mul__(self, scalar: float | tuple[float, float, float]) -> Vec3:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -655,7 +655,7 @@ class Vec4(_typing.NamedTuple):
 
     __match_args__ = 'x', 'y', 'z', 'w'
 
-    def __add__(self, other: Vec4 | tuple[float, float] | float) -> Vec4:
+    def __add__(self, other: tuple[float, float, float, float] | float) -> Vec4:
         try:
             return Vec4(
                 other[0] + self[0], other[1] + self[1], other[2] + self[2], other[3] + self[3]  # type: ignore

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -376,11 +376,19 @@ class Vec3(_typing.NamedTuple):
         except TypeError:
             return Vec3(self[0] // scalar, self[1] // scalar, self[2] // scalar)
 
-    def __rfloordiv__(self, scalar: float | tuple[float, float, float]) -> Vec3:
+    def __rfloordiv__(self, other: float | tuple[float, float, float]) -> Vec3:
         try:
-            return Vec3(scalar[0] // self[0], scalar[1] // self[1], scalar[2] // self[2])
+            return Vec3(
+                self[0] // other[0],  # type: ignore
+                self[1] // other[1],  # type: ignore
+                self[2] // other[2]   # type: ignore
+            )
         except TypeError:
-            return Vec3(scalar // self[0], scalar // self[1], scalar // self[2])
+            return Vec3(
+                 self[0] // other,  # type: ignore
+                 self[1] // other,  # type: ignore
+                 self[2] // other   # type: ignore
+            )
 
     def __abs__(self) -> Vec3:
         return Vec3(abs(self[0]), abs(self[1]), abs(self[2]))

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1,15 +1,4 @@
-# mypy: ignore-errors
-# Even when the notoriously picky pyright reports 0 errors, mypy will
-# incorrectly report plenty because:
-# 1. This file contains typing.NamedTuple subclasses
-# 2. The mypy stance on NamedTuple is "Duplicate of #5613, still low
-#    priority, better use dataclasses, as suggested above.", per
-#    https://github.com/python/mypy/issues/5944#issuecomment-441285456
 """Matrix and Vector math.
-
-.. WARNING! DO NOT TRY TO MAKE THIS FILE "PRETTIER"!
-..
-.. See the bottom of the docstring to learn why & what to do instead.
 
 This module provides Vector and Matrix objects, including Vec2, Vec3,
 Vec4, Mat3, and Mat4. Most common matrix and vector operations are
@@ -21,21 +10,13 @@ Matrices behave just like they do in GLSL: they are specified in column-major
 order and multiply on the left of vectors, which are treated as columns.
 
 All objects are immutable and hashable.
-..
-.. The code in this file is ugly and breaks the usual rules for a reason.
-.. Also, this portion of the docstring is a Sphinx comment which doesn't
-.. render in the web documentation.
-.. The code in this file has to have decent performance because:
-.. 1. It's core math code for the library
-.. 2. It has to achieve good developer ergonomics
-.. 3. It has to all of this with decent performance
-.. Unusual style is the price we pay to get all of that because:
-.. 1. pyglet is the world's only pure Python, 0-dependency GL binding
-.. 2. we can't rely on compute shaders to speed things up
-.. Compute shaders only became a core OpenGL in 2017 with v4.6. Plenty
-.. hardware still lacks full support for them, so we claw back every
-.. scrap of performance we can in other ways.
 """
+# WARNING! DO NOT TRY TO MAKE THIS FILE "PRETTIER"
+#
+# The unusual code style in this module is an intentional sacrifice:
+# * It allows decent performance despite being written in pure Python
+# * It ensures good developer experience outside pyglet.math, especially
+#   on systems without access to compute shaders
 from __future__ import annotations
 
 import math as _math

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -78,9 +78,15 @@ class Vec2(_typing.NamedTuple):
 
     def __truediv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
-            return Vec2(self[0] / scalar[0], self[1] / scalar[1])
+            return Vec2(
+                self[0] / scalar[0],  # type: ignore
+                self[1] / scalar[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(self[0] / scalar, self[1] / scalar)
+            return Vec2(
+                self[0] / scalar,  # type: ignore
+                self[1] / scalar  # type: ignore
+            )
 
     def __rtruediv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -692,9 +692,9 @@ class Vec3(_typing.NamedTuple):
     def __getattr__(self, attrs: str) -> Vec2 | Vec3 | Vec4:
         try:
             # Allow swizzled getting of attrs
-            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}.get(len(attrs))
+            vec_class = {2: Vec2, 3: Vec3, 4: Vec4}[len(attrs)]
             return vec_class(*(self['xyz'.index(c)] for c in attrs))
-        except (ValueError, TypeError) as err:
+        except (ValueError, KeyError, TypeError) as err:
             msg = f"'Vec3' has no attribute: '{attrs}'."
             raise AttributeError(msg) from err
 

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -817,17 +817,17 @@ class Vec4(_typing.NamedTuple):
     def __rtruediv__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:
         try:
             return Vec4(
-                self[0] / scalar[0],  # type: ignore
-                self[1] / scalar[1],  # type: ignore
-                self[2] / scalar[2],  # type: ignore
-                self[3] / scalar[3]  # type: ignore
+                scalar[0] / self[0],  # type: ignore
+                scalar[1] / self[1],  # type: ignore
+                scalar[2] / self[2],  # type: ignore
+                scalar[3] / self[3]   # type: ignore
             )
         except TypeError:
             return Vec4(
-                self[0] / scalar,  # type: ignore
-                self[1] / scalar,  # type: ignore
-                self[2] / scalar,  # type: ignore
-                self[3] / scalar  # type: ignore
+               scalar / self[0],  # type: ignore
+               scalar / self[1],  # type: ignore
+               scalar / self[2],  # type: ignore
+               scalar / self[3]   # type: ignore
             )
 
     def __floordiv__(self, scalar: float | tuple[float, float, float, float]) -> Vec4:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1,5 +1,9 @@
 """Matrix and Vector math.
 
+.. WARNING! DO NOT TRY TO MAKE THIS FILE "PRETTIER"!
+..
+.. See the bottom of the docstring to learn why & what to do instead.
+
 This module provides Vector and Matrix objects, including Vec2, Vec3,
 Vec4, Mat3, and Mat4. Most common matrix and vector operations are
 supported. Helper methods are included for rotating, scaling, and
@@ -10,6 +14,20 @@ Matrices behave just like they do in GLSL: they are specified in column-major
 order and multiply on the left of vectors, which are treated as columns.
 
 All objects are immutable and hashable.
+..
+.. The code in this file is ugly and breaks the usual rules for a reason.
+.. Also, this portion of the docstring is a Sphinx comment which doesn't
+.. render in the web documentation.
+.. The code in this file has to have decent performance because:
+.. 1. It's core math code for the library
+.. 2. It has to achieve good developer ergonomics
+.. 3. It has to all of this with decent performance
+.. Unusual style is the price we pay to get all of that because:
+.. 1. pyglet is the world's only pure Python, 0-dependency GL binding
+.. 2. we can't rely on compute shaders to speed things up
+.. Compute shaders only became a core OpenGL in 2017 with v4.6. Plenty
+.. hardware still lacks full support for them, so we claw back every
+.. scrap of performance we can in other ways.
 """
 from __future__ import annotations
 

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -483,7 +483,7 @@ class Vec3(_typing.NamedTuple):
     def __trunc__(self) -> Vec3:
         return Vec3(_math.trunc(self[0]), _math.trunc(self[1]), _math.trunc(self[2]))
 
-    def __mod__(self, other: Vec3 | tuple[float, float, float] | float) -> Vec3:
+    def __mod__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
                 self[0] % other[0], self[1] % other[1], self[2] % other[2]  # type: ignore

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -84,9 +84,15 @@ class Vec2(_typing.NamedTuple):
 
     def __rtruediv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
-            return Vec2(scalar[0] / self[0], scalar[1] / self[1])
+            return Vec2(
+                scalar[0] / self[0],  # type: ignore
+                scalar[1] / self[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(scalar / self[0], scalar / self[1])
+            return Vec2(
+                scalar / self[0],  # type: ignore
+                scalar / self[1]  # type: ignore
+            )
 
     def __floordiv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -96,9 +96,15 @@ class Vec2(_typing.NamedTuple):
 
     def __rfloordiv__(self, scalar: float | tuple[float, float]) -> Vec2:
         try:
-            return Vec2(scalar[0] // self[0], scalar[1] // self[1])
+            return Vec2(
+                scalar[0] // self[0],  # type: ignore
+                scalar[1] // self[1]  # type: ignore
+            )
         except TypeError:
-            return Vec2(scalar // self[0], scalar // self[1])
+            return Vec2(
+                scalar // self[0],  # type: ignore
+                scalar // self[1]  # type: ignore
+            )
 
     def __abs__(self) -> Vec2:
         return Vec2(abs(self[0]), abs(self[1]))

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -348,7 +348,7 @@ class Vec3(_typing.NamedTuple):
                  self[2] - other  # type: ignore
             )
 
-    def __rsub__(self, other: Vec3 | tuple[int, int] | float) -> Vec3:
+    def __rsub__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
                 self[0] - other[0],  # type: ignore

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -359,15 +359,15 @@ class Vec3(_typing.NamedTuple):
     def __rsub__(self, other: tuple[float, float, float] | float) -> Vec3:
         try:
             return Vec3(
-                self[0] - other[0],  # type: ignore
-                self[1] - other[1],  # type: ignore
-                self[2] - other[2]  # type: ignore
+                other[0] - self[0], # type: ignore
+                other[1] - self[1], # type: ignore
+                other[2] - self[2] # type: ignore
             )
         except TypeError:
             return Vec3(
-                 self[0] - other,  # type: ignore
-                 self[1] - other,  # type: ignore
-                 self[2] - other  # type: ignore
+                 other - self[0],  # type: ignore
+                 other - self[1],  # type: ignore
+                 other - self[2]  # type: ignore
             )
 
     def __mul__(self, scalar: float | tuple[float, float, float]) -> Vec3:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,17 @@ requires-python = ">=3.8"
 [project.urls]
 Home = "https://pyglet.org"
 
+[[tool.mypy.overrides]]
+# mypy incorrectly reports issues everywhere in pyglet.math because:
+# 1. pyglet.math is almost entirely typing.NamedTuple subclasses
+# 2. The mypy project has the following long-standing stance on
+#    supporting collections.namedtuple and typing.NamedTuple:
+#    "Duplicate of #5613, still low priority, better use dataclasses,
+#    as suggested above."
+#    https://github.com/python/mypy/issues/5944#issuecomment-441285456
+module = "pyglet.math"
+ignore_errors = true
+
 [tool.ruff]
 line-length = 120
 indent-width = 4

--- a/tests/unit/math/test_vec2.py
+++ b/tests/unit/math/test_vec2.py
@@ -45,6 +45,10 @@ def test_swizzle():
     assert v.yx == (2, 1)
     assert v.xx == (1, 1)
     assert v.yy == (2, 2)
+    assert v.xyxy == (1, 2, 1, 2)
+
+    with pytest.raises(AttributeError):
+        v.xxxxx
 
 
 def test_mutability():

--- a/tests/unit/math/test_vec2.py
+++ b/tests/unit/math/test_vec2.py
@@ -108,6 +108,29 @@ def test_add():
     assert v == Vec2(4, 6)
 
 
+def test_radd():
+    # These should be distinct and  unreachable through
+    # simple mis-addition of the mirrored values below.
+    goal_x = -1901.0
+    goal_y = 7919.0
+    pairs = [
+        # A few (+even, -odd) Vec2s + tuples
+        Vec2( -8.0,     7.0),
+        ( -6.0,     5.0),
+        Vec2( -4.0,     3.0),
+        ( -2.0,     1.0),
+
+        Vec2(goal_x, goal_y),
+
+        # Negatives of the block above the marker line
+        (  2.0, -    1.0),
+        Vec2(  4.0, -    3.0),
+        (  6.0, -    5.0),
+        Vec2(  8.0, -    7.0),
+    ]
+    assert sum(pairs) == Vec2(goal_x, goal_y)
+
+
 def test_sub():
     assert Vec2(1, 2) - Vec2(3, 4) == Vec2(-2, -2)
 

--- a/tests/unit/math/test_vec2.py
+++ b/tests/unit/math/test_vec2.py
@@ -60,6 +60,18 @@ def test_mutability():
     with pytest.raises(TypeError):
         v[0] = 1  # __setitem__ is not supported
 
+    # Swizzle is an output-only operation
+    with pytest.raises(AttributeError):
+        v.xy = (1, 2)
+    with pytest.raises(AttributeError):
+        v.yx = (2, 1)
+    with pytest.raises(AttributeError):
+        v.xx = (1, 1)
+    with pytest.raises(AttributeError):
+        v.yy = (2, 2)
+    with pytest.raises(AttributeError):
+        v.xyxy = (1, 2, 1, 2)
+
 
 def test_len():
     """Len of the collection is always 2."""

--- a/tests/unit/math/test_vec2.py
+++ b/tests/unit/math/test_vec2.py
@@ -357,6 +357,10 @@ def test_clamp():
     assert Vec2(-10, 10).clamp(Vec2(-20, -20), Vec2(20, 20)) == Vec2(-10, 10)
     assert Vec2(-10, 10).clamp(Vec2(-5, 5), Vec2(5, 5)) == Vec2(-5, 5)
 
+    # Revert if necessary for perf
+    assert Vec2(-1, 50).clamp(Vec2(0, 0), 10) == Vec2(0, 10)
+    assert Vec2(-1,  50).clamp(0, Vec2(10, 10)) == Vec2(0, 10)
+
 
 def test_dot():
     assert Vec2(1, 0).dot(Vec2(1, 0)) == 1  # same direction

--- a/tests/unit/math/test_vec3.py
+++ b/tests/unit/math/test_vec3.py
@@ -57,6 +57,22 @@ def test_mutability():
     with pytest.raises(TypeError):
         v[0] = 1  # __setitem__ is not supported
 
+    # Swizzle is an output-only operation
+    with pytest.raises(AttributeError):
+        v.xyz == (1, 2, 3)
+    with pytest.raises(AttributeError):
+        v.yxz == (2, 1, 3)
+    with pytest.raises(AttributeError):
+        v.yzx == (2, 3, 1)
+    with pytest.raises(AttributeError):
+        v.zyx == (3, 2, 1)
+    with pytest.raises(AttributeError):
+        v.xy == (1, 2)
+    with pytest.raises(AttributeError):
+        v.xxxx == (1, 1, 1, 1)
+    with pytest.raises(AttributeError):
+        v.xyzx == (1, 2, 3, 1)
+
 
 def test_len():
     """Len of the collection is always 2."""

--- a/tests/unit/math/test_vec3.py
+++ b/tests/unit/math/test_vec3.py
@@ -40,6 +40,10 @@ def test_swizzle():
     assert v.zyx == (3, 2, 1)
     assert v.xy == (1, 2)
     assert v.xxxx == (1, 1, 1, 1)
+    assert v.xyzx == (1, 2, 3, 1)
+
+    with pytest.raises(AttributeError):
+        v.xxxxx
 
 
 def test_mutability():

--- a/tests/unit/math/test_vec3.py
+++ b/tests/unit/math/test_vec3.py
@@ -328,8 +328,7 @@ def test_clamp():
 
     # Revert if necessary for perf
     assert Vec3(-1, 50, 50).clamp(Vec3(0, 0, 0), 10) == Vec3(0, 10, 10)
-    assert Vec4(-1, -1, 50).clamp(0, Vec3(10, 10, 10)) == Vec3(0, 0, 10)
-
+    assert Vec3(-1, -1, 50).clamp(0, Vec3(10, 10, 10)) == Vec3(0, 0, 10)
 
 
 def test_index():

--- a/tests/unit/math/test_vec3.py
+++ b/tests/unit/math/test_vec3.py
@@ -59,19 +59,19 @@ def test_mutability():
 
     # Swizzle is an output-only operation
     with pytest.raises(AttributeError):
-        v.xyz == (1, 2, 3)
+        v.xyz = (1, 2, 3)
     with pytest.raises(AttributeError):
-        v.yxz == (2, 1, 3)
+        v.yxz = (2, 1, 3)
     with pytest.raises(AttributeError):
-        v.yzx == (2, 3, 1)
+        v.yzx = (2, 3, 1)
     with pytest.raises(AttributeError):
-        v.zyx == (3, 2, 1)
+        v.zyx = (3, 2, 1)
     with pytest.raises(AttributeError):
-        v.xy == (1, 2)
+        v.xy = (1, 2)
     with pytest.raises(AttributeError):
-        v.xxxx == (1, 1, 1, 1)
+        v.xxxx = (1, 1, 1, 1)
     with pytest.raises(AttributeError):
-        v.xyzx == (1, 2, 3, 1)
+        v.xyzx = (1, 2, 3, 1)
 
 
 def test_len():

--- a/tests/unit/math/test_vec3.py
+++ b/tests/unit/math/test_vec3.py
@@ -109,6 +109,27 @@ def test_add():
     assert v == Vec3(2, 4, 6)
 
 
+def test_radd():
+    # The goals should be distinct and unreachable by
+    # simple mis-addition of the values below
+    goal_x = -6709.0
+    goal_y = 359.0
+    goal_z = 7829.0
+    seq = [
+        Vec3(3.0, 0.0, 0.0),
+        (0.0, 5.0, 0.0),
+        Vec3(0.0, 0.0, 7.0),
+
+        Vec3(goal_x, goal_y, goal_z),
+
+        # Opposites of the block above
+        (-3.0, 0.0, 0.0),
+        Vec3(0.0, -5.0, 0.0),
+        (0.0, 0.0, -7.0)
+    ]
+    assert sum(seq) == Vec3(goal_x, goal_y, goal_z)
+
+
 def test_sub():
     assert Vec3(1, 2, 3) - Vec3(3, 4, 6) == Vec3(-2, -2, -3)
 

--- a/tests/unit/math/test_vec4.py
+++ b/tests/unit/math/test_vec4.py
@@ -62,6 +62,24 @@ def test_mutability():
     with pytest.raises(TypeError):
         v[0] = 1  # __setitem__ is not supported
 
+    # Swizzle is an output-only operation
+    with pytest.raises(AttributeError):
+        v.xyzw = (1, 2, 3, 4)
+    with pytest.raises(AttributeError):
+        v.yxzw = (2, 1, 3, 4)
+    with pytest.raises(AttributeError):
+        v.yzxw = (2, 3, 1, 4)
+    with pytest.raises(AttributeError):
+        v.zyxw = (3, 2, 1, 4)
+    with pytest.raises(AttributeError):
+        v.xy = (1, 2)
+    with pytest.raises(AttributeError):
+        v.xyz = (1, 2, 3)
+    with pytest.raises(AttributeError):
+        v.wzyx = (4, 3, 2, 1)
+    with pytest.raises(AttributeError):
+        v.xxxx = (1, 1, 1, 1)
+
 
 def test_len():
     """Len of the collection is always 2."""

--- a/tests/unit/math/test_vec4.py
+++ b/tests/unit/math/test_vec4.py
@@ -49,8 +49,6 @@ def test_swizzle():
         v.xxxxx
 
 
-
-
 def test_mutability():
     v = Vec4(1, 2, 3, 4)
     with pytest.raises(AttributeError):

--- a/tests/unit/math/test_vec4.py
+++ b/tests/unit/math/test_vec4.py
@@ -45,6 +45,11 @@ def test_swizzle():
     assert v.wzyx == (4, 3, 2, 1)
     assert v.xxxx == (1, 1, 1, 1)
 
+    with pytest.raises(AttributeError):
+        v.xxxxx
+
+
+
 
 def test_mutability():
     v = Vec4(1, 2, 3, 4)

--- a/tests/unit/math/test_vec4.py
+++ b/tests/unit/math/test_vec4.py
@@ -116,6 +116,32 @@ def test_add():
     assert v == Vec4(2, 4, 6, 8)
 
 
+def test_radd():
+    # The goals should be distinct and unreachable by
+    # simple mis-addition of the values below
+    goal_x = -3251.0
+    goal_y = 593.0
+    goal_z = 3847.0
+    goal_w = 7621.0
+    seq = [
+        Vec4(3.0, 0.0, 0.0, 0.0),
+        (0.0, 5.0, 0.0, 0.0),
+        Vec4(0.0, 0.0, 7.0, 0.0),
+        (0.0, 0.0, 0.0, 9.0),
+
+        Vec4(goal_x, goal_y, goal_z, goal_w),
+
+        # Opposites of the block above
+        (0.0, 0.0, 0.0, -9.0),
+        Vec4(-3.0, 0.0, 0.0, 0.0),
+        (0.0, -5.0, 0.0, 0.0),
+        Vec4(0.0, 0.0, -7.0, 0.0)
+    ]
+    assert sum(seq) == Vec4(goal_x, goal_y, goal_z, goal_w)
+
+
+
+
 def test_sub():
     assert Vec4(1, 2, 3, 4) - Vec4(5, 6, 7, 8) == Vec4(-4, -4, -4, -4)
 


### PR DESCRIPTION
**TL;DR:** This carefully makes the issues go away while passing all unit tests

### Changes

#### *Handle `Vec*.clamp` issues

>[!NOTE]
> We can revert some of this if it has perf impacts.

1. Use conditional overload (`if _typing.TYPE_CHECKING`) to mitigate perf hit from `@overload`
2. Add support for mixed `Vec*.clamp` arg pairs:
  *  `(min: float, max: tuple[float, ...])`
  *  `(min: tuple[float, ...], max: float)`
3. Add tests for mixed clamp arg types 

#### Fix Swizzle's `None` issues
1. Use bracket access instead of `.get()` to:
   * eliminate a theoretically possible `None` return issue type checkers flag
   * piggy-back on the existing try/except block by adding `KeyError`
2. Expand swizzle tests a little
#### Add doc on why the file's ugly
1. Use Sphinx comments to avoid polluting the web doc
2. Explain that it's ugly to gain:
  * Good DX
  * Decent performance
  * Avoid binary or external dependencies

#### Fix internal type ambiguity

* Massive use of `# type: ignore` since it's handled by exceptions and tests

### Future work

- [ ] Plenty of optimizations
   - [ ] Low-hanging optimizations
   - [ ] Cross-ISA and Py version benchmarking to get the definitive word on `NamedTuple` / etc
- [ ] Micro-optimizations of various sorts comparing inlined dict and other items
- [ ] Feature improvements?