### PR TITLE
Bug fixes

### DIFF
--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -232,7 +232,7 @@ class VertexList:
                                                       f"keyword argument not found.")
                     attribute.set_region(attribute.buffer, instance_id - 1, 1, kwargs[attribute.name])
 
-        return self.domain._vertexinstance_class(self, instance_id)  # noqa: SLF001
+        return self.domain._vertexinstance_class(self, instance_id, start)  # noqa: SLF001
 
     def delete_instance(self, instance: VertexInstance) -> None:
         assert self.instanced
@@ -242,7 +242,7 @@ class VertexList:
 
         self.domain._instances -= 1  # noqa: SLF001
 
-        self.domain.instance_allocator.dealloc(instance.id, 1)
+        self.domain.instance_allocator.dealloc(instance.start, 3)
 
 
 class IndexedVertexList(VertexList):
@@ -339,10 +339,12 @@ class IndexedVertexList(VertexList):
 
 class VertexInstance:
     id: int
+    start: int
     _vertex_list: VertexList | IndexedVertexList
 
-    def __init__(self, vertex_list: VertexList | IndexedVertexList, instance_id: int) -> None:
+    def __init__(self, vertex_list: VertexList | IndexedVertexList, instance_id: int, start: int) -> None:
         self.id = instance_id
+        self.start = start
         self._vertex_list = vertex_list
 
     @property
@@ -351,6 +353,7 @@ class VertexInstance:
 
     def delete(self) -> None:
         self._vertex_list.delete_instance(self)
+        self._vertex_list = None
 
 
 class VertexDomain:

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -97,8 +97,7 @@ from __future__ import annotations
 
 import re
 import weakref
-
-from ctypes import c_int, c_uint, c_ubyte, sizeof, byref
+from ctypes import byref, c_int, c_ubyte, c_uint, sizeof
 
 import pyglet
 from pyglet.gl import *
@@ -1568,7 +1567,7 @@ class Texture3D(Texture, UniformTextureSequence):
         glTexImage3D(texture.target, texture.level,
                      internalformat,
                      texture.width, texture.height, texture.images, 0,
-                     GL_ALPHA, GL_UNSIGNED_BYTE,
+                     internalformat, GL_UNSIGNED_BYTE,
                      blank)
 
         items = []


### PR DESCRIPTION
A couple bug fixes:
1) Trying to pop an instance can cause an issue with the deallocator. 

2) `Texture3D.create_for_images` uses `GL_ALPHA` , when it's not supported and may cause test errors. Use `internalformat` for now.