### PR TITLE
Fixed label vertical values to align with docs

### DIFF
--- a/doc/programming_guide/examplegame.rst
+++ b/doc/programming_guide/examplegame.rst
@@ -119,9 +119,9 @@ Making the labels
 
 To make a text label in pyglet, just initialize a :class:`pyglet.text.Label` object::
 
-    score_label = pyglet.text.Label(text="Score: 0", x=10, y=460)
+    score_label = pyglet.text.Label(text="Score: 0", x=10, y=575)
     level_label = pyglet.text.Label(text="My Amazing Game",
-                                x=game_window.width//2, y=game_window.height//2, anchor_x='center')
+                                x=game_window.width//2, y=575, anchor_x='center')
 
 Notice that the second label is centered using the anchor_x attribute.
 


### PR DESCRIPTION
At the end of the "Drawing the labels" section, the docs say, "Now when you run asteroid.py, you should get a window with a score of zero in the **upper left corner** and a centered label reading “My Amazing Game” **at the top of the screen**."

With the current vertical (y) values, you instead see the score_label being lower than intended and the level_label being at the very center of the screen (both x and y axis), which clashes with the given description.

The updated values used (y=575) match the description and are consistent with the values of "score_label" used lower on the same page, in the section "Drawing with batches".