### PR TITLE
Fix paused animation frame index

### DIFF
--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -802,6 +802,15 @@ class Sprite(event.EventDispatcher):
 
     @frame_index.setter
     def frame_index(self, index: int) -> None:
+        """Set the current Animation frame.
+
+        Args:
+            index:
+                The desired frame index.
+
+        Updates the currently displayed frame of an animation immediately even if
+        the animation is paused.  If not an Animation, this has no effect.
+        """
         # Bound to available number of frames
         if self._animation is None:
             return


### PR DESCRIPTION
This addresses issue #906.  Now if you set the frame_index property for a sprite with an animation then it will update the displayed texture.