### PR TITLE
Cleanup and improvements to domains.

### DIFF
--- a/pyglet/__init__.pyi
+++ b/pyglet/__init__.pyi
@@ -1,6 +1,6 @@
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Any, ItemsView, Sequence
 
 from . import app as app
 from . import canvas as canvas
@@ -63,5 +63,14 @@ class Options:
     com_mta: bool
     osx_alt_loop: bool
     shader_bind_management: bool
+
+    def get(self, item: str, default: Any = None) -> Any:
+        ...
+
+    def items(self) -> ItemsView[str, Any]:
+        ...
+
+    def __getitem__(self, item: str) -> Any:
+        ...
 
 options: Options

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -1414,8 +1414,6 @@ class ShaderProgram:
                 Using a Batch is strongly recommended.
             group:
                 Group to add the VertexList to, or ``None`` if no group is required.
-            strict:
-                Enforces that the attributes of the vertex list matches those found in the shader.
             data:
                 Attribute formats and initial data for the vertex list.
         """

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -1336,15 +1336,15 @@ class ShaderProgram:
                     msg = (f"The attribute `{name}` was not found in the Shader Program.\n"
                            f"Please check the spelling, or it may have been optimized out by the OpenGL driver.\n"
                            f"Valid names: {list(attributes)}")
-                    print(msg)
+                    warnings.warn(msg)
                 continue
 
         if _debug_gl_shaders:
-            if missing_data := [key for key in data if key not in attributes]:
+            if missing_data := [key for key in attributes if key not in data]:
                 msg = (
                     f"No data was supplied for the following found attributes: `{missing_data}`.\n"
                 )
-                print(msg)
+                warnings.warn(msg)
 
         batch = batch or pyglet.graphics.get_default_batch()
         group = group or pyglet.graphics.ShaderGroup(program=self)

--- a/pyglet/model/__init__.py
+++ b/pyglet/model/__init__.py
@@ -50,20 +50,19 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pyglet
-
-from pyglet import gl
-from pyglet import graphics
+from pyglet import gl, graphics
 from pyglet.math import Mat4
 
-from .codecs import registry as _codec_registry
 from .codecs import add_default_codecs as _add_default_codecs
+from .codecs import registry as _codec_registry
 
 if TYPE_CHECKING:
     from typing import BinaryIO, Iterable
-    from pyglet.image import Texture
+
     from pyglet.graphics import Batch, Group
     from pyglet.graphics.shader import ShaderProgram
     from pyglet.graphics.vertexdomain import VertexList
+    from pyglet.image import Texture
     from pyglet.model.codecs import ModelDecoder
 
 
@@ -148,6 +147,7 @@ class Model:
             batch = graphics.Batch()
 
         for group, vlist in zip(self.groups, self.vertex_lists):
+            # TODO: This should have a program to migrate to?
             self._batch.migrate(vlist, gl.GL_TRIANGLES, group, batch)
 
         self._batch = batch

--- a/pyglet/model/__init__.py
+++ b/pyglet/model/__init__.py
@@ -147,7 +147,6 @@ class Model:
             batch = graphics.Batch()
 
         for group, vlist in zip(self.groups, self.vertex_lists):
-            # TODO: This should have a program to migrate to?
             self._batch.migrate(vlist, gl.GL_TRIANGLES, group, batch)
 
         self._batch = batch

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -444,11 +444,14 @@ class ShapeBase(ABC):
         self._program = program
         self._group = self.get_shape_group()
 
-        if self._batch is not None:
-            self._batch.migrate(self._vertex_list, self._draw_mode, self._group, self._batch)
-        else:
-            self._vertex_list.delete()
-            self._create_vertex_list()
+        if (self._batch and
+                self._batch.update_shader(self._vertex_list, GL_TRIANGLES, self._group, program)):
+            # Exit early if changing domain is not needed.
+            return
+
+        # Recreate vertex list.
+        self._vertex_list.delete()
+        self._create_vertex_list()
 
     @property
     def rotation(self) -> float:

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -410,7 +410,15 @@ class Sprite(event.EventDispatcher):
             return
         self._program = program
         self._group = self.get_sprite_group()
-        self._batch.migrate(self._vertex_list, GL_TRIANGLES, self._group, self._batch)
+
+        if (self._batch and
+                self._batch.update_shader(self._vertex_list, GL_TRIANGLES, self._group, program)):
+            # Exit early if changing domain is not needed.
+            return
+
+        # Recreate vertex list.
+        self._vertex_list.delete()
+        self._create_vertex_list()
 
     @property
     def batch(self) -> Batch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,4 @@ inline-quotes = 'single'
     "ERA001",
     "F405",
 ]
+"tests/*" = ["I", "E", "F", "D", "B", "W", "S", "ANN", "ARG"]

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -3,7 +3,6 @@ import sys
 
 import pytest
 import pyglet
-from pyglet.gl import gl_info
 
 
 # Platform identifiers
@@ -50,8 +49,10 @@ def require_gl_extension(extension):
 
     :param str extension: Name of the extension required.
     """
+
+    from pyglet.gl import gl_info
     return pytest.mark.skipif(not gl_info.have_extension(extension),
-                              reason='Tests requires GL extension {0}'.format(extension))
+                              reason=f'Tests requires GL extension {extension}')
 
 
 def require_python_version(version):
@@ -61,7 +62,7 @@ def require_python_version(version):
     :param tuple version: The major, minor Python version as a tuple.
     """
     return pytest.mark.skipif(sys.version_info < version,
-                              reason="Test require at least Python version {0}".format(version))
+                              reason=f"Test require at least Python version {version}")
 
 
 def skip_if_continuous_integration():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,18 +5,16 @@ def pytest_addoption(parser):
     parser.addoption('--non-interactive',
                      action='store_true',
                      help='[Interactive tests only] Do not use interactive prompts. '
-                          'Skip tests that cannot validate or run without.'
+                          'Skip tests that cannot validate or run without.',
                      )
     parser.addoption('--sanity',
                      action='store_true',
                      help='[Interactive tests only] Do not use interactive prompts. '
-                          'Only skips tests that cannot finish without user intervention.'
+                          'Only skips tests that cannot finish without user intervention.',
                      )
 
 
 # Import shared fixtures
 from .base.data import test_data
-from .base.event_loop import event_loop
-from .base.interactive import interactive
 from .base.performance import performance
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,1 @@
+from ..base.event_loop import event_loop  # noqa: TID252

--- a/tests/integration/test_integrations.py
+++ b/tests/integration/test_integrations.py
@@ -1,0 +1,2 @@
+# Don't delete.
+# This file allows some IDE's to run integration as a single test if needed.

--- a/tests/unit/shader/conftest.py
+++ b/tests/unit/shader/conftest.py
@@ -1,0 +1,6 @@
+from pytest import fixture
+
+@fixture(autouse=True)
+def monkeypatch_default_graphics_shader(monkeypatch, get_dummy_shader_program):
+    """Use a dummy shader when testing non-drawing functionality"""
+    monkeypatch.setattr('pyglet.graphics.get_default_shader', get_dummy_shader_program)

--- a/tests/unit/shader/test_shader.py
+++ b/tests/unit/shader/test_shader.py
@@ -1,0 +1,139 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+GL_TRIANGLES = 4
+
+# The default shader attributes.
+# Update this if you change the default shader.
+default_shader_attributes = {
+    'colors': {'type': 35666, 'size': 1, 'location': 1, 'count': 4, 'format': 'f', 'instance': False},
+    'position': {'type': 35665, 'size': 1, 'location': 0, 'count': 3, 'format': 'f', 'instance': False},
+    'tex_coords': {'type': 35665, 'size': 1, 'location': 2, 'count': 3, 'format': 'f', 'instance': False},
+}
+
+
+class TestDefaultShader(unittest.TestCase):
+
+    def setUp(self):
+        """Setup the fake ShaderProgram for all of the tests."""
+        patcher = patch.multiple(
+            'pyglet.graphics.shader',
+            _link_program=patch('pyglet.graphics.shader._link_program', return_value=1).start(),
+            _introspect_attributes=patch('pyglet.graphics.shader._introspect_attributes',
+                                         return_value=default_shader_attributes).start(),
+            _introspect_uniforms=patch('pyglet.graphics.shader._introspect_uniforms',
+                                       return_value={}).start(),
+            _introspect_uniform_blocks=patch('pyglet.graphics.shader._introspect_uniform_blocks',
+                                             return_value={}).start(),
+            glEnableVertexAttribArray=patch('pyglet.graphics.shader.glEnableVertexAttribArray', new_callable=MagicMock()).start(),
+            glVertexAttribPointer=patch('pyglet.graphics.shader.glVertexAttribPointer',
+                                            new_callable=MagicMock()).start(),
+        )
+        self.addCleanup(patcher.stop)
+
+        patcher_gl = patch.multiple(
+            'pyglet.gl',
+            current_context=patch('pyglet.gl.current_context', create=True).start(),
+            glUseProgram=patch('pyglet.gl.glUseProgram').start(),
+            glDeleteProgram=patch('pyglet.gl.glDeleteProgram').start(),
+            glGenVertexArrays=patch('pyglet.gl.glGenVertexArrays').start(),
+        )
+        self.addCleanup(patcher_gl.stop)
+        
+        # These are imported already before this test runs, so we need to override them. Imports fixed.
+        patcher_vertexbuffer = patch.multiple(
+            'pyglet.graphics.vertexbuffer',
+            glBindBuffer=MagicMock(),
+            glBufferData=MagicMock(),
+            glBufferSubData=MagicMock(),
+            glGenBuffers=MagicMock(),
+        )
+        self.addCleanup(patcher_vertexbuffer.stop)
+        patcher_vertexbuffer.start()
+        
+        patcher_vertexarray = patch.multiple(
+            'pyglet.graphics.vertexarray',
+            glGenVertexArrays=MagicMock(),
+            glBindVertexArray=MagicMock(),
+        )
+        self.addCleanup(patcher_vertexarray.stop)
+        patcher_vertexarray.start()
+        
+        # Create mock shaders
+        mock_shader1 = MagicMock()
+        mock_shader2 = MagicMock()
+
+        from pyglet.graphics import Batch
+        from pyglet.graphics.shader import ShaderProgram
+
+        # Patch default batch.
+        patch('pyglet.graphics.get_default_batch', return_value=Batch()).start()
+
+        self.program = ShaderProgram(mock_shader1, mock_shader2)
+
+        self.batch = Batch()
+
+    def test_index_vertex_list_create_no_batch_no_group(self):
+        vlist = self.program._vertex_list_create(  # noqa: SLF001
+            count=4,
+            mode=GL_TRIANGLES,
+            indices=[0, 1, 2, 0, 2, 3],
+            instances=None,
+            batch=None,
+            group=None,
+            position=('f', (400, 400, 0, 400 + 50, 400, 0, 400 + 50, 400 + 50, 0, 400, 400 + 50, 0)),
+            colors=('f', (1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1)),
+        )
+
+        assert vlist is not None
+        assert vlist.count == 4
+
+    def test_index_vertex_list_create_batch_no_group(self):
+        vlist = self.program._vertex_list_create(  # noqa: SLF001
+            count=4,
+            mode=GL_TRIANGLES,
+            indices=[0, 1, 2, 0, 2, 3],
+            instances=None,
+            batch=self.batch,
+            group=None,
+            position=('f', (400, 400, 0, 400 + 50, 400, 0, 400 + 50, 400 + 50, 0, 400, 400 + 50, 0)),
+            colors=('f', (1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1)),
+        )
+
+        assert vlist is not None
+        assert vlist.count == 4
+        
+    def test_index_vertex_list_create_batch_group(self):
+        from pyglet.graphics import Group
+        vlist = self.program._vertex_list_create(  # noqa: SLF001
+            count=4,
+            mode=GL_TRIANGLES,
+            indices=[0, 1, 2, 0, 2, 3],
+            instances=None,
+            batch=self.batch,
+            group=Group(),
+            position=('f', (400, 400, 0, 400 + 50, 400, 0, 400 + 50, 400 + 50, 0, 400, 400 + 50, 0)),
+            colors=('f', (1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1)),
+        )
+
+        assert vlist is not None
+        assert vlist.count == 4
+        
+    def test_index_vertex_list_create_no_batch_group(self):
+        from pyglet.graphics import Group
+        vlist = self.program._vertex_list_create(  # noqa: SLF001
+            count=4,
+            mode=GL_TRIANGLES,
+            indices=[0, 1, 2, 0, 2, 3],
+            instances=None,
+            batch=None,
+            group=Group(),
+            position=('f', (400, 400, 0, 400 + 50, 400, 0, 400 + 50, 400 + 50, 0, 400, 400 + 50, 0)),
+            colors=('f', (1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1, 1, 0.5, 0.2, 1)),
+        )
+
+        assert vlist is not None
+        assert vlist.count == 4
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Domains no longer store the shader program, as we just need their attribute info.
- Creating a vertex list now doesn't enforce all the same attribute keys needing to exist for the shader. 
- Changing the shader program of a class can now do so without all attributes needing to be implemented.
- Move ShaderGroup creation outside the domain.
- Remove isinstance checks for VertexList and go off the class variable that is set.
- Attributes no longer directly tied to Attribute buffers as it's not proper.
- Separated AttributeBufferObject to BackBufferObject
- Index buffer is now a BackedBufferObject, it should be atleast 4x faster to create and migrate IndexedVertexLists now, as it was constantly making OpenGL calls for every indice set and get.

Updated tests:
Added test for program/batch/group changing for sprites.
Add a unit test with a mock shader.
Add test for vertex list creation.

Also update Options stub to indicate they support __getitem__.

It passes tests, but if anyone can run through their own things to make sure I didn't miss anything?
