### PR TITLE
Experimental batch and drawing modifications

### DIFF
--- a/experimental/graphics/group_ordering.py
+++ b/experimental/graphics/group_ordering.py
@@ -26,20 +26,14 @@ for i in range(window.height + 1):
     group = pyglet.graphics.Group(i)
     groups.append(group)
 
-
-def make_sprite(zvalue):
+sprite_count = 60
+for i in range(sprite_count):
     sprite = pyglet.sprite.Sprite(image, x=0, y=0, batch=batch, group=groups[i])
     # Random color multiplier.
     sprite.color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
     # Add sprites to keep in memory, like a list. Otherwise, they will get GC'd when out of scope.
     sprite.scale = 0.25
     sprites.append(sprite)
-
-
-sprite_count = 60
-for i in range(sprite_count):
-    make_sprite(i)
-
 
 global elapsed
 elapsed = 0

--- a/experimental/graphics/group_ordering.py
+++ b/experimental/graphics/group_ordering.py
@@ -1,0 +1,68 @@
+"""An example of sorting sprites using many ordered groups."""
+from __future__ import annotations
+
+import math
+import random
+
+import pyglet
+
+#pyglet.options.debug_gl = False
+
+window = pyglet.window.Window(height=720, vsync=False)
+fps = pyglet.window.FPSDisplay(window)
+
+# Set example resource path.
+pyglet.resource.path = ['../../examples/resources']
+pyglet.resource.reindex()
+
+image = pyglet.resource.image("pyglet.png")
+# batch = pyglet.graphics.Batch()
+batch = pyglet.experimental.graphics.Batch()
+
+sprites = []
+
+groups = []
+for i in range(window.height + 1):
+    group = pyglet.graphics.Group(i)
+    groups.append(group)
+
+
+def make_sprite(zvalue):
+    sprite = pyglet.sprite.Sprite(image, x=0, y=0, batch=batch, group=groups[i])
+    # Random color multiplier.
+    sprite.color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
+    # Add sprites to keep in memory, like a list. Otherwise, they will get GC'd when out of scope.
+    sprite.scale = 0.25
+    sprites.append(sprite)
+
+
+sprite_count = 60
+for i in range(sprite_count):
+    make_sprite(i)
+
+
+global elapsed
+elapsed = 0
+
+
+def update(dt):
+    global elapsed
+    for i, sprite in enumerate(sprites):
+        sprite.update(x=i * .75 * (sprite.width - 15),
+                      y=.35 * window.height * (1 + math.cos(2 * elapsed + i * math.pi / sprite_count)))
+        sprite.group = groups[int(sprite.y)]
+
+    elapsed += dt
+
+
+pyglet.clock.schedule_interval(update, 1 / 60.0)
+
+
+@window.event
+def on_draw():
+    window.clear()
+    batch.draw()
+    fps.draw()
+
+
+pyglet.app.run(0)

--- a/experimental/graphics/group_rendering.py
+++ b/experimental/graphics/group_rendering.py
@@ -1,0 +1,91 @@
+"""Example on how to draw specific groups in a Batch.
+
+This can be useful if you need to draw groups during runtime; for example drawing
+into an offscreen framebuffer for effects.
+"""
+from __future__ import annotations
+
+import random
+
+import pyglet
+from pyglet.graphics import Group
+
+window = pyglet.window.Window(height=720, vsync=False)
+fps = pyglet.window.FPSDisplay(window)
+
+# Set example resource path.
+pyglet.resource.path = ['../../examples/resources']
+pyglet.resource.reindex()
+
+image = pyglet.resource.image("pyglet.png")
+# batch = pyglet.graphics.Batch()
+batch = pyglet.experimental.graphics.Batch(group_draw=True)
+
+scales = [1.0, 0.75, 0.5, 0.25]
+
+class DistinctGroup(pyglet.graphics.Group):
+    """A group that will be distinct from another."""
+    def __eq__(self, other: Group) -> bool:
+        return (self.__class__ is other.__class__ and
+                self._order == other.order and
+                self.parent == other.parent)
+
+    def __hash__(self):
+        return hash((id(self), self._order, self.parent))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(order={self._order}, id={id(self)})"
+
+group1 = DistinctGroup()
+group2 = DistinctGroup()
+
+print("Groups:", group1, group2)
+
+sprites = []
+# Create 1000 sprites at various scales.
+for i in range(100):
+    sprite = pyglet.sprite.Sprite(image,
+                                  x=random.randint(0, window.width),
+                                  y=random.randint(0, window.height),
+                                  group=group1 if i % 2 else group2,
+                                  batch=batch)  # specify the batch to enter the sprites in.
+
+    # Randomize scale.
+    sprite.scale = random.choice(scales)
+
+    # Random color multiplier.
+    sprite.color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
+
+    # Add sprites to keep in memory, like a list. Otherwise they will get GC'd when out of scope.
+    sprites.append(sprite)
+
+
+groups_to_draw = set()
+@window.event
+def on_key_press(symbol, modifiers):
+    if symbol == pyglet.window.key.A:
+        if group1 not in groups_to_draw:
+            groups_to_draw.add(group1)
+    elif symbol == pyglet.window.key.D:
+        if group2 not in groups_to_draw:
+            groups_to_draw.add(group2)
+    elif symbol == pyglet.window.key.SPACE:
+        groups_to_draw.clear()
+
+
+@window.event
+def on_draw():
+    global groups_to_draw
+    window.clear()
+    if groups_to_draw:
+        batch.draw_groups(*groups_to_draw)
+
+print("Specify Drawing Specific Groups: \nPress the following keys:")
+print("A: Add Group 1 to Draw List")
+print("D: Add Group 2 to Draw List")
+print("SPACE: Clear all groups.")
+
+
+
+pyglet.app.run()
+

--- a/experimental/graphics/sorted_group_test.py
+++ b/experimental/graphics/sorted_group_test.py
@@ -1,0 +1,66 @@
+"""An example of sorting sprites using the experimental SortedGroup."""
+from __future__ import annotations
+
+import math
+import random
+
+import pyglet
+
+# pyglet.options.debug_gl = False
+
+window = pyglet.window.Window(height=720, vsync=False)
+fps = pyglet.window.FPSDisplay(window)
+fps.label.color = (0, 255, 0)
+
+pyglet.resource.path = ['../../examples/resources']
+pyglet.resource.reindex()
+
+image = pyglet.resource.image("pyglet.png")
+batch = pyglet.experimental.graphics.Batch()
+
+sprites = []
+
+group = pyglet.experimental.graphics.SortedGroup()
+
+
+def make_sprite(zvalue):
+    sprite = pyglet.sprite.Sprite(image, x=0, y=0, batch=batch, group=group)
+    # Random color multiplier.
+    sprite.color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
+    # Add sprites to keep in memory, like a list. Otherwise, they will get GC'd when out of scope.
+    sprite.scale = 0.25
+    sprites.append(sprite)
+
+
+sprite_count = 100
+for i in range(sprite_count):
+    make_sprite(i)
+
+group.link_objects(sprites)
+
+global elapsed
+elapsed = 0
+
+
+# @profile
+def update(dt):
+    global elapsed
+    for i, sprite in enumerate(sprites):
+        sprite.update(x=i * .15 * (sprite.width - 15),
+                      y=.45 * window.height * (1 + math.cos(2 * elapsed + i * math.pi / sprite_count)))
+
+    group.sort_objects(lambda s: int(s.y))
+    elapsed += dt
+
+
+pyglet.clock.schedule_interval(update, 1 / 60.0)
+
+
+@window.event
+def on_draw():
+    window.clear()
+    batch.draw()
+    fps.draw()
+
+
+pyglet.app.run(0)

--- a/experimental/graphics/sorted_group_test.py
+++ b/experimental/graphics/sorted_group_test.py
@@ -22,19 +22,14 @@ sprites = []
 
 group = pyglet.experimental.graphics.SortedGroup()
 
-
-def make_sprite(zvalue):
+sprite_count = 100
+for i in range(sprite_count):
     sprite = pyglet.sprite.Sprite(image, x=0, y=0, batch=batch, group=group)
     # Random color multiplier.
     sprite.color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
     # Add sprites to keep in memory, like a list. Otherwise, they will get GC'd when out of scope.
     sprite.scale = 0.25
     sprites.append(sprite)
-
-
-sprite_count = 100
-for i in range(sprite_count):
-    make_sprite(i)
 
 group.link_objects(sprites)
 

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -265,7 +265,7 @@ class Options:
 
     def __setitem__(self, key: str, value: Any) -> None:
         assert key in self.__annotations__, f"Invalid option name: '{key}'"
-        assert (_SPECIAL_OPTION_VALIDATORS.get(key, None) or _OPTION_TYPE_VALIDATORS[self.__annotations__[key]])(value), \
+        assert (_SPECIAL_OPTION_VALIDATORS.get(key) or _OPTION_TYPE_VALIDATORS[self.__annotations__[key]])(value), \
             f"Invalid type: '{type(value)}' for '{key}'"
         self.__dict__[key] = value
 
@@ -439,6 +439,7 @@ if TYPE_CHECKING:
         clock,
         customtypes,
         event,
+        experimental,
         font,
         gl,
         graphics,
@@ -461,6 +462,7 @@ else:
     clock = _ModuleProxy("clock")  # type: ignore
     customtypes = _ModuleProxy("customtypes")  # type: ignore
     event = _ModuleProxy("event")  # type: ignore
+    experimental = _ModuleProxy("experimental")  # type: ignore
     font = _ModuleProxy("font")  # type: ignore
     gl = _ModuleProxy("gl")  # type: ignore
     graphics = _ModuleProxy("graphics")  # type: ignore

--- a/pyglet/__init__.pyi
+++ b/pyglet/__init__.pyi
@@ -7,6 +7,7 @@ from . import canvas as canvas
 from . import clock as clock
 from . import customtypes as customtypes
 from . import event as event
+from . import experimental as experimental
 from . import font as font
 from . import gl as gl
 from . import graphics as graphics

--- a/pyglet/experimental/__init__.py
+++ b/pyglet/experimental/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+import pyglet.experimental.graphics

--- a/pyglet/experimental/graphics/__init__.py
+++ b/pyglet/experimental/graphics/__init__.py
@@ -1,0 +1,618 @@
+"""Low-level graphics rendering and abstractions.
+
+This module provides efficient abstractions over OpenGL objects, such as
+Shaders and Buffers. It also provides classes for highly performant batched
+rendering and grouping.
+
+See the :ref:`guide_graphics` for details on how to use this graphics API.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Sequence, Tuple
+
+import pyglet
+from pyglet.experimental.graphics import vertexdomain
+from pyglet.graphics.vertexarray import VertexArray  # noqa: F401
+
+if TYPE_CHECKING:
+    from pyglet.graphics import Group
+    from pyglet.graphics.shader import ShaderProgram
+    from pyglet.graphics.vertexdomain import IndexedVertexList, VertexList
+
+_debug_graphics_batch = pyglet.options['debug_graphics_batch']
+
+_domain_class_map: dict[tuple[bool, bool], type[vertexdomain.VertexDomain]] = {
+    # Indexed, Instanced : Domain
+    (False, False): vertexdomain.VertexDomain,
+    (True, False): vertexdomain.IndexedVertexDomain,
+}
+
+DomainKey = Tuple[bool, int, int, str]
+
+
+class Batch:
+    """Manage a collection of drawables for batched rendering.
+
+    Many drawable pyglet objects accept an optional `Batch` argument in their
+    constructors. By giving a `Batch` to multiple objects, you can tell pyglet
+    that you expect to draw all of these objects at once, so it can optimise its
+    use of OpenGL. Hence, drawing a `Batch` is often much faster than drawing
+    each contained drawable separately.
+
+    The following example creates a batch, adds two sprites to the batch, and
+    then draws the entire batch::
+
+        batch = pyglet.graphics.Batch()
+        car = pyglet.sprite.Sprite(car_image, batch=batch)
+        boat = pyglet.sprite.Sprite(boat_image, batch=batch)
+
+        def on_draw():
+            batch.draw()
+
+    While any drawables can be added to a `Batch`, only those with the same
+    draw mode, shader program, and group can be optimised together.
+
+    Internally, a `Batch` manages a set of VertexDomains along with
+    information about how the domains are to be drawn. To implement batching on
+    a custom drawable, get your vertex domains from the given batch instead of
+    setting them up yourself.
+    """
+    _draw_list: list[Callable]
+    top_groups: list[Group]
+    group_children: dict[Group, list[Group]]
+    group_map: dict[Group, dict[DomainKey, vertexdomain.VertexDomain]]
+    domain_map: dict[DomainKey: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain]
+
+    def __init__(self) -> None:
+        """Create a graphics batch."""
+        # Mapping to find domain.
+        # group -> (attributes, mode, indexed) -> domain
+        self.group_map = {}
+
+        # Mapping of group to list of children.
+        self.group_children = {}
+
+        # All domains associated with the batch..
+        self.domain_map = {}
+
+        # List of top-level groups
+        self.top_groups = []
+
+        self._draw_list = []
+        self._draw_list_dirty = False
+
+        self._context = pyglet.gl.current_context
+
+        self.current_states = []
+
+    def invalidate(self) -> None:
+        """Force the batch to update the draw list.
+
+        This method can be used to force the batch to re-compute the draw list
+        when the ordering of groups has changed.
+
+        .. versionadded:: 1.2
+        """
+        self._draw_list_dirty = True
+
+    def update_shader(self, vertex_list: VertexList | IndexedVertexList, mode: int, group: Group,
+                      program: ShaderProgram) -> bool:
+        """Migrate a vertex list to another domain that has the specified shader attributes.
+
+        The results are undefined if `mode` is not correct or if `vertex_list`
+        does not belong to this batch (they are not checked and will not
+        necessarily throw an exception immediately).
+
+        Args:
+            vertex_list:
+                A vertex list currently belonging to this batch.
+            mode:
+                The current GL drawing mode of the vertex list.
+            group:
+                The new group to migrate to.
+            program:
+                The new shader program to migrate to.
+
+        Returns:
+            False if the domain's no longer match. The caller should handle this scenario.
+        """
+        # No new attributes.
+        attributes = program.attributes.copy()
+
+        # Formats may differ (normalization) than what is declared in the shader.
+        # Make those adjustments and attempt to get a domain.
+        for a_name in attributes:
+            if (a_name in vertex_list.initial_attribs and
+                    vertex_list.initial_attribs[a_name]['format'] != attributes[a_name]['format']):
+                attributes[a_name]['format'] = vertex_list.initial_attribs[a_name]['format']
+
+        domain = self.get_domain(vertex_list.indexed, vertex_list.instanced, mode, group, attributes)
+
+        # TODO: Allow migration if we can restore original vertices somehow. Much faster.
+        # If the domain's don't match, we need to re-create the vertex list. Tell caller no match.
+        if domain != vertex_list.domain:
+            return False
+
+        return True
+
+    def migrate(self, vertex_list: vertexdomain.VertexList | vertexdomain.IndexedVertexList, mode: int, group: Group, batch: Batch) -> None:
+        """Migrate a vertex list to another batch and/or group.
+
+        `vertex_list` and `mode` together identify the vertex list to migrate.
+        `group` and `batch` are new owners of the vertex list after migration.
+
+        The results are undefined if `mode` is not correct or if `vertex_list`
+        does not belong to this batch (they are not checked and will not
+        necessarily throw an exception immediately).
+
+        ``batch`` can remain unchanged if only a group change is desired.
+
+        Args:
+            vertex_list:
+                A vertex list currently belonging to this batch.
+            mode:
+                The current GL drawing mode of the vertex list.
+            group:
+                The new group to migrate to.
+            batch:
+                The batch to migrate to (or the current batch).
+
+        """
+        attributes = vertex_list.domain.attribute_meta
+        domain = batch.get_domain(vertex_list.indexed, vertex_list.instanced, mode, group, attributes)
+
+        # If it's the same domain, no need to dealloc it...
+        if domain != vertex_list.domain:
+            vertex_list.migrate(domain)
+        else:
+            # Update the group.
+            vertex_list.update_group(group)
+
+            # Updating group can potentially change draw order.
+            self._draw_list_dirty = True
+
+    def get_domain(self, indexed: bool, instanced: bool, mode: int, group: Group,
+                   attributes: dict[str, Any]) -> (
+            vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain):
+        """Get, or create, the vertex domain corresponding to the given arguments."""
+        key = (indexed, instanced, mode, str(attributes))
+
+        # Check for existing domain
+        if key in self.domain_map:
+            domain = self.domain_map[key]
+        else:
+            # Create a new domain if none exists
+            domain = _domain_class_map[(indexed, instanced)](attributes)
+            self.domain_map[key] = domain
+            self._draw_list_dirty = True
+
+        # Ensure the group association is kept.
+        if group not in self.group_map:
+            self._add_group(group)
+
+        domain_map = self.group_map[group]
+        domain_map[key] = domain
+
+        return domain
+
+    def _add_group(self, group: Group) -> None:
+        if group not in self.group_map:
+            self.group_map[group] = {}
+        if group.parent is None:
+            self.top_groups.append(group)
+        else:
+            if group.parent not in self.group_map:
+                self._add_group(group.parent)
+            if group.parent not in self.group_children:
+                self.group_children[group.parent] = []
+            self.group_children[group.parent].append(group)
+
+        group._assigned_batches.add(self)  # noqa: SLF001
+        self._draw_list_dirty = True
+
+    def _check_gl_state(self, group: Group) -> bool:
+        """Return if the group state needs updating."""
+        return any(gl_state not in self.current_states for gl_state in group.set_states)
+
+    def pop_states(self, group: Group) -> None:
+        for state in group.set_states:
+            if state in self.current_states:
+                self.current_states.remove(state)
+
+    def add_states(self, group: Group) -> bool:
+        requires_change = False
+        for state in group.set_states:
+            if state not in self.current_states:
+                self.current_states.append(state)
+                requires_change = True
+
+        return requires_change
+
+    def _create_draw_list(self) -> list:
+        # print("-----------")
+
+        def visit(current_group: Group) -> list:
+            draw_list = []
+
+            # Draw domains using this group
+            domain_map = self.group_map.get(current_group, {})
+
+            # Iterate over the domains associated with the current group
+            for (indexed, instanced, mode, formats), current_domain in list(domain_map.items()):
+                # Remove unused domains from batch
+                if current_domain.is_empty:
+                    del domain_map[(indexed, instanced, mode, formats)]
+                    continue
+
+                # If this group exists, has no vertices in the domain, skip it.
+                if current_group in current_domain.group_vertex_ranges:
+                    if not current_domain.group_vertex_ranges[current_group]:
+                        continue
+                else:
+                    continue
+
+                # If group exists, and has vertices, add a draw call.
+                draw_list.append((current_domain, mode, current_group))
+
+            # Sort and visit child groups of this group
+            children = self.group_children.get(current_group)
+            if children:
+                children.sort()
+                for child in list(children):
+                    if child.visible:
+                        draw_list.extend(visit(child))
+
+            if children or domain_map:
+                # if not domain_map:
+                #     return [(None, 'set', current_group), *draw_list, (None, 'unset', current_group)]
+                #
+                # return draw_list
+                return [(None, 'set', current_group), *draw_list, (None, 'unset', current_group)]
+
+            # Clean up if the group is empty and has no children
+            # Remove unused group from batch
+            del self.group_map[current_group]
+            current_group._assigned_batches.remove(self)  # noqa: SLF001
+            if current_group.parent:
+                self.group_children[current_group.parent].remove(current_group)
+            try:
+                del self.group_children[current_group]
+            except KeyError:
+                pass
+            try:
+                self.top_groups.remove(current_group)
+            except ValueError:
+                pass
+
+            return []
+
+        full_draw_list = []
+
+        self.top_groups.sort()
+
+        for top_group in list(self.top_groups):
+            if top_group.visible:
+                full_draw_list.extend(visit(top_group))
+
+        return full_draw_list
+
+    def _optimize_draw_list(self, draw_list: list) -> list[Callable]:
+        draw_call_list = []
+        contiguous_groups = []
+        last_mode = None
+        last_domain = None
+        # print("draw list to optimize:", draw_list)
+        # print("======")
+
+        set_states = []
+        set_groups = []
+        # test_draw_stuff = []
+
+        # Iterate through all calls to condense group calls.
+
+        # Draw calls should be: bind vao -> state -> draw -> unset_state
+        new_list = []
+        was_added = []
+
+        # Used to determine if a group is allowed to be unset. 'unset' is a marker for this.
+        ready_to_unset = set()
+
+        for domain, mode, group in draw_list:
+            # print("----START", domain, mode, group)
+            # Data: Group if no domain. If domain, mode.
+            if not domain:
+                # Mode is set/unset literal when domain is None
+                if mode == 'set':
+                    # If the state is already set or doesn't have states. Continue.
+                    if not group.set_states or group in set_groups:
+                        continue
+
+                    state_added = False
+
+                    # Check if any states in this group need to be added.
+                    for gl_state in group.set_states:
+                        if gl_state not in set_states:
+                            state_added = True
+
+                    # A new state needs to be added.
+                    if state_added:
+                        # Add all the new states.
+                        set_states.extend(group.set_states)
+                        # print("group set state:", group)
+                        # print("group states", group.set_states)
+                        # print("current states", set_states)
+                        # print("old states", old_states)
+                        groups_to_unset = []
+                        # If the state gets added, check if the previous set group states needs to be unset.
+                        for set_group in set_groups:
+                            # print("CHECK GROUP", set_group)
+                            for gl_state in set_group.set_states:
+                                # If a previously set group state is not in any of the new ones, unset those.
+                                if gl_state not in group.set_states:
+                                    # print(gl_state, group.set_states)
+                                    if set_group not in groups_to_unset and set_group in ready_to_unset:
+                                        groups_to_unset.append(set_group)
+
+                        for remove_group in reversed(groups_to_unset):
+                            # print("-removing group", remove_group)
+                            set_groups.remove(remove_group)
+                            ready_to_unset.remove(remove_group)
+                            new_list.append((None, 'unset', remove_group))
+                            for gl_state in remove_group.set_states:
+                                # print("Removing state", gl_state)
+                                set_states.remove(gl_state)
+
+                        # print("Groups removed", groups_to_unset)
+
+                        # print("States after", set_states)
+                        # print("State count after", len(set_states), len(group.set_states), len(set_states) == len(group.set_states))
+
+                        set_groups.append(group)
+                        was_added.append(group)
+                        new_list.append((None, 'set', group))
+                        # print("set groups total:", set_groups)
+
+                elif mode == 'unset':
+                    ready_to_unset.add(group)
+
+                    if not group.set_states or group not in was_added:
+                        continue
+
+                    # Group was added, but no longer in there.
+                    if group not in set_groups:
+                        raise Exception("Not sure if this should even be a thing", group, set_groups)
+                        new_list.append((None, 'unset', group))
+
+            else:
+                new_list.append((domain, mode, group))
+
+        # Unset any remaining groups:
+        for group in reversed(set_groups):
+            new_list.append((None, 'unset', group))
+            for state in group.set_states:
+                set_states.remove(state)
+
+        # At this point all the set_states should be empty if correct.
+        # We don't need to clean up since it's local, but doing it for a sanity check. TODO: Move to test?
+        assert len(set_states) == 0, f"Leftover states were found. Optimization failed. States: {set_states}"
+
+        # print("---------", "States!", set_states)
+        # print("Test list groups", new_list)
+
+        draw_list = new_list
+
+        # Collapse draw calls into contiguous render calls.
+        for draw_domain, mode, group in draw_list:
+            # print("<<<<<<<<< start consolidation", group, draw_domain, mode)
+            # If the mode, domain are None, it's a group/parent with no draws.
+            # However, it still may have a state that needs setting.
+            if draw_domain is None:
+                if mode == 'set':
+                    draw_call_list.append(group.set_state)
+                    # test_draw_stuff.append([f"set state of {group}"])
+                elif mode == 'unset':
+                    if contiguous_groups:
+                        draw_call_list.append(
+                            (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
+
+                        # test_draw_stuff.extend([f"DRAW: {contiguous_groups}"])
+                        contiguous_groups = []
+
+                    draw_call_list.append(group.unset_state)
+                    # test_draw_stuff.extend([f"UNset state of {group}"])
+                continue
+
+            # If the domain or draw mode has changed, we need to break up the draw.
+            if last_domain is None or (draw_domain == last_domain and mode == last_mode):
+                # Check if the state of this group requires changing.
+                if last_domain is None:
+                    draw_call_list.append(draw_domain.bind)
+                contiguous_groups.append(group)
+            else:
+                # Previous domain/mode is not compatible with current.
+                draw_call_list.append(draw_domain.bind)
+                if contiguous_groups:
+                    # If we have contiguous groups, we need to now combine those
+                    draw_call_list.append(
+                        (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
+
+                    # test_draw_stuff.extend(["draw", contiguous_groups])
+
+                # Reset contiguous groups for share state checks.
+                contiguous_groups = [group]
+
+            last_mode = mode
+            last_domain = draw_domain
+
+        # Draw the remaining contiguous groups
+        if contiguous_groups:
+            # test_draw_stuff.extend(["draw", contiguous_groups])
+            draw_call_list.append(
+                (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
+
+        # print("**** Optimized list:\n", test_draw_stuff)
+
+        return draw_call_list
+
+    def _update_draw_list(self) -> None:
+        self._draw_list_dirty = False
+
+        draw_list = self._create_draw_list()
+
+        self._draw_list = self._optimize_draw_list(draw_list)
+
+        if _debug_graphics_batch:
+            self._dump_draw_list()
+
+        # print("FINAL", [f"{func!s}" for func in self._draw_list])
+
+        # print("GROUPS", draw_list)
+
+    def _dump_draw_list(self, regions: bool = False) -> None:
+        total_domains = 0
+
+        def dump(current_group: Group, indent: str = '') -> None:
+            nonlocal total_domains
+            print(indent, 'Begin group', current_group, f"(order: {current_group.order})")
+            current_domain_map = self.group_map[current_group]
+            total_domains += len(current_domain_map)
+            for current_domain in current_domain_map.values():
+                print(indent, '  ', current_domain)
+                for start, size in zip(*current_domain.allocator.get_allocated_regions()):
+                    print(indent, '    ',
+                          f'Region [start: {start}, size: {size}, groups: {len(current_domain.group_vertex_ranges)}]:')
+                    for key, buffer in current_domain.attrib_name_buffers.items():
+                        print(indent, '      ', end=' ')
+                        try:
+                            region = buffer.get_region(start, size)
+                            print(key, region.array[:])
+                        except Exception:
+                            print(key, '(unmappable)')
+                # for group, ranges in current_domain.group_vertex_ranges.items():
+                #     parent_info = f" (parent: {group.parent})" if group.parent else ""
+                #     print(indent, f'  Group {group}-{hex(id(group))}:{parent_info}')
+                #     if regions:
+                #         for range_start, range_size in ranges:
+                #             print(indent, f'    Start: {range_start}, Size: {range_size}')
+            for child in self.group_children.get(current_group, ()):
+                dump(child, indent + '  ')
+            print(indent, 'End group', current_group)
+
+        print(f'Draw list for {self!r}:')
+        for top_group in self.top_groups:
+            dump(top_group)
+        print(f'Total domains used: {total_domains}')
+        print(f'Total draw list: {len(self._draw_list)}')
+
+    def draw(self) -> None:
+        """Draw the batch."""
+        if self._draw_list_dirty:
+            self._update_draw_list()
+
+        for func in self._draw_list:
+            func()
+
+    def draw_subset(self, vertex_lists: Sequence[VertexList | IndexedVertexList]) -> None:
+        """Draw only some vertex lists in the batch.
+
+        The use of this method is highly discouraged, as it is quite
+        inefficient.  Usually an application can be redesigned so that batches
+        can always be drawn in their entirety, using `draw`.
+
+        The given vertex lists must belong to this batch; behaviour is
+        undefined if this condition is not met.
+
+        Args:
+            vertex_lists:
+                Vertex lists to draw.
+
+        """
+
+        # Horrendously inefficient.
+        def visit(group: Group) -> None:
+            group.set_state()
+
+            # Draw domains using this group
+            domain_map = self.group_map[group]
+            for (_, _, mode, _, _), domain in domain_map.items():
+                for alist in vertex_lists:
+                    if alist.domain is domain:
+                        alist.draw(mode)
+
+            # Sort and visit child groups of this group
+            children = self.group_children.get(group)
+            if children:
+                children.sort()
+                for child in children:
+                    if child.visible:
+                        visit(child)
+
+            group.unset_state()
+
+        self.top_groups.sort()
+        for top_group in self.top_groups:
+            if top_group.visible:
+                visit(top_group)
+
+
+class SortedGroup(pyglet.graphics.Group):
+    """Allows maintaining draw order of sprite list."""
+    _domain: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain | None
+
+    def __init__(self, order: int = 0, parent: pyglet.graphics.Group | None = None) -> None:  # noqa: D107
+        super().__init__(order, parent)
+        self._dirty = False
+        self._object_map = []
+        self._domain = None
+
+    def initialize(self) -> None:
+        self.set_states = [pyglet.graphics.GLState(self)]
+
+    def set_state(self) -> None:
+        if self._dirty:
+            for obj in self._object_map:
+                vlist: vertexdomain.VertexList | vertexdomain.IndexedVertexList = obj._vertex_list
+                self._domain.group_index_ranges[obj._group].remove((vlist.index_start, vlist.index_count))
+                self._domain.group_index_ranges[obj._group].append((vlist.index_start, vlist.index_count))
+                self._domain.group_vertex_ranges[obj._group].remove((vlist.start, vlist.count))
+                self._domain.group_vertex_ranges[obj._group].append((vlist.start, vlist.count))
+
+            self._dirty = False
+
+    def sort_objects(self, key: Callable) -> None:
+        sorted_objects = sorted(self._object_map, key=key)
+        if sorted_objects != self._object_map:
+            self._object_map = sorted_objects
+            self._dirty = True
+
+    def link_objects(self, pyglet_objects: list[Any]) -> None:
+        assert pyglet_objects, "No objects provided."
+        first_group = pyglet_objects[0]._group
+        self._domain = pyglet_objects[0]._vertex_list.domain
+        if not all(obj._group == first_group for obj in pyglet_objects):
+            raise Exception("All objects do not belong to the same group")
+
+        for pyglet_object in pyglet_objects:
+            assert pyglet_object.group == self, "The pyglet object does not belong in this group."
+
+            self._object_map.append(pyglet_object)
+
+        self._dirty = True
+
+    def __eq__(self, other):
+        return (self.__class__ is other.__class__ and
+                self._order == other.order and
+                self.parent == other.parent)
+
+    def __hash__(self) -> int:
+        """This is an immutable return to establish the permanent identity of the object.
+
+        This is used by Python with ``__eq__`` to determine if something is unique.
+
+        For simplicity, the hash should be a tuple containing your unique identifiers of your Group.
+
+        By default, this is (``order``, ``parent``).
+
+        :see: ``__eq__`` function, both must be implemented.
+        """
+        return hash((self._order, self.parent))

--- a/pyglet/experimental/graphics/vertexdomain.py
+++ b/pyglet/experimental/graphics/vertexdomain.py
@@ -23,7 +23,7 @@ primitives of the same OpenGL primitive mode.
 from __future__ import annotations
 
 import ctypes
-from typing import TYPE_CHECKING, Any, NoReturn, Sequence, Type
+from typing import TYPE_CHECKING, Any, Sequence, Type
 
 from _ctypes import Array, _Pointer, _SimpleCData
 
@@ -41,9 +41,7 @@ from pyglet.gl.gl import (
     GLsizei,
     GLvoid,
     glDrawArrays,
-    glDrawArraysInstanced,
     glDrawElements,
-    glDrawElementsInstanced,
     glMultiDrawArrays,
     glMultiDrawElements,
 )
@@ -116,7 +114,7 @@ class VertexList:
     """
     count: int
     start: int
-    domain: VertexDomain | InstancedVertexDomain
+    domain: VertexDomain
     indexed: bool = False
     instanced: bool = False
     initial_attribs: dict
@@ -158,30 +156,25 @@ class VertexList:
     def delete(self) -> None:
         """Delete this group."""
         self.domain.allocator.dealloc(self.start, self.count)
+        group = self.domain.group_vlists[self]
+        self.domain.group_vertex_ranges[group].remove((self.start, self.count))
+        del self.domain.group_vlists[self]
+        # if not self.domain.group_vertex_ranges[group]:
 
-    def set_instance_source(self, domain: InstancedVertexDomain, instance_attributes: Sequence[str]) -> None:
-        assert self.instanced is False, "Vertex list is already an instance."
-        assert list(domain.attribute_names.keys()) == list(self.domain.attribute_names.keys()), \
-            'Domain attributes must match.'
+    #     del self.domain.group_vertex_ranges[group]
 
-        new_start = domain.safe_alloc(self.count)
-        for key, current_buffer in self.domain.attrib_name_buffers.items():
-            new_buffer = domain.attrib_name_buffers[key]
-            old_data = current_buffer.get_region(self.start, self.count)
-            if key in instance_attributes:
-                attrib = domain.attribute_names[key]
-                count = 1
-                old_data = old_data[:attrib.count]
-            else:
-                count = self.count
-            new_buffer.set_region(new_start, count, old_data)
+    def update_group(self, group: Group):
+        current_group = self.domain.group_vlists[self]
+        assert current_group != group, "Changing group to same group."
+        self.domain.group_vertex_ranges[current_group].remove((self.start, self.count))
 
-        self.domain.allocator.dealloc(self.start, self.count)
-        self.domain = domain
-        self.start = new_start
-        self.instanced = True
+        # Set new group
+        self.domain.group_vlists[self] = group
+        if group not in self.domain.group_vertex_ranges:
+            self.domain.group_vertex_ranges[group] = []
+        self.domain.group_vertex_ranges[group].append((self.start, self.count))
 
-    def migrate(self, domain: VertexDomain | InstancedVertexDomain) -> None:
+    def migrate(self, domain: VertexDomain) -> None:
         """Move this group from its current domain and add to the specified one.
 
         Attributes on domains must match.
@@ -218,39 +211,13 @@ class VertexList:
             msg = f"Invalid data size for '{name}'. Expected {array_end - array_start}, got {len(data)}."
             raise ValueError(msg) from None
 
-    def add_instance(self, **kwargs: Any) -> VertexInstance:
-        assert self.instanced
-        self.domain._instances += 1  # noqa: SLF001
-
-        instance_id = self.domain._instances  # noqa: SLF001
-
-        start = self.domain.safe_alloc_instance(3)
-
-        for buffer, attribute in self.domain.buffer_attributes:
-            if attribute.instance:
-                assert attribute.name in kwargs, (f"{attribute.name} is defined as an instance attribute, "
-                                                  f"keyword argument not found.")
-                buffer.set_region(instance_id - 1, 1, kwargs[attribute.name])
-
-        return self.domain._vertexinstance_class(self, instance_id, start)  # noqa: SLF001
-
-    def delete_instance(self, instance: VertexInstance) -> None:
-        assert self.instanced
-        if instance.id != self.domain._instances:  # noqa: SLF001
-            msg = "Only the last instance added can be removed."
-            raise Exception(msg)
-
-        self.domain._instances -= 1  # noqa: SLF001
-
-        self.domain.instance_allocator.dealloc(instance.start, 3)
-
 
 class IndexedVertexList(VertexList):
     """A list of vertices within an :py:class:`IndexedVertexDomain` that are indexed.
 
     Use :py:meth:`IndexedVertexDomain.create` to construct this list.
     """
-    domain: IndexedVertexDomain | InstancedIndexedVertexDomain
+    domain: IndexedVertexDomain
     indexed: bool = True
 
     index_count: int
@@ -264,10 +231,24 @@ class IndexedVertexList(VertexList):
 
     def delete(self) -> None:
         """Delete this group."""
+        group = self.domain.group_vlists[self]
         super().delete()
         self.domain.index_allocator.dealloc(self.index_start, self.index_count)
 
-    def migrate(self, domain: IndexedVertexDomain | InstancedIndexedVertexDomain) -> None:
+        self.domain.group_index_ranges[group].remove((self.index_start, self.index_count))
+
+    def update_group(self, group: Group):
+        current_group = self.domain.group_vlists[self]
+        super().update_group(group)
+        self.domain.group_index_ranges[current_group].remove((self.index_start, self.index_count))
+
+        # Set new group
+        self.domain.group_vlists[self] = group
+        if group not in self.domain.group_index_ranges:
+            self.domain.group_index_ranges[group] = []
+        self.domain.group_index_ranges[group].append((self.index_start, self.index_count))
+
+    def migrate(self, domain: IndexedVertexDomain) -> None:
         """Move this group from its current indexed domain and add to the specified one.
 
         Attributes on domains must match.  (In practice, used
@@ -277,37 +258,12 @@ class IndexedVertexList(VertexList):
             domain:
                 Indexed domain to migrate this vertex list to.
         """
+        if domain == self.domain:
+            return
+
         old_start = self.start
         old_domain = self.domain
         super().migrate(domain)
-
-        # Note: this code renumber the indices of the *original* domain
-        # because the vertices are in a new position in the new domain
-        if old_start != self.start:
-            diff = self.start - old_start
-            old_indices = old_domain.index_buffer.get_region(self.index_start, self.index_count)
-            old_domain.index_buffer.set_region(self.index_start, self.index_count, [i + diff for i in old_indices])
-
-        # copy indices to new domain
-        old_array = old_domain.index_buffer.get_region(self.index_start, self.index_count)
-        # must delloc before calling safe_index_alloc or else problems when same
-        # batch is migrated to because index_start changes after dealloc
-        old_domain.index_allocator.dealloc(self.index_start, self.index_count)
-
-        new_start = self.domain.safe_index_alloc(self.index_count)
-        self.domain.index_buffer.set_region(new_start, self.index_count, old_array)
-
-        self.index_start = new_start
-
-    def set_instance_source(self, domain: IndexedVertexDomain | InstancedIndexedVertexDomain,
-                            instance_attributes: Sequence[str]) -> None:
-        assert self.instanced is False, "IndexedVertexList is already an instance."
-        old_start = self.start
-        old_domain = self.domain
-        super().set_instance_source(domain, instance_attributes)
-
-        assert list(domain.attribute_names.keys()) == list(self.domain.attribute_names.keys()), \
-            'Domain attributes must match.'
 
         # Note: this code renumber the indices of the *original* domain
         # because the vertices are in a new position in the new domain
@@ -337,23 +293,7 @@ class IndexedVertexList(VertexList):
         self.domain.index_buffer.set_region(self.index_start, self.index_count, data)
 
 
-class VertexInstance:
-    id: int
-    start: int
-    _vertex_list: VertexList | IndexedVertexList
-
-    def __init__(self, vertex_list: VertexList | IndexedVertexList, instance_id: int, start: int) -> None:
-        self.id = instance_id
-        self.start = start
-        self._vertex_list = vertex_list
-
-    @property
-    def domain(self) -> InstancedVertexDomain | InstancedIndexedVertexDomain:
-        return self._vertex_list.domain
-
-    def delete(self) -> None:
-        self._vertex_list.delete_instance(self)
-        self._vertex_list = None
+CULL_TIME = 10
 
 
 class VertexDomain:
@@ -383,6 +323,10 @@ class VertexDomain:
         self.attribute_names = {}  # name: attribute
         self.buffer_attributes = []  # list of (buffer, attribute)
         self.attrib_name_buffers = {}  # dict of AttributeName: AttributeBufferObject (for VertexLists)
+
+        # This maps groups to the specific start/size regions.
+        self.group_vertex_ranges = {}  # New attribute to store vertex ranges by group
+        self.group_vlists = {}
 
         self._property_dict = {}  # name: property(_getter, _setter)
 
@@ -442,18 +386,13 @@ class VertexDomain:
             return self.allocator.realloc(start, count, new_count)
 
     def create(self, count: int, group: Group, index_count: int) -> VertexList:  # noqa: ARG002
-        """Create a :py:class:`VertexList` in this domain.
-
-        Args:
-            count:
-                Number of vertices to create.
-            group:
-                The group in which the vertices will be rendered in for this domain.
-            index_count:
-                Ignored for non indexed VertexDomains
-        """
         start = self.safe_alloc(count)
-        return self._vertexlist_class(self, start, count)
+        vertex_list = self._vertexlist_class(self, start, count)
+        if group not in self.group_vertex_ranges:
+            self.group_vertex_ranges[group] = []
+        self.group_vertex_ranges[group].append((start, count))
+        self.group_vlists[vertex_list] = group
+        return vertex_list
 
     def draw(self, mode: int) -> None:
         """Draw all vertices in the domain.
@@ -471,6 +410,34 @@ class VertexDomain:
             buffer.commit()
 
         starts, sizes = self.allocator.get_allocated_regions()
+        primcount = len(starts)
+        if primcount == 0:
+            pass
+        elif primcount == 1:
+            # Common case
+            glDrawArrays(mode, starts[0], sizes[0])
+        else:
+            starts = (GLint * primcount)(*starts)
+            sizes = (GLsizei * primcount)(*sizes)
+            glMultiDrawArrays(mode, starts, sizes, primcount)
+
+    def draw_groups(self, mode: int, groups: list[Group]) -> None:
+        """Draw all vertices associated with the specified groups.
+
+        Args:
+            mode:
+                OpenGL drawing mode, e.g., ``GL_POINTS``, ``GL_LINES``, etc.
+            groups:
+                The groups whose vertices should be drawn.
+        """
+        combined = []
+        for group in groups:
+            combined.extend(self.group_vertex_ranges[group])
+
+        if not combined:
+            return
+
+        starts, sizes = zip(*combined)
         primcount = len(starts)
         if primcount == 0:
             pass
@@ -503,130 +470,14 @@ class VertexDomain:
 
     @property
     def is_empty(self) -> bool:
-        return not self.allocator.starts
+        return not self.allocator.starts and not self.group_vertex_ranges
+
+    @property
+    def has_vertices(self) -> bool:
+        return all(not values for values in self.group_vertex_ranges.values())
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}@{id(self):x} {self.allocator}>'
-
-
-def _make_instance_attribute_property(name: str) -> property:
-    def _attribute_getter(self: VertexInstance) -> Array[CTypesDataType]:
-        buffer = self.domain.attrib_name_buffers[name]
-        region = buffer.get_region(self.id - 1, 1)
-        buffer.invalidate_region(self.id - 1, 1)
-        return region
-
-    def _attribute_setter(self: VertexInstance, data: Any) -> None:
-        buffer = self.domain.attrib_name_buffers[name]
-        buffer.set_region(self.id - 1, 1, data)
-
-    return property(_attribute_getter, _attribute_setter)
-
-
-def _make_restricted_instance_attribute_property(name: str) -> property:
-    def _attribute_getter(self: VertexInstance) -> Array[CTypesDataType]:
-        buffer = self.domain.attrib_name_buffers[name]
-        return buffer.get_region(self.id - 1, 1)
-
-    def _attribute_setter(_self: VertexInstance, _data: Any) -> NoReturn:
-        msg = f"Attribute '{name}' is not an instanced attribute."
-        raise Exception(msg)
-
-    return property(_attribute_getter, _attribute_setter)
-
-
-class InstancedVertexDomain(VertexDomain):  # noqa: D101
-    instance_allocator: Allocator
-    _instances: int
-    _instance_properties: dict[str, property]
-    _vertexinstance_class: type
-
-    def __init__(self, attribute_meta: dict[str, dict[str, Any]]) -> None:
-        super().__init__(attribute_meta)
-        self._instances = 1
-        self.instance_allocator = allocation.Allocator(self._initial_count)
-
-        self._instance_properties = {}
-        for name, attribute in self.attribute_names.items():
-            if attribute.instance:
-                self._instance_properties[name] = _make_instance_attribute_property(name)
-            else:
-                self._instance_properties[name] = _make_restricted_instance_attribute_property(name)
-
-        self._vertexinstance_class = type('VertexInstance', (VertexInstance,), self._instance_properties)
-
-    def safe_alloc_instance(self, count: int) -> int:
-        try:
-            return self.instance_allocator.alloc(count)
-        except allocation.AllocatorMemoryException as e:
-            capacity = _nearest_pow2(e.requested_capacity)
-            for buffer, attribute in self.buffer_attributes:
-                if attribute.instance:
-                    buffer.resize(capacity * buffer.stride)
-            self.instance_allocator.set_capacity(capacity)
-            return self.instance_allocator.alloc(count)
-
-    def safe_alloc(self, count: int) -> int:
-        """Allocate vertices, resizing the buffers if necessary."""
-        try:
-            return self.allocator.alloc(count)
-        except allocation.AllocatorMemoryException as e:
-            capacity = _nearest_pow2(e.requested_capacity)
-            for buffer, _ in self.buffer_attributes:
-                buffer.resize(capacity * buffer.stride)
-            self.allocator.set_capacity(capacity)
-            return self.allocator.alloc(count)
-
-    def safe_realloc(self, start: int, count: int, new_count: int) -> int:
-        """Reallocate vertices, resizing the buffers if necessary."""
-        try:
-            return self.allocator.realloc(start, count, new_count)
-        except allocation.AllocatorMemoryException as e:
-            capacity = _nearest_pow2(e.requested_capacity)
-            for buffer, _ in self.buffer_attributes:
-                buffer.resize(capacity * buffer.stride)
-            self.allocator.set_capacity(capacity)
-            return self.allocator.realloc(start, count, new_count)
-
-    def draw(self, mode: int) -> None:
-        """Draw all vertices in the domain.
-
-        All vertices in the domain are drawn at once. This is the
-        most efficient way to render primitives.
-
-        Args:
-            mode:
-                OpenGL drawing mode, e.g. ``GL_POINTS``, ``GL_LINES``, etc.
-
-        """
-        self.vao.bind()
-        for buffer, _ in self.buffer_attributes:
-            buffer.commit()
-
-        starts, sizes = self.allocator.get_allocated_regions()
-        glDrawArraysInstanced(mode, starts[0], sizes[0], self._instances)
-
-    def draw_subset(self, mode: int, vertex_list: VertexList) -> None:
-        """Draw a specific VertexList in the domain.
-
-        The `vertex_list` parameter specifies a :py:class:`VertexList`
-        to draw. Only primitives in that list will be drawn.
-
-        Args:
-            mode:
-                OpenGL drawing mode, e.g. ``GL_POINTS``, ``GL_LINES``, etc.
-            vertex_list:
-                Vertex list to draw.
-        """
-        self.vao.bind()
-        for buffer, _ in self.buffer_attributes:
-            buffer.commit()
-
-        glDrawArraysInstanced(mode, vertex_list.start, vertex_list.count, self._instances)
-
-    @property
-    def is_empty(self) -> bool:
-        return not self.allocator.starts
 
 
 class IndexedVertexDomain(VertexDomain):
@@ -664,6 +515,8 @@ class IndexedVertexDomain(VertexDomain):
         # Make a custom VertexList class w/ properties for each attribute in the ShaderProgram:
         self._vertexlist_class = type(self._vertex_class.__name__, (self._vertex_class,),
                                       self._property_dict)
+        # Dictionary to store index ranges by group
+        self.group_index_ranges = {}
 
     def safe_index_alloc(self, count: int) -> int:
         """Allocate indices, resizing the buffers if necessary."""
@@ -685,21 +538,30 @@ class IndexedVertexDomain(VertexDomain):
             self.index_allocator.set_capacity(capacity)
             return self.index_allocator.realloc(start, count, new_count)
 
-    def create(self, count: int, group: Group, index_count: int) -> IndexedVertexList:  # noqa: ARG002
+    def create(self, count: int, group: Group, index_count: int) -> IndexedVertexList:
         """Create an :py:class:`IndexedVertexList` in this domain.
 
         Args:
             count:
                 Number of vertices to create
-            group:
-                The group in which the vertices will be rendered in for this domain.
             index_count:
                 Number of indices to create
-
+            group:
+                The group to which this vertex list belongs
         """
         start = self.safe_alloc(count)
         index_start = self.safe_index_alloc(index_count)
-        return self._vertexlist_class(self, start, count, index_start, index_count)
+
+        vertex_list = self._vertexlist_class(self, start, count, index_start, index_count)
+        if group not in self.group_vertex_ranges:
+            self.group_vertex_ranges[group] = []
+        if group not in self.group_index_ranges:
+            self.group_index_ranges[group] = []
+        self.group_vertex_ranges[group].append((start, count))
+        self.group_index_ranges[group].append((index_start, index_count))
+        self.group_vlists[vertex_list] = group
+
+        return vertex_list
 
     def draw(self, mode: int) -> None:
         """Draw all vertices in the domain.
@@ -719,6 +581,51 @@ class IndexedVertexDomain(VertexDomain):
         self.index_buffer.commit()
 
         starts, sizes = self.index_allocator.get_allocated_regions()
+
+        primcount = len(starts)
+        if primcount == 0:
+            pass
+        elif primcount == 1:
+            # Common case
+            glDrawElements(mode, sizes[0], self.index_gl_type,
+                           self.index_buffer.ptr + starts[0] * self.index_element_size)
+        else:
+            starts = [s * self.index_element_size + self.index_buffer.ptr for s in starts]
+            starts = (ctypes.POINTER(GLvoid) * primcount)(*(GLintptr * primcount)(*starts))
+            sizes = (GLsizei * primcount)(*sizes)
+            glMultiDrawElements(mode, sizes, self.index_gl_type, starts, primcount)
+
+    def bind(self) -> None:
+        """Bind the domain.
+
+        This binds the VAO and all of its buffers.
+        """
+        self.vao.bind()
+
+        for buffer, _ in self.buffer_attributes:
+            buffer.commit()
+
+        self.index_buffer.commit()
+
+    def draw_groups(self, mode: int, groups: list[Group]) -> None:
+        """Draw all vertices associated with the specified groups.
+
+        This relies on the optimization of the batch call to set the state of the groups.
+
+        Args:
+            mode:
+                OpenGL drawing mode, e.g., ``GL_POINTS``, ``GL_LINES``, etc.
+            groups:
+                The groups whose vertices should be drawn.
+        """
+        combined = []
+        for group in groups:
+            combined.extend(self.group_index_ranges[group])
+
+        if not combined:
+            return
+
+        starts, sizes = zip(*combined)
         primcount = len(starts)
         if primcount == 0:
             pass
@@ -754,93 +661,6 @@ class IndexedVertexDomain(VertexDomain):
                        self.index_buffer.ptr +
                        vertex_list.index_start * self.index_element_size)
 
-
-class InstancedIndexedVertexDomain(IndexedVertexDomain, InstancedVertexDomain):
-    """Management of a set of indexed vertex lists.
-
-    Construction of an indexed vertex domain is usually done with the
-    :py:func:`create_domain` function.
-    """
-    _initial_index_count: int = 16
-
-    def __init__(self, attribute_meta: dict[str, dict[str, Any]],  # noqa: D107
-                 index_gl_type: int = GL_UNSIGNED_INT) -> None:
-        super().__init__(attribute_meta, index_gl_type)
-
-    def safe_index_alloc(self, count: int) -> int:
-        """Allocate indices, resizing the buffers if necessary.
-
-        Returns:
-            The starting index of the allocated region.
-        """
-        try:
-            return self.index_allocator.alloc(count)
-        except allocation.AllocatorMemoryException as e:
-            capacity = _nearest_pow2(e.requested_capacity)
-            self.index_buffer.resize(capacity * self.index_element_size)
-            self.index_allocator.set_capacity(capacity)
-            return self.index_allocator.alloc(count)
-
-    def safe_index_realloc(self, start: int, count: int, new_count: int) -> int:
-        """Reallocate indices, resizing the buffers if necessary."""
-        try:
-            return self.index_allocator.realloc(start, count, new_count)
-        except allocation.AllocatorMemoryException as e:
-            capacity = _nearest_pow2(e.requested_capacity)
-            self.index_buffer.resize(capacity * self.index_element_size)
-            self.index_allocator.set_capacity(capacity)
-            return self.index_allocator.realloc(start, count, new_count)
-
-    def create(self, count: int, index_count: int) -> IndexedVertexList:
-        """Create an :py:class:`IndexedVertexList` in this domain.
-
-        Args:
-            count:
-                Number of vertices to create
-            index_count:
-                Number of indices to create
-
-        """
-        start = self.safe_alloc(count)
-        index_start = self.safe_index_alloc(index_count)
-        return self._vertexlist_class(self, start, count, index_start, index_count)
-
-    def draw(self, mode: int) -> None:
-        """Draw all vertices in the domain.
-
-        All vertices in the domain are drawn at once. This is the
-        most efficient way to render primitives.
-
-        Args:
-            mode:
-                OpenGL drawing mode, e.g. ``GL_POINTS``, ``GL_LINES``, etc.
-
-        """
-        self.vao.bind()
-        for buffer, _ in self.buffer_attributes:
-            buffer.commit()
-
-        starts, sizes = self.index_allocator.get_allocated_regions()
-        glDrawElementsInstanced(mode, sizes[0], self.index_gl_type,
-                                self.index_buffer.ptr + starts[0] * self.index_element_size, self._instances)
-
-    def draw_subset(self, mode: int, vertex_list: IndexedVertexList) -> None:
-        """Draw a specific IndexedVertexList in the domain.
-
-        The ``vertex_list`` parameter specifies a :py:class:`IndexedVertexList`
-        to draw. Only primitives in that list will be drawn.
-
-        Args:
-            mode:
-                OpenGL drawing mode, e.g. ``GL_POINTS``, ``GL_LINES``, etc.
-            vertex_list:
-                Vertex list to draw.
-
-        """
-        self.vao.bind()
-        for buffer, _ in self.buffer_attributes:
-            buffer.commit()
-
-        glDrawElementsInstanced(mode, vertex_list.index_count, self.index_gl_type,
-                                self.index_buffer.ptr +
-                                vertex_list.index_start * self.index_element_size, self._instances)
+    @property
+    def has_vertices(self) -> bool:
+        return all(not values for values in self.group_index_ranges.values())

--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import ctypes
 import weakref
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Sequence, Tuple
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Sequence, Tuple, Union
 
 import pyglet
 from pyglet.gl.gl import (
@@ -233,6 +234,7 @@ _blit_fragment_source: str = """#version 330 core
     }
 """
 
+
 def get_default_batch() -> Batch:
     """Batch used globally for objects that have no Batch specified."""
     try:
@@ -253,6 +255,7 @@ def get_default_shader() -> ShaderProgram:
         pyglet.gl.current_context.object_space.pyglet_graphics_default_shader = _shader_program
         return pyglet.gl.current_context.object_space.pyglet_graphics_default_shader
 
+
 def get_default_blit_shader() -> ShaderProgram:
     """A default basic shader for blitting, provides no blending."""
     try:
@@ -264,6 +267,7 @@ def get_default_blit_shader() -> ShaderProgram:
         pyglet.gl.current_context.object_space.pyglet_graphics_default_blit_shader = _shader_program
         return pyglet.gl.current_context.object_space.pyglet_graphics_default_blit_shader
 
+
 _domain_class_map: dict[tuple[bool, bool], type[vertexdomain.VertexDomain]] = {
     # Indexed, Instanced : Domain
     (False, False): vertexdomain.VertexDomain,
@@ -273,6 +277,7 @@ _domain_class_map: dict[tuple[bool, bool], type[vertexdomain.VertexDomain]] = {
 }
 
 DomainKey = Tuple[bool, int, int, str]
+
 
 class Batch:
     """Manage a collection of drawables for batched rendering.
@@ -305,6 +310,7 @@ class Batch:
     top_groups: list[Group]
     group_children: dict[Group, list[Group]]
     group_map: dict[Group, dict[DomainKey, vertexdomain.VertexDomain]]
+    domain_map: dict[DomainKey: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain]
 
     def __init__(self) -> None:
         """Create a graphics batch."""
@@ -315,6 +321,9 @@ class Batch:
         # Mapping of group to list of children.
         self.group_children = {}
 
+        # All domains associated with the batch..
+        self.domain_map = {}
+
         # List of top-level groups
         self.top_groups = []
 
@@ -324,6 +333,8 @@ class Batch:
         self._context = pyglet.gl.current_context
 
         self._instance_count = 0
+
+        self.current_states = []
 
     def invalidate(self) -> None:
         """Force the batch to update the draw list.
@@ -400,7 +411,16 @@ class Batch:
         """
         attributes = vertex_list.domain.attribute_meta
         domain = batch.get_domain(vertex_list.indexed, vertex_list.instanced, mode, group, attributes)
-        vertex_list.migrate(domain)
+
+        # If it's the same domain, no need to dealloc it...
+        if domain != vertex_list.domain:
+            vertex_list.migrate(domain)
+        else:
+            # Update the group.
+            vertex_list.update_group(group)
+
+            # Updating group can potentially change draw order.
+            self._draw_list_dirty = True
 
     def _convert_to_instanced(self, domain: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain,
                               instance_attributes: Sequence[
@@ -428,36 +448,30 @@ class Batch:
                    attributes: dict[str, Any]) -> (
             vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain | vertexdomain.InstancedVertexDomain |
             vertexdomain.InstancedIndexedVertexDomain):
-        """Get, or create, the vertex domain corresponding to the given arguments.
+        """Get, or create, the vertex domain corresponding to the given arguments."""
+        key = (indexed, instanced, mode, str(attributes))
 
-        mode is the render mode such as GL_LINES or GL_TRIANGLES
-        """
-        # Batch group
+        # Check for existing domain
+        if key in self.domain_map:
+            domain = self.domain_map[key]
+        else:
+            # Create a new domain if none exists
+            domain = _domain_class_map[(indexed, instanced)](attributes)
+            self.domain_map[key] = domain
+            self._draw_list_dirty = True
+
+        # Ensure the group association is kept.
         if group not in self.group_map:
             self._add_group(group)
 
         domain_map = self.group_map[group]
-
-        # If instanced, ensure a separate domain, as multiple instance sources can match the key.
-        if instanced:
-            self._instance_count += 1
-            key = (indexed, self._instance_count, mode, str(attributes))
-        else:
-            # Find domain given formats, indices and mode
-            key = (indexed, 0, mode, str(attributes))
-
-        try:
-            domain = domain_map[key]
-        except KeyError:
-            # Create domain
-            domain = _domain_class_map[(indexed, instanced)](attributes)
-            domain_map[key] = domain
-            self._draw_list_dirty = True
+        domain_map[key] = domain
 
         return domain
 
     def _add_group(self, group: Group) -> None:
-        self.group_map[group] = {}
+        if group not in self.group_map:
+            self.group_map[group] = {}
         if group.parent is None:
             self.top_groups.append(group)
         else:
@@ -470,25 +484,52 @@ class Batch:
         group._assigned_batches.add(self)  # noqa: SLF001
         self._draw_list_dirty = True
 
-    def _update_draw_list(self) -> None:
-        """Visit group tree in preorder and create a list of bound methods to call."""
+    def _check_gl_state(self, group: Group) -> bool:
+        """Return if the group state needs updating."""
+        return any(gl_state not in self.current_states for gl_state in group.set_states)
 
-        def visit(group: Group) -> list:
+    def pop_states(self, group: Group) -> None:
+        for state in group.set_states:
+            if state in self.current_states:
+                self.current_states.remove(state)
+
+    def add_states(self, group: Group) -> bool:
+        requires_change = False
+        for state in group.set_states:
+            if state not in self.current_states:
+                self.current_states.append(state)
+                requires_change = True
+
+        return requires_change
+
+    def _create_draw_list(self) -> list:
+        #print("-----------")
+
+        def visit(current_group: Group) -> list:
             draw_list = []
 
             # Draw domains using this group
-            domain_map = self.group_map[group]
+            domain_map = self.group_map.get(current_group, {})
 
-            # indexed, instanced, mode, program, str(attributes))
-            for (indexed, instanced, mode, formats), domain in list(domain_map.items()):
+            # Iterate over the domains associated with the current group
+            for (indexed, instanced, mode, formats), current_domain in list(domain_map.items()):
                 # Remove unused domains from batch
-                if domain.is_empty:
+                if current_domain.is_empty:
                     del domain_map[(indexed, instanced, mode, formats)]
                     continue
-                draw_list.append((lambda d, m: lambda: d.draw(m))(domain, mode))  # noqa: PLC3002
+
+                # If this group exists, has no vertices in the domain, skip it.
+                if current_group in current_domain.group_vertex_ranges:
+                    if not current_domain.group_vertex_ranges[current_group]:
+                        continue
+                else:
+                    continue
+
+                # If group exists, and has vertices, add a draw call.
+                draw_list.append((current_domain, mode, current_group))
 
             # Sort and visit child groups of this group
-            children = self.group_children.get(group)
+            children = self.group_children.get(current_group)
             if children:
                 children.sort()
                 for child in list(children):
@@ -496,58 +537,248 @@ class Batch:
                         draw_list.extend(visit(child))
 
             if children or domain_map:
-                return [group.set_state, *draw_list, group.unset_state]
+                # if not domain_map:
+                #     return [(None, 'set', current_group), *draw_list, (None, 'unset', current_group)]
+                #
+                # return draw_list
+                return [(None, 'set', current_group), *draw_list, (None, 'unset', current_group)]
 
+            # Clean up if the group is empty and has no children
             # Remove unused group from batch
-            del self.group_map[group]
-            group._assigned_batches.remove(self)  # noqa: SLF001
-            if group.parent:
-                self.group_children[group.parent].remove(group)
+            del self.group_map[current_group]
+            current_group._assigned_batches.remove(self)  # noqa: SLF001
+            if current_group.parent:
+                self.group_children[current_group.parent].remove(current_group)
             try:
-                del self.group_children[group]
+                del self.group_children[current_group]
             except KeyError:
                 pass
             try:
-                self.top_groups.remove(group)
+                self.top_groups.remove(current_group)
             except ValueError:
                 pass
 
             return []
 
-        self._draw_list = []
+        full_draw_list = []
 
         self.top_groups.sort()
+
         for top_group in list(self.top_groups):
             if top_group.visible:
-                self._draw_list.extend(visit(top_group))
+                full_draw_list.extend(visit(top_group))
 
+        return full_draw_list
+
+    def _optimize_draw_list(self, draw_list: list) -> list[Callable]:
+        draw_call_list = []
+        contiguous_groups = []
+        last_mode = None
+        last_domain = None
+        #print("draw list to optimize:", draw_list)
+        #print("======")
+
+        set_states = []
+        set_groups = []
+        #test_draw_stuff = []
+
+        # Iterate through all calls to condense group calls.
+
+        # Draw calls should be: bind vao -> state -> draw -> unset_state
+        new_list = []
+        was_added = []
+
+        # Used to determine if a group is allowed to be unset. 'unset' is a marker for this.
+        ready_to_unset = set()
+
+        for domain, mode, group in draw_list:
+            #print("----START", domain, mode, group)
+            # Data: Group if no domain. If domain, mode.
+            if not domain:
+                # Mode is set/unset literal when domain is None
+                if mode == 'set':
+                    # If the state is already set or doesn't have states. Continue.
+                    if not group.set_states or group in set_groups:
+                        continue
+
+                    state_added = False
+
+                    # Check if any states in this group need to be added.
+                    for gl_state in group.set_states:
+                        if gl_state not in set_states:
+                            state_added = True
+
+                    # A new state needs to be added.
+                    if state_added:
+                        # Add all the new states.
+                        set_states.extend(group.set_states)
+                        #print("group set state:", group)
+                        #print("group states", group.set_states)
+                        #print("current states", set_states)
+                        #print("old states", old_states)
+                        groups_to_unset = []
+                        # If the state gets added, check if the previous set group states needs to be unset.
+                        for set_group in set_groups:
+                            #print("CHECK GROUP", set_group)
+                            for gl_state in set_group.set_states:
+                                # If a previously set group state is not in any of the new ones, unset those.
+                                if gl_state not in group.set_states:
+                                    #print(gl_state, group.set_states)
+                                    if set_group not in groups_to_unset and set_group in ready_to_unset:
+                                        groups_to_unset.append(set_group)
+
+                        for remove_group in reversed(groups_to_unset):
+                            #print("-removing group", remove_group)
+                            set_groups.remove(remove_group)
+                            ready_to_unset.remove(remove_group)
+                            new_list.append((None, 'unset', remove_group))
+                            for gl_state in remove_group.set_states:
+                                #print("Removing state", gl_state)
+                                set_states.remove(gl_state)
+
+                        #print("Groups removed", groups_to_unset)
+
+                        #print("States after", set_states)
+                        #print("State count after", len(set_states), len(group.set_states), len(set_states) == len(group.set_states))
+
+                        set_groups.append(group)
+                        was_added.append(group)
+                        new_list.append((None, 'set', group))
+                        #print("set groups total:", set_groups)
+                    else:
+                        print("State was not added.", group, group.set_states)
+
+                elif mode == 'unset':
+                    ready_to_unset.add(group)
+
+                    if not group.set_states or group not in was_added:
+                        continue
+
+                    # Group was added, but no longer in there.
+                    if group not in set_groups:
+                        raise Exception("Not sure if this should even be a thing", group, set_groups)
+                        new_list.append((None, 'unset', group))
+
+            else:
+                new_list.append((domain, mode, group))
+
+        # Unset any remaining groups:
+        for group in reversed(set_groups):
+            new_list.append((None, 'unset', group))
+            for state in group.set_states:
+                set_states.remove(state)
+
+        # At this point all the set_states should be empty if correct.
+        # We don't need to clean up since it's local, but doing it for a sanity check. TODO: Move to test?
+        assert len(set_states) == 0, f"Leftover states were found. Optimization failed. States: {set_states}"
+
+        #print("---------", "States!", set_states)
+        #print("Test list groups", new_list)
+
+        draw_list = new_list
+
+        # Collapse draw calls into contiguous render calls.
+        for draw_domain, mode, group in draw_list:
+            #print("<<<<<<<<< start consolidation", group, draw_domain, mode)
+            # If the mode, domain are None, it's a group/parent with no draws.
+            # However, it still may have a state that needs setting.
+            if draw_domain is None:
+                if mode == 'set':
+                    draw_call_list.append(group.set_state)
+                    #test_draw_stuff.append([f"set state of {group}"])
+                elif mode == 'unset':
+                    if contiguous_groups:
+                        draw_call_list.append(
+                            (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
+
+                        #test_draw_stuff.extend([f"DRAW: {contiguous_groups}"])
+                        contiguous_groups = []
+
+                    draw_call_list.append(group.unset_state)
+                    #test_draw_stuff.extend([f"UNset state of {group}"])
+                continue
+
+            # If the domain or draw mode has changed, we need to break up the draw.
+            if last_domain is None or (draw_domain == last_domain and mode == last_mode):
+                # Check if the state of this group requires changing.
+                if last_domain is None:
+                    draw_call_list.append(draw_domain.bind)
+                contiguous_groups.append(group)
+            else:
+                # Previous domain/mode is not compatible with current.
+                draw_call_list.append(draw_domain.bind)
+                if contiguous_groups:
+                    # If we have contiguous groups, we need to now combine those
+                    draw_call_list.append(
+                        (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
+
+                    #test_draw_stuff.extend(["draw", contiguous_groups])
+
+                # Reset contiguous groups for share state checks.
+                contiguous_groups = [group]
+
+            last_mode = mode
+            last_domain = draw_domain
+
+        # Draw the remaining contiguous groups
+        if contiguous_groups:
+            #test_draw_stuff.extend(["draw", contiguous_groups])
+            draw_call_list.append(
+                (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
+
+        #print("**** Optimized list:\n", test_draw_stuff)
+
+        return draw_call_list
+
+    def _update_draw_list(self) -> None:
         self._draw_list_dirty = False
+
+        draw_list = self._create_draw_list()
+
+        self._draw_list = self._optimize_draw_list(draw_list)
 
         if _debug_graphics_batch:
             self._dump_draw_list()
 
-    def _dump_draw_list(self) -> None:
-        def dump(group: Group, indent: str = '') -> None:
-            print(indent, 'Begin group', group)
-            domain_map = self.group_map[group]
-            for domain in domain_map.values():
-                print(indent, '  ', domain)
-                for start, size in zip(*domain.allocator.get_allocated_regions()):
-                    print(indent, '    ', 'Region %d size %d:' % (start, size))
-                    for key, buffer in domain.attrib_name_buffers.items():
+        #print("FINAL", [f"{func!s}" for func in self._draw_list])
+
+        #print("GROUPS", draw_list)
+
+    def _dump_draw_list(self, regions: bool = False) -> None:
+        total_domains = 0
+
+        def dump(current_group: Group, indent: str = '') -> None:
+            nonlocal total_domains
+            print(indent, 'Begin group', current_group, f"(order: {current_group.order})")
+            current_domain_map = self.group_map[current_group]
+            total_domains += len(current_domain_map)
+            for current_domain in current_domain_map.values():
+                print(indent, '  ', current_domain)
+                for start, size in zip(*current_domain.allocator.get_allocated_regions()):
+                    print(indent, '    ',
+                          f'Region [start: {start}, size: {size}, groups: {len(current_domain.group_vertex_ranges)}]:')
+                    for key, buffer in current_domain.attrib_name_buffers.items():
                         print(indent, '      ', end=' ')
                         try:
                             region = buffer.get_region(start, size)
                             print(key, region.array[:])
-                        except:  # noqa: E722
+                        except Exception:
                             print(key, '(unmappable)')
-            for child in self.group_children.get(group, ()):
+                # for group, ranges in current_domain.group_vertex_ranges.items():
+                #     parent_info = f" (parent: {group.parent})" if group.parent else ""
+                #     print(indent, f'  Group {group}-{hex(id(group))}:{parent_info}')
+                #     if regions:
+                #         for range_start, range_size in ranges:
+                #             print(indent, f'    Start: {range_start}, Size: {range_size}')
+            for child in self.group_children.get(current_group, ()):
                 dump(child, indent + '  ')
-            print(indent, 'End group', group)
+            print(indent, 'End group', current_group)
 
         print(f'Draw list for {self!r}:')
-        for group in self.top_groups:
-            dump(group)
+        for top_group in self.top_groups:
+            dump(top_group)
+        print(f'Total domains used: {total_domains}')
+        print(f'Total draw list: {len(self._draw_list)}')
 
     def draw(self) -> None:
         """Draw the batch."""
@@ -600,6 +831,12 @@ class Batch:
                 visit(top_group)
 
 
+@dataclass(slots=True)
+class GLState:  # noqa: D101
+    func: Callable | Any
+    args: tuple = ()
+
+
 class Group:
     """Group of common OpenGL state.
 
@@ -637,6 +874,12 @@ class Group:
         self.parent = parent
         self._visible = True
         self._assigned_batches = weakref.WeakSet()
+        self.set_states = []
+        self.unset_states = []
+        self.initialize()
+
+    def initialize(self) -> None:
+        """Assign any states to set_states and unset_states."""
 
     @property
     def order(self) -> int:
@@ -700,6 +943,27 @@ class Group:
         """
         return hash((self._order, self.parent))
 
+    def contiguous_same(self, other: Group) -> bool:
+        """Determines if Group state can be merged with those in the same domain with the same parent.
+
+        For example:
+            group0 = Group(0)
+            group1 = Group(1)
+            image = one_image
+            a = Sprite(image, ..., group=group0)
+            b = Sprite(image, ..., group=group1)
+
+        In this pseudocode scenario, both sprites have the same internal group, but different parental groups.
+        Normally this means each group must set/unset each of their states before drawing one by one.
+        However, the internal SpriteGroup is the same between both, the states are essentially the same without the
+        parent. This allows the child states to be merged and drawn with setting just one state..
+
+        Essentially this means we need to check if this Group has the same state as destination group without the
+        parent.
+        """
+        #return False
+        return self.__class__ is other.__class__
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(order={self._order})"
 
@@ -734,6 +998,69 @@ class Group:
         self.unset_state()
         if self.parent:
             self.parent.unset_state_recursive()
+
+
+class SortedGroup(Group):
+    """Allows maintaining draw order of sprite list."""
+    _domain: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain | None
+
+    def __init__(self, order: int = 0, parent: Group | None = None) -> None:
+        super().__init__(order, parent)
+        self._dirty = False
+        self._object_map = []
+        self._domain = None
+
+    def has_state(self):
+        return True
+
+    def set_state(self):
+        if self._dirty:
+            for obj in self._object_map:
+                vlist: vertexdomain.VertexList | vertexdomain.IndexedVertexList = obj._vertex_list
+                self._domain.group_index_ranges[obj._group].remove((vlist.index_start, vlist.index_count))
+                self._domain.group_index_ranges[obj._group].append((vlist.index_start, vlist.index_count))
+                self._domain.group_vertex_ranges[obj._group].remove((vlist.start, vlist.count))
+                self._domain.group_vertex_ranges[obj._group].append((vlist.start, vlist.count))
+
+            self._dirty = False
+
+    def sort_objects(self, key: Callable):
+        sorted_objects = sorted(self._object_map, key=key)
+        if sorted_objects != self._object_map:
+            self._object_map = sorted_objects
+            self._dirty = True
+
+    def link_objects(self, pyglet_objects: list[Any]):
+        assert pyglet_objects, "No objects provided."
+        first_group = pyglet_objects[0]._group
+        self._domain = pyglet_objects[0]._vertex_list.domain
+        if not all(obj._group == first_group for obj in pyglet_objects):
+            raise Exception("All objects do not belong to the same group")
+
+        for pyglet_object in pyglet_objects:
+            assert pyglet_object.group == self, "The pyglet object does not belong in this group."
+
+            self._object_map.append(pyglet_object)
+
+        self._dirty = True
+
+    def __eq__(self, other):
+        return (self.__class__ is other.__class__ and
+                self._order == other.order and
+                self.parent == other.parent)
+
+    def __hash__(self) -> int:
+        """This is an immutable return to establish the permanent identity of the object.
+
+        This is used by Python with ``__eq__`` to determine if something is unique.
+
+        For simplicity, the hash should be a tuple containing your unique identifiers of your Group.
+
+        By default, this is (``order``, ``parent``).
+
+        :see: ``__eq__`` function, both must be implemented.
+        """
+        return hash((self._order, self.parent))
 
 
 # Example Groups.

--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -605,7 +605,7 @@ class Batch:
                 visit(top_group)
 
 
-@dataclass(slots=True)
+@dataclass
 class GLState:  # noqa: D101
     func: Union[Callable, Any]  # noqa: UP007
     args: tuple = ()

--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -310,7 +310,6 @@ class Batch:
     top_groups: list[Group]
     group_children: dict[Group, list[Group]]
     group_map: dict[Group, dict[DomainKey, vertexdomain.VertexDomain]]
-    domain_map: dict[DomainKey: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain]
 
     def __init__(self) -> None:
         """Create a graphics batch."""
@@ -321,9 +320,6 @@ class Batch:
         # Mapping of group to list of children.
         self.group_children = {}
 
-        # All domains associated with the batch..
-        self.domain_map = {}
-
         # List of top-level groups
         self.top_groups = []
 
@@ -333,8 +329,6 @@ class Batch:
         self._context = pyglet.gl.current_context
 
         self._instance_count = 0
-
-        self.current_states = []
 
     def invalidate(self) -> None:
         """Force the batch to update the draw list.
@@ -411,16 +405,7 @@ class Batch:
         """
         attributes = vertex_list.domain.attribute_meta
         domain = batch.get_domain(vertex_list.indexed, vertex_list.instanced, mode, group, attributes)
-
-        # If it's the same domain, no need to dealloc it...
-        if domain != vertex_list.domain:
-            vertex_list.migrate(domain)
-        else:
-            # Update the group.
-            vertex_list.update_group(group)
-
-            # Updating group can potentially change draw order.
-            self._draw_list_dirty = True
+        vertex_list.migrate(domain)
 
     def _convert_to_instanced(self, domain: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain,
                               instance_attributes: Sequence[
@@ -448,30 +433,36 @@ class Batch:
                    attributes: dict[str, Any]) -> (
             vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain | vertexdomain.InstancedVertexDomain |
             vertexdomain.InstancedIndexedVertexDomain):
-        """Get, or create, the vertex domain corresponding to the given arguments."""
-        key = (indexed, instanced, mode, str(attributes))
+        """Get, or create, the vertex domain corresponding to the given arguments.
 
-        # Check for existing domain
-        if key in self.domain_map:
-            domain = self.domain_map[key]
-        else:
-            # Create a new domain if none exists
-            domain = _domain_class_map[(indexed, instanced)](attributes)
-            self.domain_map[key] = domain
-            self._draw_list_dirty = True
-
-        # Ensure the group association is kept.
+        mode is the render mode such as GL_LINES or GL_TRIANGLES
+        """
+        # Batch group
         if group not in self.group_map:
             self._add_group(group)
 
         domain_map = self.group_map[group]
-        domain_map[key] = domain
+
+        # If instanced, ensure a separate domain, as multiple instance sources can match the key.
+        if instanced:
+            self._instance_count += 1
+            key = (indexed, self._instance_count, mode, str(attributes))
+        else:
+            # Find domain given formats, indices and mode
+            key = (indexed, 0, mode, str(attributes))
+
+        try:
+            domain = domain_map[key]
+        except KeyError:
+            # Create domain
+            domain = _domain_class_map[(indexed, instanced)](attributes)
+            domain_map[key] = domain
+            self._draw_list_dirty = True
 
         return domain
 
     def _add_group(self, group: Group) -> None:
-        if group not in self.group_map:
-            self.group_map[group] = {}
+        self.group_map[group] = {}
         if group.parent is None:
             self.top_groups.append(group)
         else:
@@ -484,52 +475,25 @@ class Batch:
         group._assigned_batches.add(self)  # noqa: SLF001
         self._draw_list_dirty = True
 
-    def _check_gl_state(self, group: Group) -> bool:
-        """Return if the group state needs updating."""
-        return any(gl_state not in self.current_states for gl_state in group.set_states)
+    def _update_draw_list(self) -> None:
+        """Visit group tree in preorder and create a list of bound methods to call."""
 
-    def pop_states(self, group: Group) -> None:
-        for state in group.set_states:
-            if state in self.current_states:
-                self.current_states.remove(state)
-
-    def add_states(self, group: Group) -> bool:
-        requires_change = False
-        for state in group.set_states:
-            if state not in self.current_states:
-                self.current_states.append(state)
-                requires_change = True
-
-        return requires_change
-
-    def _create_draw_list(self) -> list:
-        #print("-----------")
-
-        def visit(current_group: Group) -> list:
+        def visit(group: Group) -> list:
             draw_list = []
 
             # Draw domains using this group
-            domain_map = self.group_map.get(current_group, {})
+            domain_map = self.group_map[group]
 
-            # Iterate over the domains associated with the current group
-            for (indexed, instanced, mode, formats), current_domain in list(domain_map.items()):
+            # indexed, instanced, mode, program, str(attributes))
+            for (indexed, instanced, mode, formats), domain in list(domain_map.items()):
                 # Remove unused domains from batch
-                if current_domain.is_empty:
+                if domain.is_empty:
                     del domain_map[(indexed, instanced, mode, formats)]
                     continue
-
-                # If this group exists, has no vertices in the domain, skip it.
-                if current_group in current_domain.group_vertex_ranges:
-                    if not current_domain.group_vertex_ranges[current_group]:
-                        continue
-                else:
-                    continue
-
-                # If group exists, and has vertices, add a draw call.
-                draw_list.append((current_domain, mode, current_group))
+                draw_list.append((lambda d, m: lambda: d.draw(m))(domain, mode))  # noqa: PLC3002
 
             # Sort and visit child groups of this group
-            children = self.group_children.get(current_group)
+            children = self.group_children.get(group)
             if children:
                 children.sort()
                 for child in list(children):
@@ -537,248 +501,58 @@ class Batch:
                         draw_list.extend(visit(child))
 
             if children or domain_map:
-                # if not domain_map:
-                #     return [(None, 'set', current_group), *draw_list, (None, 'unset', current_group)]
-                #
-                # return draw_list
-                return [(None, 'set', current_group), *draw_list, (None, 'unset', current_group)]
+                return [group.set_state, *draw_list, group.unset_state]
 
-            # Clean up if the group is empty and has no children
             # Remove unused group from batch
-            del self.group_map[current_group]
-            current_group._assigned_batches.remove(self)  # noqa: SLF001
-            if current_group.parent:
-                self.group_children[current_group.parent].remove(current_group)
+            del self.group_map[group]
+            group._assigned_batches.remove(self)  # noqa: SLF001
+            if group.parent:
+                self.group_children[group.parent].remove(group)
             try:
-                del self.group_children[current_group]
+                del self.group_children[group]
             except KeyError:
                 pass
             try:
-                self.top_groups.remove(current_group)
+                self.top_groups.remove(group)
             except ValueError:
                 pass
 
             return []
 
-        full_draw_list = []
+        self._draw_list = []
 
         self.top_groups.sort()
-
         for top_group in list(self.top_groups):
             if top_group.visible:
-                full_draw_list.extend(visit(top_group))
+                self._draw_list.extend(visit(top_group))
 
-        return full_draw_list
-
-    def _optimize_draw_list(self, draw_list: list) -> list[Callable]:
-        draw_call_list = []
-        contiguous_groups = []
-        last_mode = None
-        last_domain = None
-        #print("draw list to optimize:", draw_list)
-        #print("======")
-
-        set_states = []
-        set_groups = []
-        #test_draw_stuff = []
-
-        # Iterate through all calls to condense group calls.
-
-        # Draw calls should be: bind vao -> state -> draw -> unset_state
-        new_list = []
-        was_added = []
-
-        # Used to determine if a group is allowed to be unset. 'unset' is a marker for this.
-        ready_to_unset = set()
-
-        for domain, mode, group in draw_list:
-            #print("----START", domain, mode, group)
-            # Data: Group if no domain. If domain, mode.
-            if not domain:
-                # Mode is set/unset literal when domain is None
-                if mode == 'set':
-                    # If the state is already set or doesn't have states. Continue.
-                    if not group.set_states or group in set_groups:
-                        continue
-
-                    state_added = False
-
-                    # Check if any states in this group need to be added.
-                    for gl_state in group.set_states:
-                        if gl_state not in set_states:
-                            state_added = True
-
-                    # A new state needs to be added.
-                    if state_added:
-                        # Add all the new states.
-                        set_states.extend(group.set_states)
-                        #print("group set state:", group)
-                        #print("group states", group.set_states)
-                        #print("current states", set_states)
-                        #print("old states", old_states)
-                        groups_to_unset = []
-                        # If the state gets added, check if the previous set group states needs to be unset.
-                        for set_group in set_groups:
-                            #print("CHECK GROUP", set_group)
-                            for gl_state in set_group.set_states:
-                                # If a previously set group state is not in any of the new ones, unset those.
-                                if gl_state not in group.set_states:
-                                    #print(gl_state, group.set_states)
-                                    if set_group not in groups_to_unset and set_group in ready_to_unset:
-                                        groups_to_unset.append(set_group)
-
-                        for remove_group in reversed(groups_to_unset):
-                            #print("-removing group", remove_group)
-                            set_groups.remove(remove_group)
-                            ready_to_unset.remove(remove_group)
-                            new_list.append((None, 'unset', remove_group))
-                            for gl_state in remove_group.set_states:
-                                #print("Removing state", gl_state)
-                                set_states.remove(gl_state)
-
-                        #print("Groups removed", groups_to_unset)
-
-                        #print("States after", set_states)
-                        #print("State count after", len(set_states), len(group.set_states), len(set_states) == len(group.set_states))
-
-                        set_groups.append(group)
-                        was_added.append(group)
-                        new_list.append((None, 'set', group))
-                        #print("set groups total:", set_groups)
-                    else:
-                        print("State was not added.", group, group.set_states)
-
-                elif mode == 'unset':
-                    ready_to_unset.add(group)
-
-                    if not group.set_states or group not in was_added:
-                        continue
-
-                    # Group was added, but no longer in there.
-                    if group not in set_groups:
-                        raise Exception("Not sure if this should even be a thing", group, set_groups)
-                        new_list.append((None, 'unset', group))
-
-            else:
-                new_list.append((domain, mode, group))
-
-        # Unset any remaining groups:
-        for group in reversed(set_groups):
-            new_list.append((None, 'unset', group))
-            for state in group.set_states:
-                set_states.remove(state)
-
-        # At this point all the set_states should be empty if correct.
-        # We don't need to clean up since it's local, but doing it for a sanity check. TODO: Move to test?
-        assert len(set_states) == 0, f"Leftover states were found. Optimization failed. States: {set_states}"
-
-        #print("---------", "States!", set_states)
-        #print("Test list groups", new_list)
-
-        draw_list = new_list
-
-        # Collapse draw calls into contiguous render calls.
-        for draw_domain, mode, group in draw_list:
-            #print("<<<<<<<<< start consolidation", group, draw_domain, mode)
-            # If the mode, domain are None, it's a group/parent with no draws.
-            # However, it still may have a state that needs setting.
-            if draw_domain is None:
-                if mode == 'set':
-                    draw_call_list.append(group.set_state)
-                    #test_draw_stuff.append([f"set state of {group}"])
-                elif mode == 'unset':
-                    if contiguous_groups:
-                        draw_call_list.append(
-                            (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
-
-                        #test_draw_stuff.extend([f"DRAW: {contiguous_groups}"])
-                        contiguous_groups = []
-
-                    draw_call_list.append(group.unset_state)
-                    #test_draw_stuff.extend([f"UNset state of {group}"])
-                continue
-
-            # If the domain or draw mode has changed, we need to break up the draw.
-            if last_domain is None or (draw_domain == last_domain and mode == last_mode):
-                # Check if the state of this group requires changing.
-                if last_domain is None:
-                    draw_call_list.append(draw_domain.bind)
-                contiguous_groups.append(group)
-            else:
-                # Previous domain/mode is not compatible with current.
-                draw_call_list.append(draw_domain.bind)
-                if contiguous_groups:
-                    # If we have contiguous groups, we need to now combine those
-                    draw_call_list.append(
-                        (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
-
-                    #test_draw_stuff.extend(["draw", contiguous_groups])
-
-                # Reset contiguous groups for share state checks.
-                contiguous_groups = [group]
-
-            last_mode = mode
-            last_domain = draw_domain
-
-        # Draw the remaining contiguous groups
-        if contiguous_groups:
-            #test_draw_stuff.extend(["draw", contiguous_groups])
-            draw_call_list.append(
-                (lambda d, m, gs: lambda: d.draw_groups(m, gs))(last_domain, last_mode, contiguous_groups))
-
-        #print("**** Optimized list:\n", test_draw_stuff)
-
-        return draw_call_list
-
-    def _update_draw_list(self) -> None:
         self._draw_list_dirty = False
-
-        draw_list = self._create_draw_list()
-
-        self._draw_list = self._optimize_draw_list(draw_list)
 
         if _debug_graphics_batch:
             self._dump_draw_list()
 
-        #print("FINAL", [f"{func!s}" for func in self._draw_list])
-
-        #print("GROUPS", draw_list)
-
-    def _dump_draw_list(self, regions: bool = False) -> None:
-        total_domains = 0
-
-        def dump(current_group: Group, indent: str = '') -> None:
-            nonlocal total_domains
-            print(indent, 'Begin group', current_group, f"(order: {current_group.order})")
-            current_domain_map = self.group_map[current_group]
-            total_domains += len(current_domain_map)
-            for current_domain in current_domain_map.values():
-                print(indent, '  ', current_domain)
-                for start, size in zip(*current_domain.allocator.get_allocated_regions()):
-                    print(indent, '    ',
-                          f'Region [start: {start}, size: {size}, groups: {len(current_domain.group_vertex_ranges)}]:')
-                    for key, buffer in current_domain.attrib_name_buffers.items():
+    def _dump_draw_list(self) -> None:
+        def dump(group: Group, indent: str = '') -> None:
+            print(indent, 'Begin group', group)
+            domain_map = self.group_map[group]
+            for domain in domain_map.values():
+                print(indent, '  ', domain)
+                for start, size in zip(*domain.allocator.get_allocated_regions()):
+                    print(indent, '    ', 'Region %d size %d:' % (start, size))
+                    for key, buffer in domain.attrib_name_buffers.items():
                         print(indent, '      ', end=' ')
                         try:
                             region = buffer.get_region(start, size)
                             print(key, region.array[:])
-                        except Exception:
+                        except:  # noqa: E722
                             print(key, '(unmappable)')
-                # for group, ranges in current_domain.group_vertex_ranges.items():
-                #     parent_info = f" (parent: {group.parent})" if group.parent else ""
-                #     print(indent, f'  Group {group}-{hex(id(group))}:{parent_info}')
-                #     if regions:
-                #         for range_start, range_size in ranges:
-                #             print(indent, f'    Start: {range_start}, Size: {range_size}')
-            for child in self.group_children.get(current_group, ()):
+            for child in self.group_children.get(group, ()):
                 dump(child, indent + '  ')
-            print(indent, 'End group', current_group)
+            print(indent, 'End group', group)
 
         print(f'Draw list for {self!r}:')
-        for top_group in self.top_groups:
-            dump(top_group)
-        print(f'Total domains used: {total_domains}')
-        print(f'Total draw list: {len(self._draw_list)}')
+        for group in self.top_groups:
+            dump(group)
 
     def draw(self) -> None:
         """Draw the batch."""
@@ -833,7 +607,7 @@ class Batch:
 
 @dataclass(slots=True)
 class GLState:  # noqa: D101
-    func: Callable | Any
+    func: Union[Callable, Any]  # noqa: UP007
     args: tuple = ()
 
 
@@ -943,27 +717,6 @@ class Group:
         """
         return hash((self._order, self.parent))
 
-    def contiguous_same(self, other: Group) -> bool:
-        """Determines if Group state can be merged with those in the same domain with the same parent.
-
-        For example:
-            group0 = Group(0)
-            group1 = Group(1)
-            image = one_image
-            a = Sprite(image, ..., group=group0)
-            b = Sprite(image, ..., group=group1)
-
-        In this pseudocode scenario, both sprites have the same internal group, but different parental groups.
-        Normally this means each group must set/unset each of their states before drawing one by one.
-        However, the internal SpriteGroup is the same between both, the states are essentially the same without the
-        parent. This allows the child states to be merged and drawn with setting just one state..
-
-        Essentially this means we need to check if this Group has the same state as destination group without the
-        parent.
-        """
-        #return False
-        return self.__class__ is other.__class__
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(order={self._order})"
 
@@ -998,69 +751,6 @@ class Group:
         self.unset_state()
         if self.parent:
             self.parent.unset_state_recursive()
-
-
-class SortedGroup(Group):
-    """Allows maintaining draw order of sprite list."""
-    _domain: vertexdomain.VertexDomain | vertexdomain.IndexedVertexDomain | None
-
-    def __init__(self, order: int = 0, parent: Group | None = None) -> None:
-        super().__init__(order, parent)
-        self._dirty = False
-        self._object_map = []
-        self._domain = None
-
-    def has_state(self):
-        return True
-
-    def set_state(self):
-        if self._dirty:
-            for obj in self._object_map:
-                vlist: vertexdomain.VertexList | vertexdomain.IndexedVertexList = obj._vertex_list
-                self._domain.group_index_ranges[obj._group].remove((vlist.index_start, vlist.index_count))
-                self._domain.group_index_ranges[obj._group].append((vlist.index_start, vlist.index_count))
-                self._domain.group_vertex_ranges[obj._group].remove((vlist.start, vlist.count))
-                self._domain.group_vertex_ranges[obj._group].append((vlist.start, vlist.count))
-
-            self._dirty = False
-
-    def sort_objects(self, key: Callable):
-        sorted_objects = sorted(self._object_map, key=key)
-        if sorted_objects != self._object_map:
-            self._object_map = sorted_objects
-            self._dirty = True
-
-    def link_objects(self, pyglet_objects: list[Any]):
-        assert pyglet_objects, "No objects provided."
-        first_group = pyglet_objects[0]._group
-        self._domain = pyglet_objects[0]._vertex_list.domain
-        if not all(obj._group == first_group for obj in pyglet_objects):
-            raise Exception("All objects do not belong to the same group")
-
-        for pyglet_object in pyglet_objects:
-            assert pyglet_object.group == self, "The pyglet object does not belong in this group."
-
-            self._object_map.append(pyglet_object)
-
-        self._dirty = True
-
-    def __eq__(self, other):
-        return (self.__class__ is other.__class__ and
-                self._order == other.order and
-                self.parent == other.parent)
-
-    def __hash__(self) -> int:
-        """This is an immutable return to establish the permanent identity of the object.
-
-        This is used by Python with ``__eq__`` to determine if something is unique.
-
-        For simplicity, the hash should be a tuple containing your unique identifiers of your Group.
-
-        By default, this is (``order``, ``parent``).
-
-        :see: ``__eq__`` function, both must be implemented.
-        """
-        return hash((self._order, self.parent))
 
 
 # Example Groups.

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -1352,11 +1352,11 @@ class ShaderProgram:
 
         # Create vertex list and initialize
         if indexed:
-            vlist = domain.create(count, len(indices))
+            vlist = domain.create(count, group, len(indices))
             start = vlist.start
             vlist.indices = [i + start for i in indices]
         else:
-            vlist = domain.create(count)
+            vlist = domain.create(count, group)
 
         for name, array in initial_arrays:
             try:

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -1356,7 +1356,7 @@ class ShaderProgram:
             start = vlist.start
             vlist.indices = [i + start for i in indices]
         else:
-            vlist = domain.create(count, group)
+            vlist = domain.create(count, group, 0)
 
         for name, array in initial_arrays:
             try:

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -54,6 +54,7 @@ CTypesDataType = Type[_SimpleCData]
 CTypesPointer = _Pointer
 
 if TYPE_CHECKING:
+    from pyglet.graphics import Group
     from pyglet.graphics.allocation import Allocator
     from pyglet.graphics.shader import Attribute
     from pyglet.graphics.vertexarray import VertexArray
@@ -157,6 +158,11 @@ class VertexList:
     def delete(self) -> None:
         """Delete this group."""
         self.domain.allocator.dealloc(self.start, self.count)
+        group = self.domain.group_vlists[self]
+        self.domain.group_vertex_ranges[group].remove((self.start, self.count))
+        del self.domain.group_vlists[self]
+        #if not self.domain.group_vertex_ranges[group]:
+       #     del self.domain.group_vertex_ranges[group]
 
     def set_instance_source(self, domain: InstancedVertexDomain, instance_attributes: Sequence[str]) -> None:
         assert self.instanced is False, "Vertex list is already an instance."
@@ -263,8 +269,11 @@ class IndexedVertexList(VertexList):
 
     def delete(self) -> None:
         """Delete this group."""
+        group = self.domain.group_vlists[self]
         super().delete()
         self.domain.index_allocator.dealloc(self.index_start, self.index_count)
+
+        self.domain.group_index_ranges[group].remove((self.index_start, self.index_count))
 
     def migrate(self, domain: IndexedVertexDomain | InstancedIndexedVertexDomain) -> None:
         """Move this group from its current indexed domain and add to the specified one.
@@ -354,6 +363,7 @@ class VertexInstance:
         self._vertex_list.delete_instance(self)
         self._vertex_list = None
 
+CULL_TIME = 10
 
 class VertexDomain:
     """Management of a set of vertex lists.
@@ -382,6 +392,10 @@ class VertexDomain:
         self.attribute_names = {}  # name: attribute
         self.buffer_attributes = []  # list of (buffer, attribute)
         self.attrib_name_buffers = {}  # dict of AttributeName: AttributeBufferObject (for VertexLists)
+
+        # This maps groups to the specific start/size regions.
+        self.group_vertex_ranges = {}  # New attribute to store vertex ranges by group
+        self.group_vlists = {}
 
         self._property_dict = {}  # name: property(_getter, _setter)
 
@@ -440,17 +454,15 @@ class VertexDomain:
             self.allocator.set_capacity(capacity)
             return self.allocator.realloc(start, count, new_count)
 
-    def create(self, count: int, index_count: int | None = None) -> VertexList:  # noqa: ARG002
-        """Create a :py:class:`VertexList` in this domain.
-
-        Args:
-            count:
-                Number of vertices to create.
-            index_count:
-                Ignored for non indexed VertexDomains
-        """
+    def create(self, count: int, group: Group, index_count: int | None = None) -> VertexList:
+        assert type(group) != int, "Wrong type"
         start = self.safe_alloc(count)
-        return self._vertexlist_class(self, start, count)
+        vertex_list = self._vertexlist_class(self, start, count)
+        if group not in self.group_vertex_ranges:
+            self.group_vertex_ranges[group] = []
+        self.group_vertex_ranges[group].append((start, count))
+        self.group_vlists[vertex_list] = group
+        return vertex_list
 
     def draw(self, mode: int) -> None:
         """Draw all vertices in the domain.
@@ -479,6 +491,44 @@ class VertexDomain:
             sizes = (GLsizei * primcount)(*sizes)
             glMultiDrawArrays(mode, starts, sizes, primcount)
 
+    def draw_groups(self, mode: int, groups: list[Group]) -> None:
+        """Draw all vertices associated with the specified groups.
+
+        Args:
+            mode:
+                OpenGL drawing mode, e.g., ``GL_POINTS``, ``GL_LINES``, etc.
+            groups:
+                The groups whose vertices should be drawn.
+        """
+        self.vao.bind()
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
+
+        for group in groups:
+            group.set_state()
+            for start, size in self.group_vertex_ranges[group]:
+                glDrawArrays(mode, start, size)
+            group.unset_state()
+
+    def draw_group(self, mode: int, group: Group) -> None:
+        """Draw all vertices associated with the specified group.
+
+        Args:
+            mode:
+                OpenGL drawing mode, e.g. ``GL_POINTS``, ``GL_LINES``, etc.
+            group:
+                The group whose vertices should be drawn.
+        """
+        self.vao.bind()
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
+
+        group.set_state()
+        if group in self.group_vertex_ranges:
+            for start, size in self.group_vertex_ranges[group]:
+                glDrawArrays(mode, start, size)
+        group.unset_state()
+
     def draw_subset(self, mode: int, vertex_list: VertexList) -> None:
         """Draw a specific VertexList in the domain.
 
@@ -500,7 +550,11 @@ class VertexDomain:
 
     @property
     def is_empty(self) -> bool:
-        return not self.allocator.starts
+        return not self.allocator.starts and not self.group_vertex_ranges
+
+    @property
+    def has_vertices(self) -> bool:
+        return all(not values for values in self.group_vertex_ranges.values())
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}@{id(self):x} {self.allocator}>'
@@ -661,6 +715,8 @@ class IndexedVertexDomain(VertexDomain):
         # Make a custom VertexList class w/ properties for each attribute in the ShaderProgram:
         self._vertexlist_class = type(self._vertex_class.__name__, (self._vertex_class,),
                                       self._property_dict)
+        # Dictionary to store index ranges by group
+        self.group_index_ranges = {}
 
     def safe_index_alloc(self, count: int) -> int:
         """Allocate indices, resizing the buffers if necessary."""
@@ -682,7 +738,7 @@ class IndexedVertexDomain(VertexDomain):
             self.index_allocator.set_capacity(capacity)
             return self.index_allocator.realloc(start, count, new_count)
 
-    def create(self, count: int, index_count: int) -> IndexedVertexList:
+    def create(self, count: int, group: Group, index_count: int) -> IndexedVertexList:
         """Create an :py:class:`IndexedVertexList` in this domain.
 
         Args:
@@ -690,11 +746,22 @@ class IndexedVertexDomain(VertexDomain):
                 Number of vertices to create
             index_count:
                 Number of indices to create
-
+            group:
+                The group to which this vertex list belongs
         """
         start = self.safe_alloc(count)
         index_start = self.safe_index_alloc(index_count)
-        return self._vertexlist_class(self, start, count, index_start, index_count)
+
+        vertex_list = self._vertexlist_class(self, start, count, index_start, index_count)
+        if group not in self.group_vertex_ranges:
+            self.group_vertex_ranges[group] = []
+        if group not in self.group_index_ranges:
+            self.group_index_ranges[group] = []
+        self.group_vertex_ranges[group].append((start, count))
+        self.group_index_ranges[group].append((index_start, index_count))
+        self.group_vlists[vertex_list] = group
+
+        return vertex_list
 
     def draw(self, mode: int) -> None:
         """Draw all vertices in the domain.
@@ -727,6 +794,114 @@ class IndexedVertexDomain(VertexDomain):
             sizes = (GLsizei * primcount)(*sizes)
             glMultiDrawElements(mode, sizes, self.index_gl_type, starts, primcount)
 
+    def draw_groups(self, mode: int, groups: list[Group]) -> None:
+        """Draw all vertices associated with the specified groups.
+
+        Args:
+            mode:
+                OpenGL drawing mode, e.g., ``GL_POINTS``, ``GL_LINES``, etc.
+            groups:
+                The groups whose vertices should be drawn.
+        """
+        # Optimize, don't call if empty.
+        self.vao.bind()
+
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
+
+        self.index_buffer.sub_data()
+
+        for group in groups:
+            group.set_state()
+
+            if not self.group_index_ranges[group]:
+                continue
+
+            starts, sizes = zip(*self.group_index_ranges[group])
+            primcount = len(starts)
+            if primcount == 0:
+                pass
+            elif primcount == 1:
+                # Common case
+                glDrawElements(mode, sizes[0], self.index_gl_type,
+                               self.index_buffer.ptr + starts[0] * self.index_element_size)
+            else:
+                starts = [s * self.index_element_size + self.index_buffer.ptr for s in starts]
+                starts = (ctypes.POINTER(GLvoid) * primcount)(*(GLintptr * primcount)(*starts))
+                sizes = (GLsizei * primcount)(*sizes)
+                glMultiDrawElements(mode, sizes, self.index_gl_type, starts, primcount)
+
+            group.unset_state()
+
+    def draw_groups_shared(self, mode: int, groups: list[Group]) -> None:
+        """Draw all vertices associated with the specified groups.
+
+        This differs from draw_groups in that it renders all groups within the shared state.
+
+        Args:
+            mode:
+                OpenGL drawing mode, e.g., ``GL_POINTS``, ``GL_LINES``, etc.
+            groups:
+                The groups whose vertices should be drawn.
+        """
+        combined = []
+        for group in groups:
+            combined.extend(self.group_index_ranges[group])
+
+        if not combined:
+            return
+
+        self.vao.bind()
+
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
+
+        self.index_buffer.sub_data()
+
+        group = groups[0]
+
+        group.set_state()
+
+        #print("self.group_index_ranges[group]", self.group_index_ranges[group])
+        starts, sizes = zip(*combined)
+        primcount = len(starts)
+        #print(primcount)
+        if primcount == 0:
+            pass
+        elif primcount == 1:
+            # Common case
+            glDrawElements(mode, sizes[0], self.index_gl_type,
+                           self.index_buffer.ptr + starts[0] * self.index_element_size)
+        else:
+            starts = [s * self.index_element_size + self.index_buffer.ptr for s in starts]
+            starts = (ctypes.POINTER(GLvoid) * primcount)(*(GLintptr * primcount)(*starts))
+            sizes = (GLsizei * primcount)(*sizes)
+            glMultiDrawElements(mode, sizes, self.index_gl_type, starts, primcount)
+
+        group.unset_state()
+
+    def draw_group(self, mode: int, group: Group) -> None:
+        """Draw all vertices associated with the specified group.
+
+        Args:
+            mode:
+                OpenGL drawing mode, e.g. ``GL_POINTS``, ``GL_LINES``, etc.
+            group:
+                The group whose vertices should be drawn.
+        """
+        self.vao.bind()
+        for buffer, _ in self.buffer_attributes:
+            buffer.sub_data()
+        self.index_buffer.sub_data()
+
+        #print("RENDERING GROUP", group)
+
+        group.set_state()
+        if group in self.group_index_ranges:
+            for index_start, index_count in self.group_index_ranges[group]:
+                glDrawElements(mode, index_count, self.index_gl_type,
+                               self.index_buffer.ptr + index_start * self.index_element_size)
+        group.unset_state()
     def draw_subset(self, mode: int, vertex_list: IndexedVertexList) -> None:
         """Draw a specific IndexedVertexList in the domain.
 
@@ -747,6 +922,9 @@ class IndexedVertexDomain(VertexDomain):
                        self.index_buffer.ptr +
                        vertex_list.index_start * self.index_element_size)
 
+    @property
+    def has_vertices(self) -> bool:
+        return all(not values for values in self.group_index_ranges.values())
 
 class InstancedIndexedVertexDomain(IndexedVertexDomain, InstancedVertexDomain):
     """Management of a set of indexed vertex lists.

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -791,7 +791,7 @@ class InstancedIndexedVertexDomain(IndexedVertexDomain, InstancedVertexDomain):
             self.index_allocator.set_capacity(capacity)
             return self.index_allocator.realloc(start, count, new_count)
 
-    def create(self, count: int, index_count: int) -> IndexedVertexList:
+    def create(self, count: int, group: Group, index_count: int) -> IndexedVertexList:
         """Create an :py:class:`IndexedVertexList` in this domain.
 
         Args:

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -226,7 +226,7 @@ class SpriteGroup(graphics.Group):
         self.program.stop()
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.texture})"
+        return f"{self.__class__.__name__}({self.texture} id={hex(id(self))})"
 
     def __eq__(self, other: SpriteGroup) -> bool:
         return (other.__class__ is self.__class__ and
@@ -241,7 +241,35 @@ class SpriteGroup(graphics.Group):
         return hash((self.program, self.parent,
                      self.texture.id, self.texture.target,
                      self.blend_src, self.blend_dest))
-
+    def contiguous_same(self, other: SpriteGroup) -> bool:
+        return False
+        # print("SELF", self.__class__,
+        #         self.program,
+        #         self.texture.target,
+        #         self.texture.id,
+        #         self.blend_src,
+        #         self.blend_dest,
+        #       )
+        #
+        # print("OTHER", other.__class__,
+        #         other.program,
+        #         other.texture.target,
+        #         other.texture.id,
+        #         other.blend_src,
+        #         other.blend_dest,
+        #       )
+        # print(
+        #         self.program is other.program and
+        #         self.texture.target == other.texture.target and
+        #         self.texture.id == other.texture.id and
+        #         self.blend_src == other.blend_src and
+        #         self.blend_dest == other.blend_dest)
+        return (other.__class__ is self.__class__ and
+                self.program is other.program and
+                self.texture.target == other.texture.target and
+                self.texture.id == other.texture.id and
+                self.blend_src == other.blend_src and
+                self.blend_dest == other.blend_dest)
 
 class Sprite(event.EventDispatcher):
     """Manipulate an on-screen image.

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -240,8 +240,7 @@ class SpriteGroup(graphics.Group):
         self.program.stop()
 
     def __repr__(self) -> str:
-        #return f"{self.__class__.__name__}({self.texture} id={hex(id(self))})"
-        return f"{self.__class__.__name__}"
+        return f"{self.__class__.__name__}(texture={self.texture}, program={self.program})"
 
     def __eq__(self, other: SpriteGroup) -> bool:
         return (other.__class__ is self.__class__ and
@@ -256,14 +255,6 @@ class SpriteGroup(graphics.Group):
         return hash((self.program, self.parent,
                      self.texture.id, self.texture.target,
                      self.blend_src, self.blend_dest))
-    def contiguous_same(self, other: SpriteGroup) -> bool:
-        #return False
-        return (other.__class__ is self.__class__ and
-                self.program is other.program and
-                self.texture.target == other.texture.target and
-                self.texture.id == other.texture.id and
-                self.blend_src == other.blend_src and
-                self.blend_dest == other.blend_dest)
 
 class Sprite(event.EventDispatcher):
     """Manipulate an on-screen image.

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -206,11 +206,25 @@ class SpriteGroup(graphics.Group):
             parent:
                 Optional parent group.
         """
-        super().__init__(parent=parent)
         self.texture = texture
         self.blend_src = blend_src
         self.blend_dest = blend_dest
         self.program = program
+
+        super().__init__(parent=parent)
+
+    def initialize(self) -> None:
+        self.set_states = [
+            graphics.GLState(self.program.use),
+            graphics.GLState(glActiveTexture, (GL_TEXTURE0,)),
+            graphics.GLState(glEnable, (GL_BLEND,)),
+            graphics.GLState(glBlendFunc, (self.blend_src, self.blend_dest)),
+        ]
+
+        self.unset_states = [
+            graphics.GLState(glDisable, (GL_BLEND,)),
+            graphics.GLState(self.program.stop),
+        ]
 
     def set_state(self) -> None:
         self.program.use()
@@ -226,7 +240,8 @@ class SpriteGroup(graphics.Group):
         self.program.stop()
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.texture})"
+        #return f"{self.__class__.__name__}({self.texture} id={hex(id(self))})"
+        return f"{self.__class__.__name__}"
 
     def __eq__(self, other: SpriteGroup) -> bool:
         return (other.__class__ is self.__class__ and
@@ -241,7 +256,14 @@ class SpriteGroup(graphics.Group):
         return hash((self.program, self.parent,
                      self.texture.id, self.texture.target,
                      self.blend_src, self.blend_dest))
-
+    def contiguous_same(self, other: SpriteGroup) -> bool:
+        #return False
+        return (other.__class__ is self.__class__ and
+                self.program is other.program and
+                self.texture.target == other.texture.target and
+                self.texture.id == other.texture.id and
+                self.blend_src == other.blend_src and
+                self.blend_dest == other.blend_dest)
 
 class Sprite(event.EventDispatcher):
     """Manipulate an on-screen image.

--- a/pyglet/text/layout/base.py
+++ b/pyglet/text/layout/base.py
@@ -815,6 +815,7 @@ class TextDecorationGroup(Group):
                  parent: graphics.Group | None = None) -> None:
         self.program = program
         super().__init__(order=order, parent=parent)
+
     def initialize(self) -> None:
         self.set_states = [
             graphics.GLState(self.program.use),

--- a/pyglet/text/layout/base.py
+++ b/pyglet/text/layout/base.py
@@ -757,9 +757,23 @@ class TextLayoutGroup(graphics.Group):
 
     def __init__(self, texture: Texture, program: ShaderProgram, order: int = 1,  # noqa: D107
                  parent: graphics.Group | None = None) -> None:
-        super().__init__(order=order, parent=parent)
         self.texture = texture
         self.program = program
+        super().__init__(order=order, parent=parent)
+
+    def initialize(self) -> None:
+        self.set_states = [
+            graphics.GLState(self.program.use),
+            graphics.GLState(self.program, ('scissor', False)),
+            graphics.GLState(glActiveTexture, (GL_TEXTURE0,)),
+            graphics.GLState(glBindTexture, (self.texture.target, self.texture.id)),
+            graphics.GLState(glEnable, (GL_BLEND,)),
+            graphics.GLState(glBlendFunc, (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)),
+        ]
+        self.unset_states = [
+            graphics.GLState(glDisable, (GL_BLEND,)),
+            graphics.GLState(self.program.stop),
+        ]
 
     def set_state(self) -> None:
         self.program.use()
@@ -799,8 +813,19 @@ class TextDecorationGroup(Group):
 
     def __init__(self, program: ShaderProgram, order: int = 0,  # noqa: D107
                  parent: graphics.Group | None = None) -> None:
-        super().__init__(order=order, parent=parent)
         self.program = program
+        super().__init__(order=order, parent=parent)
+    def initialize(self) -> None:
+        self.set_states = [
+            graphics.GLState(self.program.use),
+            graphics.GLState(self.program, ('scissor', False)),
+            graphics.GLState(glEnable, (GL_BLEND,)),
+            graphics.GLState(glBlendFunc, (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)),
+        ]
+        self.unset_states = [
+            graphics.GLState(glDisable, (GL_BLEND,)),
+            graphics.GLState(self.program.stop),
+        ]
 
     def set_state(self) -> None:
         self.program.use()

--- a/tests/integration/graphics/test_groups.py
+++ b/tests/integration/graphics/test_groups.py
@@ -1,0 +1,140 @@
+import ctypes
+from unittest.mock import MagicMock
+
+import pyglet
+
+
+class GroupNoState(pyglet.graphics.Group):
+    """This group has no state to be set.
+    
+    It should be optimized out.
+    """
+
+
+class GroupWithUniqueGLState(pyglet.graphics.Group):
+    """This group has a state.
+    
+    It should exist after optimization.
+    """
+    def initialize(self):
+        self.set_states = [pyglet.graphics.GLState(pyglet.gl.gl.glEnable, (pyglet.gl.gl.GL_SCISSOR_TEST,))]
+
+
+test_image = pyglet.image.ImageData(1, 1, 'RGBA', (ctypes.c_byte * 4)(0, 0, 0, 0))
+
+def _validate_group(batch, no_state_groups, state_groups, expected_sets, expected_unsets, expected_optimized_sets,
+                    expected_optimized_unsets, expected_binds, expected_draws):
+    draw_list = batch._create_draw_list()  # noqa: SLF001
+
+    assert len([domain for domain, mode, draw_group in draw_list if mode == 'set']) == expected_sets
+    assert len([domain for domain, mode, draw_group in draw_list if mode == 'unset']) == expected_unsets
+
+    draw_list_groups = [draw_group for domain, mode, draw_group in draw_list]
+
+    optimized = batch._optimize_draw_list(draw_list)  # noqa: SLF001
+
+    optimized_bound_instances = [func.__self__ for func in optimized if hasattr(func, '__self__')]
+
+    for nsg in no_state_groups:
+        assert nsg in draw_list_groups  # Group exists in original draw list.
+        assert nsg not in optimized_bound_instances  # No state, no set.
+
+    for sg in state_groups:
+        assert sg in draw_list_groups  # Group exists in original draw list.
+        assert sg in optimized_bound_instances  # State set, should be found.
+
+    # set_state, bind, <lambda>, and unset_state
+    function_names = [func.__name__ for func in optimized]
+
+    assert function_names.count("set_state") == expected_optimized_sets
+    assert function_names.count("unset_state") == expected_optimized_unsets
+    assert function_names.count("bind") == expected_binds
+    assert function_names.count("<lambda>") == expected_draws
+
+
+def test_group_parent_no_state():
+    # Make sure a parent state is optimized out if it has no state. 
+    batch = pyglet.graphics.Batch()
+
+    group = GroupNoState()
+
+    sprite = pyglet.sprite.Sprite(test_image, x=0, y=0, group=group, batch=batch)
+
+    _validate_group(batch, [group], [sprite._group],
+                    expected_sets=2,
+                    expected_unsets=2,
+                    expected_optimized_sets=1,
+                    expected_optimized_unsets=1,
+                    expected_draws=1,
+                    expected_binds=1,
+                    )
+
+def test_group_parent_with_state():
+    """State should be kept of parent."""
+    batch = pyglet.graphics.Batch()
+
+    group = GroupWithUniqueGLState()
+
+    sprite = pyglet.sprite.Sprite(test_image, x=0, y=0, group=group, batch=batch)
+
+    _validate_group(batch, [], [group, sprite._group],
+                    expected_sets=2,
+                    expected_unsets=2,
+                    expected_optimized_sets=2,
+                    expected_optimized_unsets=2,
+                    expected_draws=1,
+                    expected_binds=1,
+                    )
+
+
+def test_group_no_parent():
+    # Make sure parent state exists if a child changes it
+    batch = pyglet.graphics.Batch()
+
+    sprite = pyglet.sprite.Sprite(test_image, x=0, y=0, batch=batch)
+
+    _validate_group(batch, [], [sprite._group],
+                    expected_sets=1,
+                    expected_unsets=1,
+                    expected_optimized_sets=1,
+                    expected_optimized_unsets=1,
+                    expected_draws=1,
+                    expected_binds=1,
+                    )
+
+
+def test_group_ordering():
+    # Make sure groups are ordered by ordering number.
+    pass
+
+
+def test_group_consolidation():
+    # Make sure the same groups consolidate.
+    batch = pyglet.graphics.Batch()
+
+    sprite = pyglet.sprite.Sprite(test_image, x=0, y=0, batch=batch)
+    sprite2 = pyglet.sprite.Sprite(test_image, x=0, y=0, batch=batch)
+
+    _validate_group(batch, [], [sprite._group, sprite2._group],
+                    expected_sets=1,
+                    expected_unsets=1,
+                    expected_optimized_sets=1,
+                    expected_optimized_unsets=1,
+                    expected_draws=1,
+                    expected_binds=1,
+                    )
+
+
+def test_group_comparison():
+    # Make sure similar groups compare to eachother.
+    pass
+
+
+def test_group_deletion():
+    # Make sure groups are freed from the domain and batch when GC'd.
+    pass
+
+
+def test_group_buildup():
+    # Ensure group count in a domain does not exceed the total number of groups.
+    pass

--- a/tests/integration/graphics/test_groups.py
+++ b/tests/integration/graphics/test_groups.py
@@ -54,7 +54,7 @@ def _validate_group(batch, no_state_groups, state_groups, expected_sets, expecte
 
 def test_group_parent_no_state():
     # Make sure a parent state is optimized out if it has no state. 
-    batch = pyglet.graphics.Batch()
+    batch = pyglet.experimental.graphics.Batch()
 
     group = GroupNoState()
 
@@ -71,7 +71,7 @@ def test_group_parent_no_state():
 
 def test_group_parent_with_state():
     """State should be kept of parent."""
-    batch = pyglet.graphics.Batch()
+    batch = pyglet.experimental.graphics.Batch()
 
     group = GroupWithUniqueGLState()
 
@@ -89,7 +89,7 @@ def test_group_parent_with_state():
 
 def test_group_no_parent():
     # Make sure parent state exists if a child changes it
-    batch = pyglet.graphics.Batch()
+    batch = pyglet.experimental.graphics.Batch()
 
     sprite = pyglet.sprite.Sprite(test_image, x=0, y=0, batch=batch)
 
@@ -110,7 +110,7 @@ def test_group_ordering():
 
 def test_group_consolidation():
     # Make sure the same groups consolidate.
-    batch = pyglet.graphics.Batch()
+    batch = pyglet.experimental.graphics.Batch()
 
     sprite = pyglet.sprite.Sprite(test_image, x=0, y=0, batch=batch)
     sprite2 = pyglet.sprite.Sprite(test_image, x=0, y=0, batch=batch)


### PR DESCRIPTION
This is a concept I came up with to improve draw performance in a lot of areas, especially with lots of uniforms, shaders, and buffers. 

This has been added to `pyglet.experimental.graphics.Batch`.

Some issues this identifies:
* Currently every different shader you use is made into a separate group which makes it a separate draw call. Even though a lot of these groups share the same domain, there are a lot of wasted calls by rebinding the same domain again or creating separate VAOs for them.
* Another issue with normal groups is that they have no state, but are useful for ordering. However, each draw with these does nothing and is wasted on the CPU. With a lot of them it can add up to a large performance decrease.
* Wasted states between groups if a previous state was already set.

Some changes and improvements
* There is now a direct link between vertex lists, batches, and groups. These are stored on the domain. This allows batched drawing in the same domain, even if the data areas are not continuous.
* Modified the draw list so there is now an optimization stage where all contiguous groups are optimized in order. So for example if you have 100 groups ordered 0-100, with a sprite in each, it will no longer draw bind the VAO each time, and draw each sprite, separately, then set and unset the group. Instead it will bind the VAO once, and draw the vertex data together in one call.
* Domains are no longer tied to a specific shader program, it is now the attribute data. This way, shaders that use the same vertex attribute format can be optimized together when possible. 
* Due to the above change, this improves changing shader speed, as vertex lists don't have to migrate between domains. 
* You can now draw specific groups in a Batch via `batch.draw_groups`. This is useful for times where you may want to do something like draw a bunch of sprites into an FBO and make effects for them. As opposed to a draw_subset where you would have to draw each vertex list individually.

Additions:
* Added a `GLState` dataclass for use with `Group`'s. Groups now have an `initialization` function. This is used during the optimization process to determine if the state of OpenGL changes. If the state does not change, then it can be assumed to be safe to keep the state until it no longer makes sense. This reduces draw calls. (For example if all your group does is set a blend mode, and that blend mode continues, it doesn't make sense to waste time unsetting it, just to set it again)
* Added a `pyglet.experimental.graphics.SortedGroup` group. This is a special group that allows you to order a bunch of sprites without having to create many groups. This can be useful in places where you don't want to mess with depth ordering, but still have some sort of control over the order of rendering without tons of `Group`'s. (See example)

Further optimizations or ideas:
* The optimization process does not remove redundant states nor does it use `GLState` to set states; only for comparisons. However, `GLState`, could be used to further optimize things by becoming the actual state of the `Group`. In the optimization process it could remove redundant states that were already set to prevent additional GL calls.  For example, by having uniforms with different values in your groups, this will force the shader to bind and unbind multiple times. With an optimization it could just `bind shader -> set uniform -> draw -> set uniform -> draw -> unbind shader` instead of `bind -> set uniform -> draw -> unbind -> bind -> set uniform -> draw -> unbind`.  However, I am not sure how user friendly the `GLState` would be, as it's essentially arguments and functions in a list.

* When the function `Batch.draw_groups` is called during rendering, it consolidates all of the vertex ranges and creates a new list of vertices every time. This could potentially be optimized with something like the Allocator, that internally keeps track of the allocated regions to ensure as many are consolidated as possible. However care would have to be taken in order to maintain the order of vertices in the group order passed.

* Share VBOs across domains. If you have 3 shaders, all with similar vertex attributes but 1, new buffers are created and considered separate for each domain. I'm not quite sure this is worth it, since you would have to ensure the regions of data exist across all shared VBOs which would then leave large gaps of unallocated space.  Even then, each of those domains would still need their own VAO, which the VBO's would already be bound to. So the only thing this would improve would be GPU memory, but with the gaps, is it a wash? No idea.

Comparison from my machine: 
group_order.py
**Old Batch:** 40 FPS
**Experimental Batch**: 1400 FPS. 

sorted_group_test.py
**Sorted Group (500 sprites)**: 1200 FPS.
**Delete/Create in Batch**: 30 FPS
**Drawing each sprite individually** 75 FPS

Any suggestions and further testing by others for any potential issues would be appreciated.