### PR TITLE
Add separate blit shader to resolve blending issue.

### DIFF
--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1359,8 +1359,6 @@ class Texture(AbstractImage):
             glPixelStorei(GL_PACK_ALIGNMENT, 1)
             glGetTexImage(self.target, self.level, gl_format, GL_UNSIGNED_BYTE, buf)
 
-        glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
-
         data = ImageData(self.width, self.height, fmt, buf)
         if self.images > 1:
             data = data.get_region(0, z * self.height, self.width, self.height)
@@ -1417,7 +1415,8 @@ class Texture(AbstractImage):
 
         glDrawElements(GL_TRIANGLES, len(indices), GL_UNSIGNED_BYTE, 0)
         glFlush()
-
+        glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
+        
         # Deactivate shader program:
         program.stop()
         # Discard everything after blitting:

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1359,6 +1359,8 @@ class Texture(AbstractImage):
             glPixelStorei(GL_PACK_ALIGNMENT, 1)
             glGetTexImage(self.target, self.level, gl_format, GL_UNSIGNED_BYTE, buf)
 
+        glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
+
         data = ImageData(self.width, self.height, fmt, buf)
         if self.images > 1:
             data = data.get_region(0, z * self.height, self.width, self.height)

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1415,7 +1415,6 @@ class Texture(AbstractImage):
 
         glDrawElements(GL_TRIANGLES, len(indices), GL_UNSIGNED_BYTE, 0)
         glFlush()
-        glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
         
         # Deactivate shader program:
         program.stop()

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1386,7 +1386,7 @@ class Texture(AbstractImage):
         glBindVertexArray(vao_id)
 
         # Activate shader program:
-        program = pyglet.graphics.get_default_shader()
+        program = pyglet.graphics.get_default_blit_shader()
         program.use()
         pos_attrs = program.attributes['position']
         tex_attrs = program.attributes['tex_coords']


### PR DESCRIPTION
The default shader has a colors attribute, but it's not used with blit. Some drivers don't interpret no data as 0, and disables blending. Created a new shader for just blitting without colors attribute. Existing default shader needs to keep colors as `program.vertex_list` requires colors and is used in examples.

Resolves #1169