### PR TITLE
Fix audio and vsync env vars

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -273,11 +273,16 @@ class Options:
 #: Instance of :py:class:`~pyglet.Options` used to set runtime options.
 options: Options = Options()
 
+_OPTION_TYPE_REMAPS = {
+    "audio": "sequence",
+    "vsync": "bool",
+}
 
 for _key, _type in options.__annotations__.items():
     """Check Environment Variables for pyglet options"""
     if _value := os.environ.get(f"PYGLET_{_key.upper()}"):
-        if _type == 'tuple':
+        _type = _OPTION_TYPE_REMAPS.get(_key, _type)
+        if _type == 'sequence':
             options[_key] = _value.split(",")
         elif _type == 'bool':
             options[_key] = _value in ("true", "TRUE", "True", "1")


### PR DESCRIPTION
Follow-up to #1161.

I have to apologize, as updating the type hints in the PR above introduced this breakage.  
For the options whose types as annotated in the new `Options` class are more complex, another dict now is used as an additional lookup to decide on the method to convert the value of the env var with.
