### PR TITLE
Fix F1,F2,.. handling on Mac

### DIFF
--- a/pyglet/app/cocoa.py
+++ b/pyglet/app/cocoa.py
@@ -6,7 +6,25 @@ from pyglet.app.base import PlatformEventLoop, EventLoop
 from pyglet.libs.darwin import cocoapy, AutoReleasePool, ObjCSubclass, PyObjectEncoding, ObjCInstance, send_super, \
     ObjCClass, get_selector
 
-NSApplication = cocoapy.ObjCClass('NSApplication')
+
+class PygletNSApplication_Implementation:
+
+    _F_KEYS = (cocoapy.NSF1, cocoapy.NSF2, cocoapy.NSF3, cocoapy.NSF4, cocoapy.NSF5, cocoapy.NSF6, cocoapy.NSF7,
+               cocoapy.NSF8, cocoapy.NSF9, cocoapy.NSF10, cocoapy.NSF11, cocoapy.NSF12, cocoapy.NSF13, cocoapy.NSF14,
+               cocoapy.NSF15, cocoapy.NSF16, cocoapy.NSF17, cocoapy.NSF18, cocoapy.NSF19, cocoapy.NSF20)
+
+    PygletNSApplication = ObjCSubclass('NSApplication', 'PygletNSApplication')
+
+    @PygletNSApplication.method('v@')
+    def sendEvent_(self, nsevent):
+        if nsevent.type() == cocoapy.NSKeyDown:
+            key_code = nsevent.keyCode()
+            if key_code in PygletNSApplication_Implementation._F_KEYS:
+                self.keyWindow().sendEvent_(nsevent)
+                return
+        ObjCInstance(send_super(self, 'sendEvent:', nsevent, superclass_name='NSApplication'))
+
+NSApplication = cocoapy.ObjCClass('PygletNSApplication')
 NSMenu = cocoapy.ObjCClass('NSMenu')
 NSMenuItem = cocoapy.ObjCClass('NSMenuItem')
 NSDate = cocoapy.ObjCClass('NSDate')

--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -229,6 +229,28 @@ NSKeyUp              = 11
 NSFlagsChanged       = 12
 NSApplicationDefined = 15
 
+# Function keys codes
+NSF1 = 122
+NSF2 = 120
+NSF3 = 99
+NSF4 = 118
+NSF5 = 96
+NSF6 = 97
+NSF7 = 98
+NSF8 = 100
+NSF9 = 101
+NSF10 = 109
+NSF11 = 103
+NSF12 = 111
+NSF13 = 105
+NSF14 = 107
+NSF15 = 113
+NSF16 = 106
+NSF17 = 64
+NSF18 = 79
+NSF19 = 80
+NSF20 = 90
+
 # Undocumented left/right modifier masks found by experimentation:
 NSLeftShiftKeyMask = 1 << 1
 NSRightShiftKeyMask = 1 << 2


### PR DESCRIPTION
Regression was created in 1.5.28 after switching to NSApplication event loop. F1,F2,F3,.. keys stopped being properly handled. Only keyup events are registered, but not keydown.

Attempt to fix by sending F* keydown events to window. They seem to get lost in the propagation chain, but I don't know why.