### PR TITLE
Improve attribute buffer behavior

### DIFF
--- a/pyglet/graphics/vertexbuffer.py
+++ b/pyglet/graphics/vertexbuffer.py
@@ -227,7 +227,7 @@ class BackedBufferObject(BufferObject):
     count: int
     ctype: CTypesDataType
 
-    def __init__(self, size: int, c_type: CTypesDataType, stride: int, count: int,
+    def __init__(self, size: int, c_type: CTypesDataType, stride: int, count: int,  # noqa: D107
                  usage: int = GL_DYNAMIC_DRAW) -> None:
         super().__init__(size, usage)
 
@@ -244,8 +244,8 @@ class BackedBufferObject(BufferObject):
         self.stride = stride
         self.count = count
 
-    def sub_data(self) -> None:
-        """Updates the buffer if any data has been changed or invalidated.
+    def commit(self) -> None:
+        """Commits all saved changes to the underlying buffer before drawing.
 
         Allows submitting multiple changes at once, rather than having to call glBufferSubData for every change.
         """
@@ -296,12 +296,10 @@ class BackedBufferObject(BufferObject):
         self.data_ptr = ctypes.addressof(data)
         self.size = size
 
-        glBindBuffer(GL_ARRAY_BUFFER, self.id)
-        glBufferData(GL_ARRAY_BUFFER, self.size, self.data, self.usage)
-
-        self._dirty_min = sys.maxsize
-        self._dirty_max = 0
-        self._dirty = False
+        # Set the dirty range to be the entire buffer.
+        self._dirty_min = 0
+        self._dirty_max = self.size
+        self._dirty = True
 
         self.get_region.cache_clear()
 
@@ -331,6 +329,6 @@ class AttributeBufferObject(BackedBufferObject):
 class IndexedBufferObject(BackedBufferObject):
     """A backed buffer used for indices."""
 
-    def __init__(self, size: int, c_type: CTypesDataType, stride: int, count: int,
+    def __init__(self, size: int, c_type: CTypesDataType, stride: int, count: int,  # noqa: D107
                  usage: int = GL_DYNAMIC_DRAW) -> None:
         super().__init__(size, c_type, stride, count, usage)

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -465,7 +465,7 @@ class VertexDomain:
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
 
         starts, sizes = self.allocator.get_allocated_regions()
         primcount = len(starts)
@@ -494,7 +494,7 @@ class VertexDomain:
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
 
         glDrawArrays(mode, vertex_list.start, vertex_list.count)
 
@@ -598,7 +598,7 @@ class InstancedVertexDomain(VertexDomain):  # noqa: D101
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
 
         starts, sizes = self.allocator.get_allocated_regions()
         glDrawArraysInstanced(mode, starts[0], sizes[0], self._instances)
@@ -617,7 +617,7 @@ class InstancedVertexDomain(VertexDomain):  # noqa: D101
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
 
         glDrawArraysInstanced(mode, vertex_list.start, vertex_list.count, self._instances)
 
@@ -709,9 +709,9 @@ class IndexedVertexDomain(VertexDomain):
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
 
-        self.index_buffer.sub_data()
+        self.index_buffer.commit()
 
         starts, sizes = self.index_allocator.get_allocated_regions()
         primcount = len(starts)
@@ -741,7 +741,9 @@ class IndexedVertexDomain(VertexDomain):
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
+
+        self.index_buffer.commit()
 
         glDrawElements(mode, vertex_list.index_count, self.index_gl_type,
                        self.index_buffer.ptr +
@@ -811,7 +813,7 @@ class InstancedIndexedVertexDomain(IndexedVertexDomain, InstancedVertexDomain):
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
 
         starts, sizes = self.index_allocator.get_allocated_regions()
         glDrawElementsInstanced(mode, sizes[0], self.index_gl_type,
@@ -832,7 +834,7 @@ class InstancedIndexedVertexDomain(IndexedVertexDomain, InstancedVertexDomain):
         """
         self.vao.bind()
         for buffer, _ in self.buffer_attributes:
-            buffer.sub_data()
+            buffer.commit()
 
         glDrawElementsInstanced(mode, vertex_list.index_count, self.index_gl_type,
                                 self.index_buffer.ptr +


### PR DESCRIPTION
* Resizing a backed buffer now waits for the commit before resizing.
* Rename sub_data to commit to better reflect it's usage.
* Fix issue with draw_subset not committing the index buffer.

From initial testing this cuts loading large data sets by half due to only resizing the buffer once instead of multiple times in one iteration.   0.74 seconds to 0.36

Also from initial testing this also now allows creating Pyglet objects within a thread since the changes aren't committed until the draw cycle. Note that you still have to load atleast one of each object first outside the thread so the initial threads are created.