### PR TITLE
Add support for FFmpeg 7.1

### DIFF
--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -13,7 +13,7 @@ following are available:
 #. The built-in pyglet WAV file decoder (always available)
 #. Platform-specific APIs and libraries
 #. PyOgg
-#. :ref:`guide-supportedmedia-ffmpeg` version 4, 5, or 6
+#. :ref:`guide-supportedmedia-ffmpeg` version 4, 5, 6, or 7.
 
 Video is played into OpenGL textures, allowing real-time manipulation
 by applications. Examples include use in 3D environments or shader-based
@@ -304,7 +304,7 @@ FFmpeg
 ^^^^^^
 .. _FFmpeg's license overview: https://www.ffmpeg.org/legal.html
 
-.. note:: The most recent pyglet release can use FFmpeg 4.X, 5.X, or 6.X
+.. note:: The most recent pyglet release can use FFmpeg versions 4.X, 5.X, 6.X, and 7.X
 
           See :ref:`guide-media-ffmpeginstall` to learn more.
 
@@ -389,6 +389,7 @@ See the following to learn more:
   * `The FFmpeg 4.4 license breakdown <https://ffmpeg.org/doxygen/4.4/md_LICENSE.html>`_
   * `The FFmpeg 5.1 license breakdown <https://ffmpeg.org/doxygen/5.1/md_LICENSE.html>`_
   * `The FFmpeg 6.0 license breakdown <https://ffmpeg.org/doxygen/6.0/md_LICENSE.html>`_
+  * `The FFmpeg 7.0 license breakdown <https://ffmpeg.org/doxygen/7.1/md_LICENSE.html>`_
 
 .. _guide-media-ffmpeginstall:
 
@@ -400,8 +401,11 @@ in the `FFmpeg download <https://www.ffmpeg.org/download.html>`_ page. You must
 choose the shared build for the targeted OS with the architecture similar to
 the Python interpreter.
 
-All recent pyglet versions support FFmpeg 4.x and 5.x. To use FFmpeg 6.X,
-you must use pyglet 2.0.8 or later.
+All recent pyglet versions support FFmpeg 4.x.
+
+* Support for version 5.X requires at least: 1.5.28.
+* Support for version 6.X requires at least: 2.0.8.
+* Support for version 7.X requires at least: 2.0.20.
 
 Choose the correct architecture depending on the targeted
 **Python interpreter**. If you're shipping your project with a 32 bits
@@ -450,6 +454,8 @@ For Linux and Mac OS::
          * Exiting gracefully after the the user clicks OK on a dialog
          * Limiting the formats your project will attempt to load
 
+If you still have issues with the FFmpeg not being recognized, try enabling the debug flags to see if any relevant
+information is output: ``pyglet.options.debug_lib`` and/or ``pyglet.options.debug_media``.
 
 .. _guide-media-loading:
 

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -389,7 +389,7 @@ See the following to learn more:
   * `The FFmpeg 4.4 license breakdown <https://ffmpeg.org/doxygen/4.4/md_LICENSE.html>`_
   * `The FFmpeg 5.1 license breakdown <https://ffmpeg.org/doxygen/5.1/md_LICENSE.html>`_
   * `The FFmpeg 6.0 license breakdown <https://ffmpeg.org/doxygen/6.0/md_LICENSE.html>`_
-  * `The FFmpeg 7.0 license breakdown <https://ffmpeg.org/doxygen/7.1/md_LICENSE.html>`_
+  * `The FFmpeg 7.0 license breakdown <https://ffmpeg.org/doxygen/7.0/md_LICENSE.html>`_
 
 .. _guide-media-ffmpeginstall:
 

--- a/pyglet/media/codecs/ffmpeg_lib/compat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/compat.py
@@ -17,6 +17,7 @@ release_versions = {
     4: {'avcodec': 58, 'avformat': 58, 'avutil': 56, 'swresample': 3, 'swscale': 5},  # 4.x
     5: {'avcodec': 59, 'avformat': 59, 'avutil': 57, 'swresample': 4, 'swscale': 6},  # 5.x
     6: {'avcodec': 60, 'avformat': 60, 'avutil': 58, 'swresample': 4, 'swscale': 7},  # 6.x
+    7: {'avcodec': 61, 'avformat': 61, 'avutil': 59, 'swresample': 5, 'swscale': 8},  # 7.x
 }
 
 # Removals done per library and version.

--- a/pyglet/media/codecs/ffmpeg_lib/libavcodec.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavcodec.py
@@ -1,7 +1,7 @@
 """Wrapper for include/libavcodec/avcodec.h
 """
 
-from ctypes import c_int, c_uint16, c_int64, c_uint32, c_uint64
+from ctypes import c_int, c_uint16, c_int64, c_uint32, c_uint64, c_size_t
 from ctypes import c_uint8, c_uint, c_float, c_char_p
 from ctypes import c_void_p, POINTER, CFUNCTYPE, Structure
 
@@ -9,18 +9,21 @@ import pyglet.lib
 from pyglet.util import debug_print
 from . import compat
 from . import libavutil
+from .libavutil import AVChannelLayout, AVDictionary
 
 _debug = debug_print('debug_media')
 
 avcodec = pyglet.lib.load_library(
     'avcodec',
-    win32=('avcodec-60', 'avcodec-59', 'avcodec-58'),
-    darwin=('avcodec.60', 'avcodec.59', 'avcodec.58')
+    win32=('avcodec-61', 'avcodec-60', 'avcodec-59', 'avcodec-58'),
+    darwin=('avcodec.61', 'avcodec.60', 'avcodec.59', 'avcodec.58')
 )
 
 avcodec.avcodec_version.restype = c_int
 
-compat.set_version('avcodec', avcodec.avcodec_version() >> 16)
+avcodec_version = avcodec.avcodec_version() >> 16
+
+compat.set_version('avcodec', avcodec_version)
 
 
 FF_INPUT_BUFFER_PADDING_SIZE = 32
@@ -54,9 +57,9 @@ AVPacket_Fields = [
         ('side_data_elems', c_int),
         ('duration', c_int64),
         ('pos', c_int64),
-        ('opaque', c_void_p),  # 5.x only
-        ('opaque_ref', c_void_p),  # 5.x only
-        ('time_base', AVRational),  # 5.x only
+        ('opaque', c_void_p),  # 5.x+
+        ('opaque_ref', c_void_p),  # 5.x+
+        ('time_base', AVRational),  # 5.x+
         ('convergence_duration', c_int64)  # 4.x only
     ]
 
@@ -64,48 +67,59 @@ AVPacket_Fields = [
 compat.add_version_changes('avcodec', 58, AVPacket, AVPacket_Fields,
                            removals=('opaque', 'opaque_ref', 'time_base'))
 
-compat.add_version_changes('avcodec', 59, AVPacket, AVPacket_Fields,
-                           removals=('convergence_duration',))
-
-compat.add_version_changes('avcodec', 60, AVPacket, AVPacket_Fields,
-                           removals=('convergence_duration',))
+for compat_ver in (59, 60, 61):
+    compat.add_version_changes('avcodec', compat_ver, AVPacket, AVPacket_Fields,
+                               removals=('convergence_duration',))
 
 class AVCodecParserContext(Structure):
     pass
 
 
 class AVCodecParameters(Structure):
-    _fields_ = [
-        ('codec_type', c_int),
-        ('codec_id', c_int),
-        ('codec_tag', c_uint32),
-        ('extradata', POINTER(c_uint8)),
-        ('extradata_size', c_int),
-        ('format', c_int),
-        ('bit_rate', c_int64),
-        ('bits_per_coded_sample', c_int),
-        ('bits_per_raw_sample', c_int),
-        ('profile', c_int),
-        ('level', c_int),
-        ('width', c_int),
-        ('height', c_int),
-        ('sample_aspect_ratio', AVRational),
-        ('field_order', c_int),
-        ('color_range', c_int),
-        ('color_primaries', c_int),
-        ('color_trc', c_int),
-        ('color_space', c_int),
-        ('chroma_location', c_int),
-        ('video_delay', c_int),
-        ('channel_layout', c_uint64),  # deprecated as of 59
-        ('channels', c_int),  # deprecated as of 59
-        ('sample_rate', c_int),
-        ('block_align', c_int),
-        ('frame_size', c_int),
-        ('initial_padding', c_int),
-        ('trailing_padding', c_int),
-        ('seek_preroll', c_int)
-    ]
+    pass
+
+AVCodecParameters_Fields = [
+    ('codec_type', c_int),
+    ('codec_id', c_int),
+    ('codec_tag', c_uint32),
+    ('extradata', POINTER(c_uint8)),
+    ('extradata_size', c_int),
+    ('coded_side_data', POINTER(AVPacketSideData)),  # added in 61
+    ('nb_coded_side_data', c_int),  # added in 61
+    ('format', c_int),
+    ('bit_rate', c_int64),
+    ('bits_per_coded_sample', c_int),
+    ('bits_per_raw_sample', c_int),
+    ('profile', c_int),
+    ('level', c_int),
+    ('width', c_int),
+    ('height', c_int),
+    ('sample_aspect_ratio', AVRational),
+    ('framerate', AVRational),  # added in 61
+    ('field_order', c_int),
+    ('color_range', c_int),
+    ('color_primaries', c_int),
+    ('color_trc', c_int),
+    ('color_space', c_int),
+    ('chroma_location', c_int),
+    ('video_delay', c_int),
+    ('ch_layout', AVChannelLayout),  # added in 61
+    ('channel_layout', c_uint64),  # deprecated as of 59. removed in 61
+    ('channels', c_int),  # deprecated as of 59. removed in 61
+    ('sample_rate', c_int),
+    ('block_align', c_int),
+    ('frame_size', c_int),
+    ('initial_padding', c_int),
+    ('trailing_padding', c_int),
+    ('seek_preroll', c_int),
+]
+
+for compat_ver in (58, 59, 60):
+    compat.add_version_changes('avcodec', compat_ver, AVCodecParameters, AVCodecParameters_Fields,
+                               removals=('coded_side_data', 'nb_coded_side_data', 'ch_layout', 'framerate'))
+
+compat.add_version_changes('avcodec', 61, AVCodecParameters, AVCodecParameters_Fields,
+                           removals=('channel_layout', 'channels'))
 
 
 class AVProfile(Structure):
@@ -159,236 +173,415 @@ class RcOverride(Structure):
 class AVHWAccel(Structure):
     pass
 
+AVFrameSideDataType = c_int
+
+class AVFrameSideData(Structure):
+    _fields_ = [
+        ("type", AVFrameSideDataType),
+        ("data", POINTER(c_uint8)),
+        ("size", c_size_t),
+        ("metadata", POINTER(AVDictionary)),
+        ("buf", POINTER(AVBufferRef))
+    ]
 
 AVClass = libavutil.AVClass
 AVFrame = libavutil.AVFrame
 AV_NUM_DATA_POINTERS = libavutil.AV_NUM_DATA_POINTERS
 
-AVCodecContext_Fields = [
-    ('av_class', POINTER(AVClass)),
-    ('log_level_offset', c_int),
-    ('codec_type', c_int),
-    ('codec', POINTER(AVCodec)),
-    ('codec_id', c_int),
-    ('codec_tag', c_uint),
-    ('priv_data', c_void_p),
-    ('internal', POINTER(AVCodecInternal)),
-    ('opaque', c_void_p),
-    ('bit_rate', c_int64),
-    ('bit_rate_tolerance', c_int),
-    ('global_quality', c_int),
-    ('compression_level', c_int),
-    ('flags', c_int),
-    ('flags2', c_int),
-    ('extradata', POINTER(c_uint8)),
-    ('extradata_size', c_int),
-    ('time_base', AVRational),
-    ('ticks_per_frame', c_int),
-    ('delay', c_int),
-    ('width', c_int),
-    ('height', c_int),
-    ('coded_width', c_int),
-    ('coded_height', c_int),
-    ('gop_size', c_int),
-    ('pix_fmt', c_int),
-    ('draw_horiz_band', CFUNCTYPE(None,
-                                  POINTER(AVCodecContext), POINTER(AVFrame),
-                                  c_int * 8, c_int, c_int, c_int)),
-    ('get_format', CFUNCTYPE(c_int, POINTER(AVCodecContext), POINTER(c_int))),
-    ('max_b_frames', c_int),
-    ('b_quant_factor', c_float),
-    ('b_frame_strategy', c_int),  # Deprecated. Removed in 59.
-    ('b_quant_offset', c_float),
-    ('has_b_frames', c_int),
-    ('mpeg_quant', c_int),  # Deprecated. Removed in 59.
-    ('i_quant_factor', c_float),
-    ('i_quant_offset', c_float),
-    ('lumi_masking', c_float),
-    ('temporal_cplx_masking', c_float),
-    ('spatial_cplx_masking', c_float),
-    ('p_masking', c_float),
-    ('dark_masking', c_float),
-    ('slice_count', c_int),
-    ('prediction_method', c_int),  # Deprecated. Removed in 59.
-    ('slice_offset', POINTER(c_int)),
-    ('sample_aspect_ratio', AVRational),
-    ('me_cmp', c_int),
-    ('me_sub_cmp', c_int),
-    ('mb_cmp', c_int),
-    ('ildct_cmp', c_int),
-    ('dia_size', c_int),
-    ('last_predictor_count', c_int),
-    ('pre_me', c_int),  # Deprecated. Removed in 59.
-    ('me_pre_cmp', c_int),
-    ('pre_dia_size', c_int),
-    ('me_subpel_quality', c_int),
-    ('me_range', c_int),
-    ('slice_flags', c_int),
-    ('mb_decision', c_int),
-    ('intra_matrix', POINTER(c_uint16)),
-    ('inter_matrix', POINTER(c_uint16)),
-    ('scenechange_threshold', c_int),  # Deprecated. Removed in 59.
-    ('noise_reduction', c_int),  # Deprecated. Removed in 59.
-    ('intra_dc_precision', c_int),
-    ('skip_top', c_int),
-    ('skip_bottom', c_int),
-    ('mb_lmin', c_int),
-    ('mb_lmax', c_int),
-    ('me_penalty_compensation', c_int),  # Deprecated. Removed in 59.
-    ('bidir_refine', c_int),
-    ('brd_scale', c_int),  # Deprecated. Removed in 59.
-    ('keyint_min', c_int),
-    ('refs', c_int),
-    ('chromaoffset', c_int),  # Deprecated. Removed in 59.
-    ('mv0_threshold', c_int),
-    ('b_sensitivity', c_int),  # Deprecated. Removed in 59.
-    ('color_primaries', c_int),
-    ('color_trc', c_int),
-    ('colorspace', c_int),
-    ('color_range', c_int),
-    ('chroma_sample_location', c_int),
-    ('slices', c_int),
-    ('field_order', c_int),
-    ('sample_rate', c_int),
-    ('channels', c_int),
-    ('sample_fmt', c_int),
-    ('frame_size', c_int),
-    ('frame_number', c_int),
-    ('block_align', c_int),
-    ('cutoff', c_int),
-    ('channel_layout', c_uint64),
-    ('request_channel_layout', c_uint64),
-    ('audio_service_type', c_int),
-    ('request_sample_fmt', c_int),
-    ('get_buffer2', CFUNCTYPE(c_int, POINTER(AVCodecContext), POINTER(AVFrame), c_int)),
-    ('refcounted_frames', c_int),  # Deprecated. Removed in 59.
-    ('qcompress', c_float),
-    ('qblur', c_float),
-    ('qmin', c_int),
-    ('qmax', c_int),
-    ('max_qdiff', c_int),
-    ('rc_buffer_size', c_int),
-    ('rc_override_count', c_int),
-    ('rc_override', POINTER(RcOverride)),
-    ('rc_max_rate', c_int64),
-    ('rc_min_rate', c_int64),
-    ('rc_max_available_vbv_use', c_float),
-    ('rc_min_vbv_overflow_use', c_float),
-    ('rc_initial_buffer_occupancy', c_int),
-    ('coder_type', c_int),  # Deprecated. Removed in 59.
-    ('context_model', c_int),  # Deprecated. Removed in 59.
-    ('frame_skip_threshold', c_int),  # Deprecated. Removed in 59.
-    ('frame_skip_factor', c_int),  # Deprecated. Removed in 59.
-    ('frame_skip_exp', c_int),  # Deprecated. Removed in 59.
-    ('frame_skip_cmp', c_int),  # Deprecated. Removed in 59.
-    ('trellis', c_int),
-    ('min_prediction_order', c_int),  # Deprecated. Removed in 59.
-    ('max_prediction_order', c_int),  # Deprecated. Removed in 59.
-    ('timecode_frame_start', c_int64),  # Deprecated. Removed in 59.
-    ('rtp_callback', CFUNCTYPE(None,  # Deprecated. Removed in 59.
-                              POINTER(AVCodecContext), c_void_p, c_int, c_int)),
-    ('rtp_payload_size', c_int),  # Deprecated. Removed in 59.
-    ('mv_bits', c_int),  # Deprecated. Removed in 59.
-    ('header_bits', c_int),  # Deprecated. Removed in 59.
-    ('i_tex_bits', c_int),  # Deprecated. Removed in 59.
-    ('p_tex_bits', c_int),  # Deprecated. Removed in 59.
-    ('i_count', c_int),  # Deprecated. Removed in 59.
-    ('p_count', c_int),  # Deprecated. Removed in 59.
-    ('skip_count', c_int),  # Deprecated. Removed in 59.
-    ('misc_bits', c_int),  # Deprecated. Removed in 59.
-    ('frame_bits', c_int),  # Deprecated. Removed in 59.
-    ('stats_out', c_char_p),
-    ('stats_in', c_char_p),
-    ('workaround_bugs', c_int),
-    ('strict_std_compliance', c_int),
-    ('error_concealment', c_int),
-    ('debug', c_int),
-    ('err_recognition', c_int),
-    ('reordered_opaque', c_int64),
-    ('hwaccel', POINTER(AVHWAccel)),
-    ('hwaccel_context', c_void_p),
-    ('error', c_uint64 * AV_NUM_DATA_POINTERS),
-    ('dct_algo', c_int),
-    ('idct_algo', c_int),
-    ('bits_per_coded_sample', c_int),
-    ('bits_per_raw_sample', c_int),
-    ('lowres', c_int),
-    ('coded_frame', POINTER(AVFrame)),  # Deprecated. Removed in 59.
-    ('thread_count', c_int),
-    ('thread_type', c_int),
-    ('active_thread_type', c_int),
-    ('thread_safe_callbacks', c_int),
-    ('execute', CFUNCTYPE(c_int,
-                          POINTER(AVCodecContext),
-                          CFUNCTYPE(c_int, POINTER(AVCodecContext), c_void_p),
-                          c_void_p, c_int, c_int, c_int)),
-    ('execute2', CFUNCTYPE(c_int,
-                           POINTER(AVCodecContext),
-                           CFUNCTYPE(c_int, POINTER(AVCodecContext), c_void_p, c_int, c_int),
-                           c_void_p, c_int, c_int)),
-    ('nsse_weight', c_int),
-    ('profile', c_int),
-    ('level', c_int),
-    ('skip_loop_filter', c_int),
-    ('skip_idct', c_int),
-    ('skip_frame', c_int),
-    ('subtitle_header', POINTER(c_uint8)),
-    ('subtitle_header_size', c_int),
-    ('vbv_delay', c_uint64),  # Deprecated. Removed in 59.
-    ('side_data_only_packets', c_int),  # Deprecated. Removed in 59.
-    ('initial_padding', c_int),
-    ('framerate', AVRational),
-    # !
-    ('sw_pix_fmt', c_int),
-    ('pkt_timebase', AVRational),
-    ('codec_dexcriptor', AVCodecDescriptor),
-    ('pts_correction_num_faulty_pts', c_int64),
-    ('pts_correction_num_faulty_dts', c_int64),
-    ('pts_correction_last_pts', c_int64),
-    ('pts_correction_last_dts', c_int64),
-    ('sub_charenc', c_char_p),
-    ('sub_charenc_mode', c_int),
-    ('skip_alpha', c_int),
-    ('seek_preroll', c_int),
-    ('debug_mv', c_int),
-    ('chroma_intra_matrix', POINTER(c_uint16)),
-    ('dump_separator', POINTER(c_uint8)),
-    ('codec_whitelist', c_char_p),
-    ('properties', c_uint),
-    ('coded_side_data', POINTER(AVPacketSideData)),
-    ('nb_coded_side_data', c_int),
-    ('hw_frames_ctx', POINTER(AVBufferRef)),
-    ('sub_text_format', c_int),
-    ('trailing_padding', c_int),
-    ('max_pixels', c_int64),
-    ('hw_device_ctx', POINTER(AVBufferRef)),
-    ('hwaccel_flags', c_int),
-    ('apply_cropping', c_int),
-    ('extra_hw_frames', c_int)
-]
+# Significant deprecation and re-ordering of the entire structure makes it unmanagable to
+# track of all the changes via compat module. Re-define the structure and compat the new one going forward.
+if avcodec_version >= 61:
+    AVCodecContext_Fields = [
+        # Basic fields
+        ("av_class", POINTER(AVClass)),
+        ("log_level_offset", c_int),
 
-compat.add_version_changes('avcodec', 58, AVCodecContext, AVCodecContext_Fields, removals=None)
+        # Codec fields
+        ("codec_type", c_int),  # enum AVMediaType
+        ("codec", POINTER(AVCodec)),
+        ("codec_id", c_int),  # enum AVCodecID
+        ("codec_tag", c_uint),
 
-compat.add_version_changes('avcodec', 59, AVCodecContext, AVCodecContext_Fields,
-    removals=('b_frame_strategy', 'mpeg_quant', 'prediction_method', 'pre_me', 'scenechange_threshold',
-                  'noise_reduction', 'me_penalty_compensation', 'brd_scale', 'chromaoffset', 'b_sensitivity',
-                  'refcounted_frames', 'coder_type', 'context_model', 'coder_type', 'context_model',
-                  'frame_skip_threshold', 'frame_skip_factor', 'frame_skip_exp', 'frame_skip_cmp',
-                  'min_prediction_order', 'max_prediction_order', 'timecode_frame_start', 'rtp_callback',
-                  'rtp_payload_size', 'mv_bits', 'header_bits', 'i_tex_bits', 'p_tex_bits', 'i_count', 'p_count',
-                  'skip_count', 'misc_bits', 'frames_bits', 'coded_frame', 'vbv_delay', 'side_data_only_packets')
-)
+        ("priv_data", c_void_p),
+        ("internal", POINTER(AVCodecInternal)),
+        ("opaque", c_void_p),
+        ("bit_rate", c_int64),
+        ("flags", c_int),
+        ("flags2", c_int),
+        ("extradata", POINTER(c_uint8)),
+        ("extradata_size", c_int),
 
-compat.add_version_changes('avcodec', 60, AVCodecContext, AVCodecContext_Fields,
-    removals=('b_frame_strategy', 'mpeg_quant', 'prediction_method', 'pre_me', 'scenechange_threshold',
-                  'noise_reduction', 'me_penalty_compensation', 'brd_scale', 'chromaoffset', 'b_sensitivity',
-                  'refcounted_frames', 'coder_type', 'context_model', 'coder_type', 'context_model',
-                  'frame_skip_threshold', 'frame_skip_factor', 'frame_skip_exp', 'frame_skip_cmp',
-                  'min_prediction_order', 'max_prediction_order', 'timecode_frame_start', 'rtp_callback',
-                  'rtp_payload_size', 'mv_bits', 'header_bits', 'i_tex_bits', 'p_tex_bits', 'i_count', 'p_count',
-                  'skip_count', 'misc_bits', 'frames_bits', 'coded_frame', 'vbv_delay', 'side_data_only_packets')
-)
+        # Timebase
+        ("time_base", AVRational),
+        ("pkt_timebase", AVRational),
+        ("framerate", AVRational),
 
+        # Video fields
+        ("ticks_per_frame", c_int),  # Deprecated in 61.
+        ("delay", c_int),
+        ("width", c_int),
+        ("height", c_int),
+        ("coded_width", c_int),
+        ("coded_height", c_int),
+        ("sample_aspect_ratio", AVRational),  # AVRational
+        ("pix_fmt", c_int),  # enum AVPixelFormat
+        ("sw_pix_fmt", c_int),  # enum AVPixelFormat
+        ("color_primaries", c_int),  # enum AVColorPrimaries
+        ("color_trc", c_int),  # enum AVColorTransferCharacteristic
+        ("colorspace", c_int),  # enum AVColorSpace
+        ("color_range", c_int),  # enum AVColorRange
+        ("chroma_sample_location", c_int),  # enum AVChromaLocation
+        ("field_order", c_int),  # enum AVFieldOrder
+        ("refs", c_int),
+        ("has_b_frames", c_int),
+        ("slice_flags", c_int),
+
+        ("draw_horiz_band", CFUNCTYPE(None, POINTER(AVCodecContext), POINTER(AVFrame), POINTER(c_int), c_int, c_int, c_int)),
+        ("get_format", CFUNCTYPE(c_int, POINTER(AVCodecContext), POINTER(c_int))),
+
+        # Video encoding parameters
+        ("max_b_frames", c_int),
+        ("b_quant_factor", c_float),
+        ("b_quant_offset", c_float),
+        ("i_quant_factor", c_float),
+        ("i_quant_offset", c_float),
+        ("lumi_masking", c_float),
+        ("temporal_cplx_masking", c_float),
+        ("spatial_cplx_masking", c_float),
+        ("p_masking", c_float),
+        ("dark_masking", c_float),
+        ("nsse_weight", c_int),
+        ("me_cmp", c_int),
+        ("me_sub_cmp", c_int),
+        ("mb_cmp", c_int),
+        ("ildct_cmp", c_int),
+        ("dia_size", c_int),
+        ("last_predictor_count", c_int),
+        ("me_pre_cmp", c_int),
+        ("pre_dia_size", c_int),
+        ("me_subpel_quality", c_int),
+        ("me_range", c_int),
+        ("mb_decision", c_int),
+        ("intra_matrix", POINTER(c_uint16)),
+        ("inter_matrix", POINTER(c_uint16)),
+        ("chroma_intra_matrix", POINTER(c_uint16)),
+        ("intra_dc_precision", c_int),
+        ("mb_lmin", c_int),
+        ("mb_lmax", c_int),
+        ("bidir_refine", c_int),
+        ("keyint_min", c_int),
+        ("gop_size", c_int),
+        ("mv0_threshold", c_int),
+        ("slices", c_int),
+
+        # Audio fields
+        ("sample_rate", c_int),
+        ("sample_fmt", c_int),  # enum AVSampleFormat
+        ("ch_layout", AVChannelLayout),  # AVChannelLayout
+        ("frame_size", c_int),
+        ("block_align", c_int),
+        ("cutoff", c_int),
+        ("audio_service_type", c_int),  # enum AVAudioServiceType
+        ("request_sample_fmt", c_int),  # enum AVSampleFormat
+        ("initial_padding", c_int),
+        ("trailing_padding", c_int),
+        ("seek_preroll", c_int),
+
+        # Encoding parameters
+        ("bit_rate_tolerance", c_int),
+        ("global_quality", c_int),
+        ("compression_level", c_int),
+        ("qcompress", c_float),
+        ("qblur", c_float),
+        ("qmin", c_int),
+        ("qmax", c_int),
+        ("max_qdiff", c_int),
+        ("rc_buffer_size", c_int),
+        ("rc_override_count", c_int),
+        ("rc_override", POINTER(RcOverride)),
+        ("rc_max_rate", c_int64),
+        ("rc_min_rate", c_int64),
+        ("rc_max_available_vbv_use", c_float),
+        ("rc_min_vbv_overflow_use", c_float),
+        ("rc_initial_buffer_occupancy", c_int),
+        ("trellis", c_int),
+        ("stats_out", c_char_p),
+        ("stats_in", c_char_p),
+        ("workaround_bugs", c_int),
+        ("strict_std_compliance", c_int),
+        ("error_concealment", c_int),
+        ("debug", c_int),
+        ("err_recognition", c_int),
+        ("hwaccel", POINTER(AVHWAccel)),
+        ("hwaccel_context", c_void_p),
+        ("hw_frames_ctx", POINTER(AVBufferRef)),
+        ("hw_device_ctx", POINTER(AVBufferRef)),
+        ("hwaccel_flags", c_int),
+        ("extra_hw_frames", c_int),
+        ("error", c_uint64 * AV_NUM_DATA_POINTERS),
+        ("dct_algo", c_int),
+        ("idct_algo", c_int),
+        ("bits_per_coded_sample", c_int),
+        ("bits_per_raw_sample", c_int),
+        ("thread_count", c_int),
+        ("thread_type", c_int),
+        ("active_thread_type", c_int),
+        ("execute",
+         CFUNCTYPE(c_int, POINTER(AVCodecContext), CFUNCTYPE(c_int, POINTER(AVCodecContext), c_void_p), c_void_p,
+                   POINTER(c_int), c_int, c_int)),
+        ("execute2", CFUNCTYPE(c_int, POINTER(AVCodecContext),
+                               CFUNCTYPE(c_int, POINTER(AVCodecContext), c_void_p, c_int, c_int), c_void_p,
+                               POINTER(c_int), c_int)),
+        ("profile", c_int),
+        ("level", c_int),
+        ("properties", c_uint),
+        ("skip_loop_filter", c_int),  # enum AVDiscard
+        ("skip_idct", c_int),  # enum AVDiscard
+        ("skip_frame", c_int),  # enum AVDiscard
+        ("skip_alpha", c_int),
+        ("skip_top", c_int),
+        ("skip_bottom", c_int),
+        ("lowres", c_int),
+        ("codec_descriptor", POINTER(AVCodecDescriptor)),
+        ("sub_charenc", c_char_p),
+        ("sub_charenc_mode", c_int),
+        ("subtitle_header_size", c_int),
+        ("subtitle_header", POINTER(c_uint8)),
+        ("dump_separator", POINTER(c_uint8)),
+        ("codec_whitelist", c_char_p),
+        ("coded_side_data", POINTER(AVPacketSideData)),
+        ("nb_coded_side_data", c_int),
+        ("export_side_data", c_int),
+        ("max_pixels", c_int64),
+        ("apply_cropping", c_int),
+        ("discard_damaged_percentage", c_int),
+        ("max_samples", c_int64),
+        ("get_encode_buffer", CFUNCTYPE(c_int, POINTER(AVCodecContext), POINTER(AVPacket), c_int)),
+        ("frame_num", c_int64),
+        ("side_data_prefer_packet", POINTER(c_int)),
+        ("nb_side_data_prefer_packet", c_uint),
+        ("decoded_side_data", POINTER(POINTER(AVFrameSideData))),
+        ("nb_decoded_side_data", c_int),
+    ]
+
+    compat.add_version_changes('avcodec', 61, AVCodecContext, AVCodecContext_Fields, removals=None)
+
+else:
+    AVCodecContext_Fields = [
+        ('av_class', POINTER(AVClass)),
+        ('log_level_offset', c_int),
+        ('codec_type', c_int),
+        ('codec', POINTER(AVCodec)),
+        ('codec_id', c_int),
+        ('codec_tag', c_uint),
+        ('priv_data', c_void_p),
+        ('internal', POINTER(AVCodecInternal)),
+        ('opaque', c_void_p),
+        ('bit_rate', c_int64),
+        ('bit_rate_tolerance', c_int),
+        ('global_quality', c_int),
+        ('compression_level', c_int),
+        ('flags', c_int),
+        ('flags2', c_int),
+        ('extradata', POINTER(c_uint8)),
+        ('extradata_size', c_int),
+        ('time_base', AVRational),
+        ('ticks_per_frame', c_int),  # deprecated. to be removed post 61.
+        ('delay', c_int),
+        ('width', c_int),
+        ('height', c_int),
+        ('coded_width', c_int),
+        ('coded_height', c_int),
+        ('gop_size', c_int),
+        ('pix_fmt', c_int),
+        ('draw_horiz_band', CFUNCTYPE(None,
+                                      POINTER(AVCodecContext), POINTER(AVFrame),
+                                      c_int * 8, c_int, c_int, c_int)),
+        ('get_format', CFUNCTYPE(c_int, POINTER(AVCodecContext), POINTER(c_int))),
+        ('max_b_frames', c_int),
+        ('b_quant_factor', c_float),
+        ('b_frame_strategy', c_int),  # Deprecated. Removed in 59.
+        ('b_quant_offset', c_float),
+        ('has_b_frames', c_int),
+        ('mpeg_quant', c_int),  # Deprecated. Removed in 59.
+        ('i_quant_factor', c_float),
+        ('i_quant_offset', c_float),
+        ('lumi_masking', c_float),
+        ('temporal_cplx_masking', c_float),
+        ('spatial_cplx_masking', c_float),
+        ('p_masking', c_float),
+        ('dark_masking', c_float),
+        ('slice_count', c_int),
+        ('prediction_method', c_int),  # Deprecated. Removed in 59.
+        ('slice_offset', POINTER(c_int)),
+        ('sample_aspect_ratio', AVRational),  # Moved in 61
+        ('me_cmp', c_int),
+        ('me_sub_cmp', c_int),
+        ('mb_cmp', c_int),
+        ('ildct_cmp', c_int),
+        ('dia_size', c_int),
+        ('last_predictor_count', c_int),
+        ('pre_me', c_int),  # Deprecated. Removed in 59.
+        ('me_pre_cmp', c_int),
+        ('pre_dia_size', c_int),
+        ('me_subpel_quality', c_int),
+        ('me_range', c_int),
+        ('slice_flags', c_int),
+        ('mb_decision', c_int),
+        ('intra_matrix', POINTER(c_uint16)),
+        ('inter_matrix', POINTER(c_uint16)),
+        ('scenechange_threshold', c_int),  # Deprecated. Removed in 59.
+        ('noise_reduction', c_int),  # Deprecated. Removed in 59.
+        ('intra_dc_precision', c_int),
+        ('skip_top', c_int),
+        ('skip_bottom', c_int),
+        ('mb_lmin', c_int),
+        ('mb_lmax', c_int),
+        ('me_penalty_compensation', c_int),  # Deprecated. Removed in 59.
+        ('bidir_refine', c_int),
+        ('brd_scale', c_int),  # Deprecated. Removed in 59.
+        ('keyint_min', c_int),
+        ('refs', c_int),
+        ('chromaoffset', c_int),  # Deprecated. Removed in 59.
+        ('mv0_threshold', c_int),
+        ('b_sensitivity', c_int),  # Deprecated. Removed in 59.
+        ('color_primaries', c_int),
+        ('color_trc', c_int),
+        ('colorspace', c_int),
+        ('color_range', c_int),
+        ('chroma_sample_location', c_int),
+        ('slices', c_int),
+        ('field_order', c_int),
+        ('sample_rate', c_int),
+        ('channels', c_int),
+        ('sample_fmt', c_int),
+        ('frame_size', c_int),
+        ('frame_number', c_int),
+        ('block_align', c_int),
+        ('cutoff', c_int),
+        ('channel_layout', c_uint64),
+        ('request_channel_layout', c_uint64),
+        ('audio_service_type', c_int),
+        ('request_sample_fmt', c_int),
+        ('get_buffer2', CFUNCTYPE(c_int, POINTER(AVCodecContext), POINTER(AVFrame), c_int)),
+        ('refcounted_frames', c_int),  # Deprecated. Removed in 59.
+        ('qcompress', c_float),
+        ('qblur', c_float),
+        ('qmin', c_int),
+        ('qmax', c_int),
+        ('max_qdiff', c_int),
+        ('rc_buffer_size', c_int),
+        ('rc_override_count', c_int),
+        ('rc_override', POINTER(RcOverride)),
+        ('rc_max_rate', c_int64),
+        ('rc_min_rate', c_int64),
+        ('rc_max_available_vbv_use', c_float),
+        ('rc_min_vbv_overflow_use', c_float),
+        ('rc_initial_buffer_occupancy', c_int),
+        ('coder_type', c_int),  # Deprecated. Removed in 59.
+        ('context_model', c_int),  # Deprecated. Removed in 59.
+        ('frame_skip_threshold', c_int),  # Deprecated. Removed in 59.
+        ('frame_skip_factor', c_int),  # Deprecated. Removed in 59.
+        ('frame_skip_exp', c_int),  # Deprecated. Removed in 59.
+        ('frame_skip_cmp', c_int),  # Deprecated. Removed in 59.
+        ('trellis', c_int),
+        ('min_prediction_order', c_int),  # Deprecated. Removed in 59.
+        ('max_prediction_order', c_int),  # Deprecated. Removed in 59.
+        ('timecode_frame_start', c_int64),  # Deprecated. Removed in 59.
+        ('rtp_callback', CFUNCTYPE(None,  # Deprecated. Removed in 59.
+                                  POINTER(AVCodecContext), c_void_p, c_int, c_int)),
+        ('rtp_payload_size', c_int),  # Deprecated. Removed in 59.
+        ('mv_bits', c_int),  # Deprecated. Removed in 59.
+        ('header_bits', c_int),  # Deprecated. Removed in 59.
+        ('i_tex_bits', c_int),  # Deprecated. Removed in 59.
+        ('p_tex_bits', c_int),  # Deprecated. Removed in 59.
+        ('i_count', c_int),  # Deprecated. Removed in 59.
+        ('p_count', c_int),  # Deprecated. Removed in 59.
+        ('skip_count', c_int),  # Deprecated. Removed in 59.
+        ('misc_bits', c_int),  # Deprecated. Removed in 59.
+        ('frame_bits', c_int),  # Deprecated. Removed in 59.
+        ('stats_out', c_char_p),
+        ('stats_in', c_char_p),
+        ('workaround_bugs', c_int),
+        ('strict_std_compliance', c_int),
+        ('error_concealment', c_int),
+        ('debug', c_int),
+        ('err_recognition', c_int),
+        ('reordered_opaque', c_int64),
+        ('hwaccel', POINTER(AVHWAccel)),
+        ('hwaccel_context', c_void_p),
+        ('error', c_uint64 * AV_NUM_DATA_POINTERS),
+        ('dct_algo', c_int),
+        ('idct_algo', c_int),
+        ('bits_per_coded_sample', c_int),
+        ('bits_per_raw_sample', c_int),
+        ('lowres', c_int),
+        ('coded_frame', POINTER(AVFrame)),  # Deprecated. Removed in 59.
+        ('thread_count', c_int),
+        ('thread_type', c_int),
+        ('active_thread_type', c_int),
+        ('thread_safe_callbacks', c_int),
+        ('execute', CFUNCTYPE(c_int,
+                              POINTER(AVCodecContext),
+                              CFUNCTYPE(c_int, POINTER(AVCodecContext), c_void_p),
+                              c_void_p, c_int, c_int, c_int)),
+        ('execute2', CFUNCTYPE(c_int,
+                               POINTER(AVCodecContext),
+                               CFUNCTYPE(c_int, POINTER(AVCodecContext), c_void_p, c_int, c_int),
+                               c_void_p, c_int, c_int)),
+        ('nsse_weight', c_int),
+        ('profile', c_int),
+        ('level', c_int),
+        ('skip_loop_filter', c_int),
+        ('skip_idct', c_int),
+        ('skip_frame', c_int),
+        ('subtitle_header', POINTER(c_uint8)),
+        ('subtitle_header_size', c_int),
+        ('vbv_delay', c_uint64),  # Deprecated. Removed in 59.
+        ('side_data_only_packets', c_int),  # Deprecated. Removed in 59.
+        ('initial_padding', c_int),
+        ('framerate', AVRational),
+        # !
+        ('sw_pix_fmt', c_int),
+        ('pkt_timebase', AVRational),
+        ('codec_dexcriptor', AVCodecDescriptor),
+        ('pts_correction_num_faulty_pts', c_int64),
+        ('pts_correction_num_faulty_dts', c_int64),
+        ('pts_correction_last_pts', c_int64),
+        ('pts_correction_last_dts', c_int64),
+        ('sub_charenc', c_char_p),
+        ('sub_charenc_mode', c_int),
+        ('skip_alpha', c_int),
+        ('seek_preroll', c_int),
+        ('debug_mv', c_int),
+        ('chroma_intra_matrix', POINTER(c_uint16)),
+        ('dump_separator', POINTER(c_uint8)),
+        ('codec_whitelist', c_char_p),
+        ('properties', c_uint),
+        ('coded_side_data', POINTER(AVPacketSideData)),
+        ('nb_coded_side_data', c_int),
+        ('hw_frames_ctx', POINTER(AVBufferRef)),
+        ('sub_text_format', c_int),
+        ('trailing_padding', c_int),
+        ('max_pixels', c_int64),
+        ('hw_device_ctx', POINTER(AVBufferRef)),
+        ('hwaccel_flags', c_int),
+        ('apply_cropping', c_int),
+        ('extra_hw_frames', c_int)
+    ]
+
+    compat.add_version_changes('avcodec', 58, AVCodecContext, AVCodecContext_Fields, removals=None)
+
+    for compat_ver in (59, 60):
+        compat.add_version_changes('avcodec', compat_ver, AVCodecContext, AVCodecContext_Fields,
+            removals=('b_frame_strategy', 'mpeg_quant', 'prediction_method', 'pre_me', 'scenechange_threshold',
+                          'noise_reduction', 'me_penalty_compensation', 'brd_scale', 'chromaoffset', 'b_sensitivity',
+                          'refcounted_frames', 'coder_type', 'context_model', 'coder_type', 'context_model',
+                          'frame_skip_threshold', 'frame_skip_factor', 'frame_skip_exp', 'frame_skip_cmp',
+                          'min_prediction_order', 'max_prediction_order', 'timecode_frame_start', 'rtp_callback',
+                          'rtp_payload_size', 'mv_bits', 'header_bits', 'i_tex_bits', 'p_tex_bits', 'i_count', 'p_count',
+                          'skip_count', 'misc_bits', 'frames_bits', 'coded_frame', 'vbv_delay', 'side_data_only_packets')
+        )
 
 AV_CODEC_ID_VP8 = 139
 AV_CODEC_ID_VP9 = 167

--- a/pyglet/media/codecs/ffmpeg_lib/libavformat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavformat.py
@@ -2,7 +2,7 @@
 """
 from ctypes import c_int, c_int64
 from ctypes import c_uint8, c_uint, c_double, c_ubyte, c_size_t, c_char, c_char_p
-from ctypes import c_void_p, POINTER, CFUNCTYPE, Structure
+from ctypes import c_void_p, POINTER, CFUNCTYPE, Structure, Union
 
 import pyglet.lib
 from pyglet.util import debug_print
@@ -14,13 +14,15 @@ _debug = debug_print('debug_media')
 
 avformat = pyglet.lib.load_library(
     'avformat',
-    win32=('avformat-60', 'avformat-59', 'avformat-58'),
-    darwin=('avformat.60', 'avformat.59', 'avformat.58')
+    win32=('avformat-61', 'avformat-60', 'avformat-59', 'avformat-58'),
+    darwin=('avformat.61', 'avformat.60', 'avformat.59', 'avformat.58')
 )
 
 avformat.avformat_version.restype = c_int
 
-compat.set_version('avformat', avformat.avformat_version() >> 16)
+avformat_version = avformat.avformat_version() >> 16
+
+compat.set_version('avformat', avformat_version)
 
 AVSEEK_FLAG_BACKWARD = 1  # ///< seek backward
 AVSEEK_FLAG_BYTE = 2  # ///< seeking based on position in bytes
@@ -145,9 +147,11 @@ compat.add_version_changes('avformat', 58, AVStream, AVStream_Fields, removals=(
 compat.add_version_changes('avformat', 59, AVStream, AVStream_Fields,
                            removals=('av_class', 'codec', 'recommended_encoder_configuration', 'info'))
 
-compat.add_version_changes('avformat', 60, AVStream, AVStream_Fields,
-                           removals=('codec', 'recommended_encoder_configuration', 'info'),
-                           repositions=(compat.Reposition("codecpar", "id"),))
+for compat_ver in (60, 61):
+    compat.add_version_changes('avformat', compat_ver, AVStream, AVStream_Fields,
+                               removals=('codec', 'recommended_encoder_configuration', 'info'),
+                               repositions=(compat.Reposition("codecpar", "id"),))
+
 
 class AVProgram(Structure):
     pass
@@ -167,104 +171,248 @@ class AVIOInterruptCB(Structure):
         ('opaque', c_void_p)
     ]
 
+class AVIAMFAudioElement(Structure):
+    ...
+
+class AVIAMFMixPresentation(Structure):
+    ...
+
+class _AvStreamGroupTileGridOffsets(Structure):
+    _fields_ = [
+        ('idx', c_uint),
+        ('horizontal', c_int),
+        ('vertical', c_int),
+    ]
+
+class AVStreamGroupTileGrid(Structure):
+    _fields_ = [
+        ('av_class', POINTER(AVClass)),
+        ('nb_tiles', c_uint),
+        ('coded_width', c_int),
+        ('coded_height', c_int),
+        ('offsets', POINTER(_AvStreamGroupTileGridOffsets)),
+        ('background', c_uint8 * 4),
+        ('horizontal_offset', c_int),
+        ('vertical_offset', c_int),
+        ('width', c_int),
+        ('height', c_int),
+    ]
+
+class AVStreamGroupLCEVC(Structure):
+    _fields_ = [
+        ('av_class', POINTER(AVClass)),
+        ('lcevc_index', c_int),
+        ('width', c_int),
+        ('height', c_int)
+    ]
+
+class _AVStreamGroupParams(Union):
+    _fields_ = [
+        ('iamf_audio_element', POINTER(AVIAMFAudioElement)),
+        ('iamf_mix_presentation', POINTER(AVIAMFMixPresentation)),
+        ('tile_grid', POINTER(AVStreamGroupTileGrid)),
+        ('lcevc', POINTER(AVStreamGroupLCEVC))
+    ]
+
+class AVStreamGroup(Structure):
+    _fields_ = [
+        ('av_class', POINTER(AVClass)),
+        ('priv_data', c_void_p),
+        ('index', c_uint),
+        ('id', c_int64),
+        ('type', c_int),
+        ('params', _AVStreamGroupParams),
+        ('metadata', POINTER(AVDictionary)),
+        ('nb_streams', c_uint),
+        ('streams', POINTER(POINTER(AVStream))),
+        ('disposition', c_int),
+    ]
+
 
 class AVFormatContext(Structure):
     pass
 
 
-AVFormatContext_Fields = [
-    ('av_class', POINTER(AVClass)),
-    ('iformat', POINTER(AVInputFormat)),
-    ('oformat', POINTER(AVOutputFormat)),
-    ('priv_data', c_void_p),
-    ('pb', POINTER(AVIOContext)),
-    ('ctx_flags', c_int),
-    ('nb_streams', c_uint),
-    ('streams', POINTER(POINTER(AVStream))),
-    ('filename', c_char * 1024),  # Deprecated. Removed in 59
-    ('url', c_char_p),
-    ('start_time', c_int64),
-    ('duration', c_int64),
-    ('bit_rate', c_int64),
-    ('packet_size', c_uint),
-    ('max_delay', c_int),
-    ('flags', c_int),
-    ('probesize', c_int64),
-    ('max_analyze_duration', c_int64),
-    ('key', POINTER(c_uint8)),
-    ('keylen', c_int),
-    ('nb_programs', c_uint),
-    ('programs', POINTER(POINTER(AVProgram))),
-    ('video_codec_id', c_int),
-    ('audio_codec_id', c_int),
-    ('subtitle_codec_id', c_int),
-    ('max_index_size', c_uint),
-    ('max_picture_buffer', c_uint),
-    ('nb_chapters', c_uint),
-    ('chapters', POINTER(POINTER(AVChapter))),
-    ('metadata', POINTER(AVDictionary)),
-    ('start_time_realtime', c_int64),
-    ('fps_probe_size', c_int),
-    ('error_recognition', c_int),
-    ('interrupt_callback', AVIOInterruptCB),
-    ('debug', c_int),
-    ('max_interleave_delta', c_int64),
-    ('strict_std_compliance', c_int),
-    ('event_flags', c_int),
-    ('max_ts_probe', c_int),
-    ('avoid_negative_ts', c_int),
-    ('ts_id', c_int),
-    ('audio_preload', c_int),
-    ('max_chunk_duration', c_int),
-    ('max_chunk_size', c_int),
-    ('use_wallclock_as_timestamps', c_int),
-    ('avio_flags', c_int),
-    ('duration_estimation_method', c_uint),
-    ('skip_initial_bytes', c_int64),
-    ('correct_ts_overflow', c_uint),
-    ('seek2any', c_int),
-    ('flush_packets', c_int),
-    ('probe_score', c_int),
-    ('format_probesize', c_int),
-    ('codec_whitelist', c_char_p),
-    ('format_whitelist', c_char_p),
-    ('internal', POINTER(AVFormatInternal)),  # Deprecated. Removed in 59
-    ('io_repositioned', c_int),
-    ('video_codec', POINTER(AVCodec)),
-    ('audio_codec', POINTER(AVCodec)),
-    ('subtitle_codec', POINTER(AVCodec)),
-    ('data_codec', POINTER(AVCodec)),
-    ('metadata_header_padding', c_int),
-    ('opaque', c_void_p),
-    ('control_message_cb', CFUNCTYPE(c_int,
-                                     POINTER(AVFormatContext), c_int, c_void_p,
-                                     c_size_t)),
-    ('output_ts_offset', c_int64),
-    ('dump_separator', POINTER(c_uint8)),
-    ('data_codec_id', c_int),
-    ('protocol_whitelist', c_char_p),
-    ('io_open', CFUNCTYPE(c_int,
-                          POINTER(AVFormatContext),
-                          POINTER(POINTER(AVIOContext)),
-                          c_char_p, c_int,
-                          POINTER(POINTER(AVDictionary)))),
-    ('io_close', CFUNCTYPE(None,
-                           POINTER(AVFormatContext), POINTER(AVIOContext))),
-    ('protocol_blacklist', c_char_p),
-    ('max_streams', c_int),
-    ('skip_estimate_duration_from_pts', c_int),  # Added in 59.
-    ('max_probe_packets', c_int), # Added in 59.
-    ('io_close2', CFUNCTYPE(c_int, POINTER(AVFormatContext), POINTER(AVIOContext))) # Added in 59.
-]
+if avformat_version >= 61:
+    AVFormatContext_Fields = [
+        ('av_class', POINTER(AVClass)),
+        ('iformat', POINTER(AVInputFormat)),
+        ('oformat', POINTER(AVOutputFormat)),
+        ('priv_data', c_void_p),
+        ('pb', POINTER(AVIOContext)),
+        ('ctx_flags', c_int),
+        ('nb_streams', c_uint),
+        ('streams', POINTER(POINTER(AVStream))),
+        ('nb_stream_groups', c_uint),
+        ('stream_groups', POINTER(POINTER(AVStreamGroup))),
+        ('nb_chapters', c_uint),  # Moved after streams in 7.x
+        ('chapters', POINTER(POINTER(AVChapter))),  # Moved after streams in 7.x
+        ('url', c_char_p),
+        ('start_time', c_int64),
+        ('duration', c_int64),
+        ('bit_rate', c_int64),
+        ('packet_size', c_uint),
+        ('max_delay', c_int),
+        ('flags', c_int),
+        ('probesize', c_int64),
+        ('max_analyze_duration', c_int64),
+        ('key', POINTER(c_uint8)),
+        ('keylen', c_int),
+        ('nb_programs', c_uint),
+        ('programs', POINTER(POINTER(AVProgram))),
+        ('video_codec_id', c_int),
+        ('audio_codec_id', c_int),
+        ('subtitle_codec_id', c_int),
+        ('data_codec_id', c_int),
+        ('metadata', POINTER(AVDictionary)),
+        ('start_time_realtime', c_int64),
+        ('fps_probe_size', c_int),
+        ('error_recognition', c_int),
+        ('interrupt_callback', AVIOInterruptCB),
+        ('debug', c_int),
+        ('max_streams', c_int),
+        ('max_index_size', c_uint),
+        ('max_picture_buffer', c_uint),
+        ('max_interleave_delta', c_int64),
+        ('max_ts_probe', c_int),
+        ('max_chunk_duration', c_int),
+        ('max_chunk_size', c_int),
+        ('max_probe_packets', c_int),
+        ('strict_std_compliance', c_int),
+        ('event_flags', c_int),
+        ('avoid_negative_ts', c_int),
+        ('audio_preload', c_int),
+        ('use_wallclock_as_timestamps', c_int),
+        ('skip_estimate_duration_from_pts', c_int),  # Added in 59.
+        ('avio_flags', c_int),
+        ('duration_estimation_method', c_uint),
+        ('skip_initial_bytes', c_int64),
+        ('correct_ts_overflow', c_uint),
+        ('seek2any', c_int),
+        ('flush_packets', c_int),
+        ('probe_score', c_int),
+        ('format_probesize', c_int),
+        ('codec_whitelist', c_char_p),
+        ('format_whitelist', c_char_p),
+        ('protocol_whitelist', c_char_p),
+        ('protocol_blacklist', c_char_p),
+        ('io_repositioned', c_int),
+        ('video_codec', POINTER(AVCodec)),
+        ('audio_codec', POINTER(AVCodec)),
+        ('subtitle_codec', POINTER(AVCodec)),
+        ('data_codec', POINTER(AVCodec)),
+        ('metadata_header_padding', c_int),
+        ('opaque', c_void_p),
+        ('control_message_cb', CFUNCTYPE(c_int,
+                                         POINTER(AVFormatContext), c_int, c_void_p,
+                                         c_size_t)),
+        ('output_ts_offset', c_int64),
+        ('dump_separator', POINTER(c_uint8)),
 
-compat.add_version_changes('avformat', 58, AVFormatContext, AVFormatContext_Fields,
-                           removals=('skip_estimate_duration_from_pts', 'max_probe_packets', 'io_close2'))
+        ('io_open', CFUNCTYPE(c_int,
+                              POINTER(AVFormatContext),
+                              POINTER(POINTER(AVIOContext)),
+                              c_char_p, c_int,
+                              POINTER(POINTER(AVDictionary)))),
 
-compat.add_version_changes('avformat', 59, AVFormatContext, AVFormatContext_Fields,
-                           removals=('filename', 'internal'))
+        ('io_close2', CFUNCTYPE(c_int, POINTER(AVFormatContext), POINTER(AVIOContext)))  # Added in 59.
+    ]
 
-compat.add_version_changes('avformat', 60, AVFormatContext, AVFormatContext_Fields,
-                           removals=('filename', 'internal'))
+    compat.add_version_changes('avformat', 61, AVFormatContext, AVFormatContext_Fields, removals=None)
+
+
+else:
+    AVFormatContext_Fields = [
+        ('av_class', POINTER(AVClass)),
+        ('iformat', POINTER(AVInputFormat)),
+        ('oformat', POINTER(AVOutputFormat)),
+        ('priv_data', c_void_p),
+        ('pb', POINTER(AVIOContext)),
+        ('ctx_flags', c_int),
+        ('nb_streams', c_uint),
+        ('streams', POINTER(POINTER(AVStream))),
+        ('filename', c_char * 1024),  # Deprecated. Removed in 59
+        ('url', c_char_p),
+        ('start_time', c_int64),
+        ('duration', c_int64),
+        ('bit_rate', c_int64),
+        ('packet_size', c_uint),
+        ('max_delay', c_int),
+        ('flags', c_int),
+        ('probesize', c_int64),
+        ('max_analyze_duration', c_int64),
+        ('key', POINTER(c_uint8)),
+        ('keylen', c_int),
+        ('nb_programs', c_uint),
+        ('programs', POINTER(POINTER(AVProgram))),
+        ('video_codec_id', c_int),
+        ('audio_codec_id', c_int),
+        ('subtitle_codec_id', c_int),
+        ('max_index_size', c_uint),
+        ('max_picture_buffer', c_uint),
+        ('nb_chapters', c_uint),  # Moved after streams in 7.x
+        ('chapters', POINTER(POINTER(AVChapter))),  # Moved after streams in 7.x
+        ('metadata', POINTER(AVDictionary)),
+        ('start_time_realtime', c_int64),
+        ('fps_probe_size', c_int),
+        ('error_recognition', c_int),
+        ('interrupt_callback', AVIOInterruptCB),
+        ('debug', c_int),
+        ('max_interleave_delta', c_int64),
+        ('strict_std_compliance', c_int),
+        ('event_flags', c_int),
+        ('max_ts_probe', c_int),
+        ('avoid_negative_ts', c_int),
+        ('ts_id', c_int),
+        ('audio_preload', c_int),
+        ('max_chunk_duration', c_int),
+        ('max_chunk_size', c_int),
+        ('use_wallclock_as_timestamps', c_int),
+        ('avio_flags', c_int),
+        ('duration_estimation_method', c_uint),
+        ('skip_initial_bytes', c_int64),
+        ('correct_ts_overflow', c_uint),
+        ('seek2any', c_int),
+        ('flush_packets', c_int),
+        ('probe_score', c_int),
+        ('format_probesize', c_int),
+        ('codec_whitelist', c_char_p),
+        ('format_whitelist', c_char_p),
+        ('internal', POINTER(AVFormatInternal)),  # Deprecated. Removed in 59
+        ('io_repositioned', c_int),
+        ('video_codec', POINTER(AVCodec)),
+        ('audio_codec', POINTER(AVCodec)),
+        ('subtitle_codec', POINTER(AVCodec)),
+        ('data_codec', POINTER(AVCodec)),
+        ('metadata_header_padding', c_int),
+        ('opaque', c_void_p),
+        ('control_message_cb', CFUNCTYPE(c_int,
+                                         POINTER(AVFormatContext), c_int, c_void_p,
+                                         c_size_t)),
+        ('output_ts_offset', c_int64),
+        ('dump_separator', POINTER(c_uint8)),
+        ('data_codec_id', c_int),
+        ('protocol_whitelist', c_char_p),
+        ('io_open', CFUNCTYPE(c_int,
+                              POINTER(AVFormatContext),
+                              POINTER(POINTER(AVIOContext)),
+                              c_char_p, c_int,
+                              POINTER(POINTER(AVDictionary)))),
+        ('io_close', CFUNCTYPE(None,
+                               POINTER(AVFormatContext), POINTER(AVIOContext))),
+        ('protocol_blacklist', c_char_p),
+        ('max_streams', c_int),
+        ('skip_estimate_duration_from_pts', c_int),  # Added in 59.
+        ('max_probe_packets', c_int), # Added in 59.
+        ('io_close2', CFUNCTYPE(c_int, POINTER(AVFormatContext), POINTER(AVIOContext))) # Added in 59.
+    ]
+
+    compat.add_version_changes('avformat', 58, AVFormatContext, AVFormatContext_Fields,
+                               removals=('skip_estimate_duration_from_pts', 'max_probe_packets', 'io_close2'))
+
+    for compat_ver in (59, 60):
+        compat.add_version_changes('avformat', compat_ver, AVFormatContext, AVFormatContext_Fields,
+                                   removals=('filename', 'internal'))
 
 avformat.av_find_input_format.restype = c_int
 avformat.av_find_input_format.argtypes = [c_int]
@@ -313,5 +461,7 @@ __all__ = [
     'AVSEEK_FLAG_BYTE',
     'AVSEEK_FLAG_ANY',
     'AVSEEK_FLAG_FRAME',
-    'AVFormatContext'
+    'AVFormatContext',
+    'AVCodecContext',
+    'avformat_version',
 ]

--- a/pyglet/media/codecs/ffmpeg_lib/libswresample.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libswresample.py
@@ -1,37 +1,50 @@
 """Wrapper for include/libswresample/swresample.h
 """
-from ctypes import c_int, c_int64
+from ctypes import c_int, c_int64, c_char_p, c_double
 from ctypes import c_uint8
 from ctypes import c_void_p, POINTER, Structure
 
 import pyglet.lib
 from pyglet.util import debug_print
 from . import compat
+from .libavutil import AVChannelLayout, AVSampleFormat
 
 _debug = debug_print('debug_media')
 
 swresample = pyglet.lib.load_library(
     'swresample',
-    win32=('swresample-4', 'swresample-3'),
-    darwin=('swresample.4', 'swresample.3')
+    win32=('swresample-5', 'swresample-4', 'swresample-3'),
+    darwin=('swresample.5', 'swresample.4', 'swresample.3')
 )
 
 swresample.swresample_version.restype = c_int
 
-compat.set_version('swresample', swresample.swresample_version() >> 16)
+swresample_version = swresample.swresample_version() >> 16
 
+compat.set_version('swresample', swresample_version)
 
 SWR_CH_MAX = 32
-
 
 class SwrContext(Structure):
     pass
 
 
-swresample.swr_alloc_set_opts.restype = POINTER(SwrContext)
-swresample.swr_alloc_set_opts.argtypes = [POINTER(SwrContext),
-                                          c_int64, c_int, c_int, c_int64,
-                                          c_int, c_int, c_int, c_void_p]
+if swresample_version < 5:
+    swresample.swr_alloc_set_opts.restype = POINTER(SwrContext)
+    swresample.swr_alloc_set_opts.argtypes = [POINTER(SwrContext),
+                                              c_int64, c_int, c_int, c_int64,
+                                              c_int, c_int, c_int, c_void_p]
+else:
+    swresample.swr_alloc.restype = POINTER(SwrContext)
+    swresample.swr_alloc.argtypes = []
+
+    swresample.swr_alloc_set_opts2.restype = c_int
+    swresample.swr_alloc_set_opts2.argtypes = [POINTER(POINTER(SwrContext)),
+                                              POINTER(AVChannelLayout), AVSampleFormat, c_int,
+                                              POINTER(AVChannelLayout), AVSampleFormat, c_int,
+                                              c_int, c_void_p]
+
+
 swresample.swr_init.restype = c_int
 swresample.swr_init.argtypes = [POINTER(SwrContext)]
 swresample.swr_free.argtypes = [POINTER(POINTER(SwrContext))]
@@ -50,5 +63,6 @@ swresample.swr_get_out_samples.argtypes = [POINTER(SwrContext), c_int]
 __all__ = [
     'swresample',
     'SWR_CH_MAX',
-    'SwrContext'
+    'SwrContext',
+    'swresample_version',
 ]

--- a/pyglet/media/codecs/ffmpeg_lib/libswscale.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libswscale.py
@@ -13,8 +13,8 @@ _debug = debug_print('debug_media')
 
 swscale = pyglet.lib.load_library(
     'swscale',
-    win32=('swscale-7', 'swscale-6', 'swscale-5'),
-    darwin=('swscale.7', 'swscale.6', 'swscale.5')
+    win32=('swscale-8', 'swscale-7', 'swscale-6', 'swscale-5'),
+    darwin=('swscale.8', 'swscale.7', 'swscale.6', 'swscale.5')
 )
 
 swscale.swscale_version.restype = c_int


### PR DESCRIPTION
Update FFMpeg to support new versions as lots of deprecations and re-orderings were made to the structures.

Tested on Windows 10 x64 with version Ffmpeg 7.1 and Python 3.10 and 3.12.