### PR TITLE
Fix for issue uncovered in #1175

### DIFF
--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -389,9 +389,9 @@ class Source:
         """Return the ``Source`` to be used as the queue source for a player.
 
         Default implementation returns ``self`` if this source is precise as
-        specified by :meth:`is_precise` or if the ``imprecise_ok`` argument
-        is given. Otherwise, a new :class:`PreciseStreamingSource` wrapping
-        this source is returned.
+        specified by :meth:`is_precise`.
+        Otherwise, a new :class:`PreciseStreamingSource` wrapping this source
+        is returned.
 
         Returns:
             :class:`Source`

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -388,15 +388,12 @@ class Source:
     def get_queue_source(self) -> 'Source':
         """Return the ``Source`` to be used as the queue source for a player.
 
-        Default implementation returns ``self`` if this source is precise as
-        specified by :meth:`is_precise`.
-        Otherwise, a new :class:`PreciseStreamingSource` wrapping this source
-        is returned.
+        Default implementation returns ``self``.
 
         Returns:
             :class:`Source`
         """
-        return self if self.is_precise() else PreciseStreamingSource(self)
+        return self
 
     def get_audio_data(self, num_bytes: int, compensation_time=0.0) -> Optional[AudioData]:
         """Get next packet of audio data.
@@ -629,106 +626,3 @@ class SourceGroup:
                 self._advance()
 
         return AudioData(buffer, len(buffer), timestamp, duration)
-
-
-class PreciseStreamingSource(StreamingSource):
-    """Wrap non-precise sources that may over- or undershoot.
-
-    Purpose of this source is to always return data whose length is equal or
-    less than in length, where less hints at definite source exhaustion.
-
-    This source is used by pyglet internally, you probably don't need to
-    bother with it.
-
-    This source erases AudioData-contained timestamp/duration information and
-    events.
-    """
-
-    def __init__(self, source: Source) -> None:
-        self._source = source
-        self._buffer = bytearray()
-        self._exhausted = False
-        self._is_player_source = False
-
-        # Forward formats, info and duration
-        self.audio_format = source.audio_format
-        self.video_format = source.video_format
-        self.info = source.info
-
-        self._duration = source.duration
-
-    @property
-    def is_player_source(self) -> bool:
-        return self._source.is_player_source
-
-    @is_player_source.setter
-    def is_player_source(self, n: bool) -> None:
-        self._source.is_player_source = n
-
-    def is_precise(self) -> bool:
-        return True
-
-    def seek(self, timestamp: float) -> None:
-        self._buffer.clear()
-        self._exhausted = False
-        self._source.seek(timestamp)
-
-    def get_audio_data(self, num_bytes: int) -> Optional[AudioData]:
-        if self._exhausted:
-            return None
-
-        if len(self._buffer) < num_bytes:
-            # Buffer is incapable of fulfilling request, get more
-
-            # Reduce amount of required bytes by buffer length
-            required_bytes = num_bytes - len(self._buffer)
-
-            # Don't bother with super-small requests to something that likely does some form of I/O
-            # Also, intentionally overshoot since some sources may just barely undercut.
-            base_attempt = next_or_equal_power_of_two(max(4096, required_bytes + 16))
-            attempts = (base_attempt, base_attempt, base_attempt * 2, base_attempt * 8)
-            cur_attempt_idx = 0
-            # A malicious decoder could technically trap us by delivering empty AudioData, though
-            # the argument that this is unnecessarily defensive programming is definitely valid.
-            empty_bailout = 4
-
-            while True:
-                if cur_attempt_idx + 1 < 4: # len(attempts)
-                    cur_attempt_idx += 1
-                res = self._source.get_audio_data(attempts[cur_attempt_idx])
-
-                if res is None:
-                    self._exhausted = True
-                elif res.length == 0:
-                    empty_bailout -= 1
-                    if empty_bailout <= 0:
-                        self._exhausted = True
-                else:
-                    empty_bailout = 4
-                    self._buffer += res.data
-
-                if len(self._buffer) >= num_bytes or self._exhausted:
-                    break
-
-        res = self._buffer[:num_bytes]
-        if not res:
-            return None
-
-        del self._buffer[:num_bytes]
-        return AudioData(res, len(res))
-
-    def get_next_video_timestamp(self) -> Optional[float]:
-        return self._source.get_next_video_timestamp()
-
-    def get_next_video_frame(self) -> Optional['AbstractImage']:
-        return self._source.get_next_video_frame()
-
-    def save(self,
-             filename: str,
-             file: Optional[BinaryIO] = None,
-             encoder: Optional['MediaEncoder'] = None) -> None:
-        self._source.save(filename, file, encoder)
-
-    def delete(self) -> None:
-        self._source.delete()
-        self._buffer.clear()

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -368,7 +368,7 @@ class Source:
 
         If this method is overridden to return ``True`` although the source
         does not comply with the requirements above, audio playback may be
-        negatively impacted at best and memory access violations occurr at
+        negatively impacted at best and memory access violations occur at
         worst.
 
         :Returns:

--- a/pyglet/media/drivers/base.py
+++ b/pyglet/media/drivers/base.py
@@ -1,14 +1,83 @@
 from collections import deque
 import ctypes
+from typing import Any
 import weakref
 from abc import ABCMeta, abstractmethod
 
 import pyglet
 from pyglet.media.codecs import AudioData
-from pyglet.util import debug_print
+from pyglet.util import debug_print, next_or_equal_power_of_two
 
 
 _debug = debug_print('debug_media')
+
+
+class SourcePrecisionBuffer:
+    """Wrap non-precise sources that may over- or undershoot.
+
+    This class's purpose is to always return data whose length is equal or
+    less than the requested size, where less hints at definite source
+    exhaustion.
+
+    This class erases AudioData-contained timestamp/duration information and
+    events.
+    """
+
+    def __init__(self, source):
+        self._source = weakref.proxy(source)
+        self._buffer = bytearray()
+        self._exhausted = False
+
+    def get_audio_data(self, requested_size):
+        if self._exhausted:
+            return None
+
+        if len(self._buffer) < requested_size:
+            # Buffer is incapable of fulfilling request, get more
+
+            # Reduce amount of required bytes by buffer length
+            required_bytes = requested_size - len(self._buffer)
+
+            # Don't bother with super-small requests to something that likely does some form of I/O
+            # Also, intentionally overshoot since some sources may just barely undercut.
+            base_attempt = next_or_equal_power_of_two(max(4096, required_bytes + 16))
+            attempts = (base_attempt, base_attempt, base_attempt * 2, base_attempt * 8)
+            cur_attempt_idx = 0
+            # A malicious decoder could technically trap us by delivering empty AudioData, though
+            # the argument that this is unnecessarily defensive programming is definitely valid.
+            empty_bailout = 4
+
+            while True:
+                if cur_attempt_idx + 1 < 4: # len(attempts)
+                    cur_attempt_idx += 1
+                res = self._source.get_audio_data(attempts[cur_attempt_idx])
+
+                if res is None:
+                    self._exhausted = True
+                elif res.length == 0:
+                    empty_bailout -= 1
+                    if empty_bailout <= 0:
+                        self._exhausted = True
+                else:
+                    empty_bailout = 4
+                    self._buffer += res.data
+
+                if len(self._buffer) >= requested_size or self._exhausted:
+                    break
+
+        res = self._buffer[:requested_size]
+        if not res:
+            return None
+
+        del self._buffer[:requested_size]
+        return AudioData(res, len(res))
+
+    def set_source(self, source):
+        self._source = weakref.proxy(source)
+
+    def reset(self):
+        self._buffer.clear()
+        self._exhausted = False
 
 
 class AbstractAudioPlayer(metaclass=ABCMeta):
@@ -39,6 +108,8 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         # the audio_player
         self.source = weakref.proxy(source)
         self.player = weakref.proxy(player)
+
+        self._precision_buffer = None if source.is_precise() else SourcePrecisionBuffer(source)
 
         afmt = source.audio_format
         # How much data should ideally be in memory ready to be played.
@@ -87,6 +158,13 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         self.clear()
         self.source = weakref.proxy(source)
 
+        if source.is_precise():
+            self._precision_buffer = None
+        elif self._precision_buffer is None:
+            self._precision_buffer = SourcePrecisionBuffer(source)
+        else:
+            self._precision_buffer.set_source(source)
+
     @abstractmethod
     def prefill_audio(self):
         """Prefill the audio buffer with audio data.
@@ -123,6 +201,8 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         self._compensated_bytes = 0
         self.audio_sync_measurements.clear()
         self.audio_sync_cumul_measurements = 0
+        if self._precision_buffer is not None:
+            self._precision_buffer.reset()
 
     @abstractmethod
     def delete(self):
@@ -251,6 +331,11 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
 
         return 0, False
 
+    def _get_audio_data(self, requested_size):
+        if self._precision_buffer is None:
+            return self.source.get_audio_data(requested_size)
+        return self._precision_buffer.get_audio_data(requested_size)
+
     def _get_and_compensate_audio_data(self, requested_size, audio_position=None):
         """
         Retrieve a packet of `AudioData` of the given size.
@@ -259,7 +344,7 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         desync_bytes, extreme_desync = self.get_audio_time_diff(audio_time)
 
         if desync_bytes == 0:
-            return self.source.get_audio_data(requested_size)
+            return self._get_audio_data(requested_size)
 
         compensated_bytes = 0
         afmt = self.source.audio_format
@@ -278,7 +363,7 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
                 self.desync_correction_bytes_minor,
             )
 
-            audio_data = self.source.get_audio_data(requested_size - compensated_bytes)
+            audio_data = self._get_audio_data(requested_size - compensated_bytes)
             if audio_data is not None:
                 if audio_data.length < afmt.bytes_per_frame:
                     raise RuntimeError("Partial audio frame returned?")
@@ -299,7 +384,7 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
                                  if extreme_desync
                                  else min(-desync_bytes, self.desync_correction_bytes_minor))
 
-            audio_data = self.source.get_audio_data(requested_size + compensated_bytes)
+            audio_data = self._get_audio_data(requested_size + compensated_bytes)
             if audio_data is not None:
                 if audio_data.length <= compensated_bytes:
                     compensated_bytes = -audio_data.length

--- a/pyglet/media/drivers/base.py
+++ b/pyglet/media/drivers/base.py
@@ -1,6 +1,5 @@
 from collections import deque
 import ctypes
-from typing import Any
 import weakref
 from abc import ABCMeta, abstractmethod
 

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -11,7 +11,7 @@ import pyglet
 from pyglet.gl import GL_TEXTURE_2D
 from pyglet.media import buffered_logger as bl
 from pyglet.media.drivers import get_audio_driver
-from pyglet.media.codecs.base import PreciseStreamingSource, Source, SourceGroup
+from pyglet.media.codecs.base import Source, SourceGroup
 
 _debug = pyglet.options['debug_media']
 
@@ -162,14 +162,7 @@ class Player(pyglet.event.EventDispatcher):
         if new_source is None:
             self._source = None
         else:
-            qs = new_source.get_queue_source()
-            # HACK: for 2.0.x, players perform additional PreciseStreamingSource wrapping.
-            # Existing sources might not use `super().get_queue_source()`, leading to an
-            # imprecise source on here, which may not happen.
-            if not isinstance(qs, PreciseStreamingSource) and not qs.is_precise():
-                self._source = PreciseStreamingSource(qs)
-            else:
-                self._source = qs
+            self._source = new_source.get_queue_source()
 
     def _set_playing(self, playing: bool) -> None:
         # stopping = self._playing and not playing

--- a/tests/unit/media/test_sources.py
+++ b/tests/unit/media/test_sources.py
@@ -153,23 +153,11 @@ class SourceTestCase(unittest.TestCase):
         with self.assertRaises(MediaException):
             ret.get_queue_source()
 
-    def test_precise_queue_source(self):
-        source = StreamingSource()
-        with mock.patch.object(source, "is_precise", lambda: True):
-            qsource = source.get_queue_source()
-            self.assertIs(qsource, source)
-            self.assertTrue(qsource.is_player_source)
-
-    def test_nonprecise_queue_source(self):
-        source = Source()
-        qsource = source.get_queue_source()
-        self.assertIsNot(qsource, source)
-        self.assertIsInstance(qsource, PreciseStreamingSource)
-
+    def test_queue_source(self):
         source = StreamingSource()
         qsource = source.get_queue_source()
-        self.assertIsNot(qsource, source)
-        self.assertIsInstance(qsource, PreciseStreamingSource)
+        self.assertIs(qsource, source)
+        self.assertTrue(qsource.is_player_source)
 
 
 class StaticSourceTestCase(unittest.TestCase):


### PR DESCRIPTION
This fixes the issue of `PreciseStreamingSource`s not passing through their wrapped source's attributes by removing it entirely, moving the logic that buffers audio from imprecise sources into the `AudioPlayer` base class.

Wrapping sources like that is quite messy, the truly solid alternative would be forwarding source attributes entirely via property overrides (See https://github.com/Square789/pyglet/tree/precise_streaming_fix_a). I did not open that branch as a PR because i believe this solution is preferrable.  
This commit series also removes an instance in `Player` where the `PreciseStreamingSource` wrapper had to be created parallel to the `Source.get_queue_source`, removing a duplication of logic.
