### PR TITLE
Fix blinking cursor again for Mac

### DIFF
--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 NSArray = ObjCClass('NSArray')
 NSApplication = ObjCClass('NSApplication')
-
+NSColor = ObjCClass('NSColor')
 
 # This custom NSTextView subclass is used for capturing all of the
 # on_text, on_text_motion, and on_text_motion_select events.
@@ -37,8 +37,8 @@ class PygletTextView_Implementation:
         self.setFieldEditor_(False)
         self.empty_string = CFSTR('')
 
-        # Prevent a blinking cursor in bottom left corner
-        self.setEditable_(False)
+        # Prevent a blinking cursor in bottom left corner Python 3.9 w/ ARM mac.
+        self.setInsertionPointColor_(NSColor.clearColor())
         return self
 
     @PygletTextView.method("v@")


### PR DESCRIPTION
Python 3.9 is buggy with ARM Mac's.

Fixing blinking caret issue.

Resolves https://github.com/pyglet/pyglet/issues/1197