### PR TITLE
Missing caret import in text_input example

### DIFF
--- a/examples/text/text_input.py
+++ b/examples/text/text_input.py
@@ -5,6 +5,7 @@ mouse focus.
 """
 
 import pyglet
+import pyglet.text.caret
 import pyglet.text.layout
 
 


### PR DESCRIPTION
Running the example leads to
```py
AttributeError: module 'pyglet.text' has no attribute 'caret'
```