### PR TITLE
Mac: Fix focus being stolen by other apps during launch.

### DIFF
--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -360,6 +360,7 @@ NSApplicationPresentationDisableHideApplication = 1 << 8
 NSApplicationActivationPolicyRegular = 0
 NSApplicationActivationPolicyAccessory = 1
 NSApplicationActivationPolicyProhibited = 2
+NSApplicationActivateIgnoringOtherApps = 1 << 1
 
 ######################################################################
 


### PR DESCRIPTION
This PR fixes an issue with MacOS and launching windows getting their focus stolen causing a weird state of input. This only seems to happen if it's an unbundled app from what I've found.

The menu bar appears like it's out of focus even on launch:
![image](https://github.com/user-attachments/assets/cd65d4de-8c60-46cd-b58b-0c94cfc10dbd)

This issue is very repeatable using something like PyCharm. If you click the launch button to launch your app, then immediately begin moving your mouse, this will occur 100% of the time. If you don't move your mouse, everything launches correctly.

My guess is since PyCharm is focused when launching (or any app that does this, such as Terminal), then your mouse continues to accept input from that app (as evident by the cursor changing as you move it). This then 'steals' back the focus of the newly launching app causing it to enter a weird state where it thinks it's on top, and activated, but is not. The only way to correct it is to click on another app, then click back to the new app.

This fix is a workaround: it will activate the dock to ensure all focus is lost from other apps, then set our apps focus after a short delay. I've tried various combinations of other fixes out there from other libraries, without the delay, without the dock implementation, with other detection methods, and all of it fails to work with my reproducing method. This is the only way I have been able to resolve it.

Needs some further testing to ensure it works correctly outside of my machine as Mac is not very consistent. (Tested on MacOS 15.0 M2 and PyCharm)