### PR TITLE
Screen and Display bases

### DIFF
--- a/pyglet/display/__init__.py
+++ b/pyglet/display/__init__.py
@@ -36,7 +36,6 @@ if _is_pyglet_doc_run:
     from pyglet.display.base import Display, Screen, Canvas, ScreenMode
 else:
     from pyglet import compat_platform, options
-
     if options['headless']:
         from pyglet.display.headless import HeadlessDisplay as Display
         from pyglet.display.headless import HeadlessScreen as Screen

--- a/pyglet/display/__init__.py
+++ b/pyglet/display/__init__.py
@@ -37,15 +37,15 @@ if _is_pyglet_doc_run:
 else:
     from pyglet import compat_platform, options
 
-    if options["headless"]:
+    if options['headless']:
         from pyglet.display.headless import HeadlessDisplay as Display
         from pyglet.display.headless import HeadlessScreen as Screen
         from pyglet.display.headless import HeadlessCanvas as Canvas
-    elif compat_platform == "darwin":
+    elif compat_platform == 'darwin':
         from pyglet.display.cocoa import CocoaDisplay as Display
         from pyglet.display.cocoa import CocoaScreen as Screen
         from pyglet.display.cocoa import CocoaCanvas as Canvas
-    elif compat_platform in ("win32", "cygwin"):
+    elif compat_platform in ('win32', 'cygwin'):
         from pyglet.display.win32 import Win32Display as Display
         from pyglet.display.win32 import Win32Screen as Screen
         from pyglet.display.win32 import Win32Canvas as Canvas

--- a/pyglet/display/__init__.py
+++ b/pyglet/display/__init__.py
@@ -22,6 +22,8 @@ by the application; see the documentation for :class:`Screen`.
 .. versionadded:: 1.2
 """  # noqa: I002
 
+from __future__ import annotations
+
 import sys
 import weakref
 

--- a/pyglet/display/__init__.py
+++ b/pyglet/display/__init__.py
@@ -25,6 +25,8 @@ by the application; see the documentation for :class:`Screen`.
 import sys
 import weakref
 
+from pyglet.display.base import DisplayBase
+
 _is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
 
 
@@ -32,15 +34,16 @@ if _is_pyglet_doc_run:
     from pyglet.display.base import Display, Screen, Canvas, ScreenMode
 else:
     from pyglet import compat_platform, options
-    if options['headless']:
+
+    if options["headless"]:
         from pyglet.display.headless import HeadlessDisplay as Display
         from pyglet.display.headless import HeadlessScreen as Screen
         from pyglet.display.headless import HeadlessCanvas as Canvas
-    elif compat_platform == 'darwin':
+    elif compat_platform == "darwin":
         from pyglet.display.cocoa import CocoaDisplay as Display
         from pyglet.display.cocoa import CocoaScreen as Screen
         from pyglet.display.cocoa import CocoaCanvas as Canvas
-    elif compat_platform in ('win32', 'cygwin'):
+    elif compat_platform in ("win32", "cygwin"):
         from pyglet.display.win32 import Win32Display as Display
         from pyglet.display.win32 import Win32Screen as Screen
         from pyglet.display.win32 import Win32Canvas as Canvas
@@ -50,14 +53,14 @@ else:
         from pyglet.display.xlib import XlibCanvas as Canvas
 
 
-_displays: weakref.WeakSet = weakref.WeakSet()
+_displays: weakref.WeakSet[DisplayBase] = weakref.WeakSet()
 """Set of all open displays.  Instances of :class:`Display` are automatically
 added to this set upon construction.  The set uses weak references, so displays
 are removed from the set when they are no longer referenced.
 """
 
 
-def get_display() -> Display:
+def get_display() -> DisplayBase:
     """Get the default display device.
 
     If there is already a :class:`Display` connection, that display will be
@@ -72,5 +75,6 @@ def get_display() -> Display:
 
     # Otherwise, create a new display and return it.
     return Display()
+
 
 __all__ = ['Display', 'Screen', 'Canvas', 'ScreenMode', 'get_display']

--- a/pyglet/display/base.py
+++ b/pyglet/display/base.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from pyglet.window import BaseWindow
 
 
-class Display:
+class DisplayBase:
     """A display device supporting one or more screens."""
 
     name: str = None
@@ -21,30 +21,30 @@ class Display:
     x_screen: int = None
     """The X11 screen number of this display, if applicable."""
 
-    def __init__(self, name: str = None, x_screen: int = None) -> None:
+    def __init__(self, name: str | None = None, x_screen: int | None = None) -> None:
         """Create a display connection for the given name and screen.
 
         On X11, :attr:`name` is of the form ``"hostname:display"``, where the
-        default is usually ``":1"``.  On X11, :attr:`x_screen` gives the X 
-        screen number to use with this display.  A pyglet display can only be 
+        default is usually ``":1"``.  On X11, :attr:`x_screen` gives the X
+        screen number to use with this display.  A pyglet display can only be
         used with one X screen; open multiple display connections to access
-        multiple X screens.  
-        
+        multiple X screens.
+
         Note that TwinView, Xinerama, xrandr and other extensions present
         multiple monitors on a single X screen; this is usually the preferred
         mechanism for working with multiple monitors under X11 and allows each
         screen to be accessed through a single pyglet`~pyglet.display.Display`
 
-        On platforms other than X11, :attr:`name` and :attr:`x_screen` are 
+        On platforms other than X11, :attr:`name` and :attr:`x_screen` are
         ignored; there is only a single display device on these systems.
         """
         display._displays.add(self)
 
-    def get_screens(self) -> list[Screen]:
+    def get_screens(self) -> list[ScreenBase]:
         """Get the available screens.
 
         A typical multi-monitor workstation comprises one :class:`Display`
-        with multiple :class:`Screen` s.  This method returns a list of 
+        with multiple :class:`Screen` s.  This method returns a list of
         screens which can be enumerated to select one for full-screen display.
 
         For the purposes of creating an OpenGL config, the default screen
@@ -54,7 +54,7 @@ class Display:
         """
         raise NotImplementedError('abstract')
 
-    def get_default_screen(self) -> Screen:
+    def get_default_screen(self) -> ScreenBase:
         """Get the default (primary) screen as specified by the user's operating system
         preferences.
         """
@@ -71,7 +71,12 @@ class Display:
         return [win for win in app.windows if win.display is self]
 
 
-class Screen:
+# NOTE: Dynamically overridden to the platform specific class
+class Display(DisplayBase):
+    pass
+
+
+class ScreenBase:
     """A virtual monitor that supports fullscreen windows.
 
     Screens typically map onto a physical display such as a
@@ -218,19 +223,24 @@ class Screen:
         """
         raise NotImplementedError('abstract')
 
-    def get_dpi(self):
+    def get_dpi(self) -> int:
         """Get the DPI of the screen.
 
         :rtype: int
         """
         raise NotImplementedError('abstract')
 
-    def get_scale(self):
+    def get_scale(self) -> float:
         """Get the pixel scale ratio of the screen.
 
         :rtype: float
         """
         raise NotImplementedError('abstract')
+
+
+# NOTE: Dynamically overridden to the platform specific class
+class Screen(ScreenBase):
+    pass
 
 
 class ScreenMode:
@@ -257,7 +267,7 @@ class ScreenMode:
     rate: int = None
     """Screen refresh rate in Hz."""
 
-    def __init__(self, screen: Screen) -> None:
+    def __init__(self, screen: ScreenBase) -> None:
         self.screen = screen
 
     def __repr__(self) -> str:
@@ -273,6 +283,6 @@ class Canvas:
     .. versionadded:: 1.2
     """
 
-    def __init__(self, display: Display) -> None:
+    def __init__(self, display: DisplayBase) -> None:
         self.display = display
         """Display this canvas was created on."""

--- a/pyglet/display/base.py
+++ b/pyglet/display/base.py
@@ -25,17 +25,17 @@ class DisplayBase:
         """Create a display connection for the given name and screen.
 
         On X11, :attr:`name` is of the form ``"hostname:display"``, where the
-        default is usually ``":1"``.  On X11, :attr:`x_screen` gives the X
-        screen number to use with this display.  A pyglet display can only be
+        default is usually ``":1"``.  On X11, :attr:`x_screen` gives the X 
+        screen number to use with this display.  A pyglet display can only be 
         used with one X screen; open multiple display connections to access
-        multiple X screens.
+        multiple X screens.  
 
         Note that TwinView, Xinerama, xrandr and other extensions present
         multiple monitors on a single X screen; this is usually the preferred
         mechanism for working with multiple monitors under X11 and allows each
         screen to be accessed through a single pyglet`~pyglet.display.Display`
 
-        On platforms other than X11, :attr:`name` and :attr:`x_screen` are
+        On platforms other than X11, :attr:`name` and :attr:`x_screen` are 
         ignored; there is only a single display device on these systems.
         """
         display._displays.add(self)
@@ -44,7 +44,7 @@ class DisplayBase:
         """Get the available screens.
 
         A typical multi-monitor workstation comprises one :class:`Display`
-        with multiple :class:`Screen` s.  This method returns a list of
+        with multiple :class:`Screen` s.  This method returns a list of 
         screens which can be enumerated to select one for full-screen display.
 
         For the purposes of creating an OpenGL config, the default screen


### PR DESCRIPTION
Quick test making bases for `Screen` and `Display` so it's possible to do typing. The `Screen` and `Display` types are dynamically overridden by the platform specific types so it's impossible to do anything related to typing with those.

Accidentally whitespace trimmer on. Can revert that if needed.
