### PR TITLE
Patch COM module for pyglet 1.5

### DIFF
--- a/pyglet/libs/win32/com.py
+++ b/pyglet/libs/win32/com.py
@@ -197,21 +197,21 @@ class COMInterfaceMeta(type):
        cache so it can recognize the type arguments.
     """
 
-    def __init__(cls, name, bases, dct, /, create_pointer_type=True) -> None:
+    def __init__(self, name, bases, dct, /, create_pointer_type=True) -> None:
         super().__init__(name, bases, dct)
 
         if create_pointer_type:
             if not bases:
-                _ptr_bases = (cls, COMPointer)
+                _ptr_bases = (self, COMPointer)
             else:
-                _ptr_bases = (cls, ctypes.POINTER(bases[0]))
+                _ptr_bases = (self, ctypes.POINTER(bases[0]))
 
             # Class type is dynamically created inside __new__ based on metaclass inheritence; update ctypes cache manually.
             from ctypes import _pointer_type_cache
-            _pointer_type_cache[cls] = COMPointerMeta("POINTER({})".format(cls.__name__),
-                                                      _ptr_bases,
-                                                      {"__interface__": cls},
-                                                      create_pointer_type=False)
+            _pointer_type_cache[self] = COMPointerMeta("POINTER({})".format(self.__name__),
+                                                       _ptr_bases,
+                                                       {"__interface__": self},
+                                                       create_pointer_type=False)
 
     def __get_subclassed_methodcount(self):
         """Returns the amount of COM methods in all subclasses to determine offset of methods.

--- a/pyglet/libs/win32/com.py
+++ b/pyglet/libs/win32/com.py
@@ -197,25 +197,33 @@ class COMInterfaceMeta(type):
        cache so it can recognize the type arguments.
     """
 
-    def __new__(mcs, name, bases, dct):
+    def __new__(mcs, name, bases, dct, /, create_pointer_type=True):
+        if not create_pointer_type:
+            return super().__new__(mcs, name, bases, dct)
+
         methods = dct.pop("_methods_", None)
         cls = type.__new__(mcs, name, bases, dct)
 
         if methods is not None:
             cls._methods_ = methods
 
-        if not bases:
-            _ptr_bases = (cls, COMPointer)
-        else:
-            _ptr_bases = (cls, ctypes.POINTER(bases[0]))
-
-        # Class type is dynamically created inside __new__ based on metaclass inheritence; update ctypes cache manually.
-        from ctypes import _pointer_type_cache
-        _pointer_type_cache[cls] = type(COMPointer)("POINTER({})".format(cls.__name__),
-                                                    _ptr_bases,
-                                                    {"__interface__": cls})
-
         return cls
+
+    def __init__(cls, name, bases, dct, /, create_pointer_type=True) -> None:
+        super().__init__(name, bases, dct)
+
+        if create_pointer_type:
+            if not bases:
+                _ptr_bases = (cls, COMPointer)
+            else:
+                _ptr_bases = (cls, ctypes.POINTER(bases[0]))
+
+            # Class type is dynamically created inside __new__ based on metaclass inheritence; update ctypes cache manually.
+            from ctypes import _pointer_type_cache
+            _pointer_type_cache[cls] = COMPointerMeta("POINTER({})".format(cls.__name__),
+                                                      _ptr_bases,
+                                                      {"__interface__": cls},
+                                                      create_pointer_type=False)
 
     def __get_subclassed_methodcount(self):
         """Returns the amount of COM methods in all subclasses to determine offset of methods.
@@ -236,8 +244,14 @@ class COMInterfaceMeta(type):
 class COMPointerMeta(type(ctypes.c_void_p), COMInterfaceMeta):
     """Required to prevent metaclass conflicts with inheritance."""
 
+    # The `create_pointer_type` arg is needed in Python version 3.13 due to changes in the
+    # PyCSimpleType (metatype of c_void_p) initialization process.
+    # It fails on 3.12 and lower unless it's filtered out in this method.
+    def __new__(cls, name, bases, dct, /, create_pointer_type=True):
+        return super().__new__(cls, name, bases, dct)
 
-class COMPointer(ctypes.c_void_p, metaclass=COMPointerMeta):
+
+class COMPointer(ctypes.c_void_p, metaclass=COMPointerMeta, create_pointer_type=False):
     """COM Pointer base, could use c_void_p but need to override from_param ."""
 
     @classmethod
@@ -257,7 +271,6 @@ class COMPointer(ctypes.c_void_p, metaclass=COMPointerMeta):
                 return ptr_dct[cls.__interface__]
             except KeyError:
                 raise TypeError("Interface {} doesn't have a pointer in this class.".format(cls.__name__))
-
 
 def _missing_impl(interface_name, method_name):
     """Functions that are not implemented use this to prevent errors when called."""


### PR DESCRIPTION
Iny Python 3.13, ctypes' `PyCSimpleType` metaclass changed from performing its initialization in `__new__` to `__init__`.
This necessitates a move of relevant custom metatype logic to `__init__` as well, specifically that of `COMInterfaceMeta`.

- Move ctypes initialization to `__init__` to fix an error on 3.13.
- This causes an error on 3.12 and below, as `__init__` is run on the definition of `COMPointer` and all other types with the metatype `COMPointerMeta`.
- Implement the `create_pointer_type` class initialization argument from [the current pyglet 2.0 implementation](https://github.com/pyglet/pyglet/blob/2f09a8c35296513b0e3229fac3a7a66f8b816655/pyglet/libs/win32/com.py).
- Python 3.12 and below still fail, as the `create_pointer_type` keyword-argument is not consumed by any `__new__` method and causes an error in `__init_subclass__`.
- Add a `__new__` method to `COMPointerMeta` that consumes `create_pointer_type`.

NOTE: Functionally, `COMInterfaceMeta.__new__` was being called on definition of `COMPointer` in Python 3.13, when it previously wasn't. All non-ctypes relevant things (those were moved to `COMInterfaceMeta.__init__`) that this function did were:
  - Call `type.__new__` directly instead of using `super`.
  - Remove the `_methods_` kwarg from the class dict prior to type creation, only to then set it back after.

As these steps aren't critical, and things work exactly the same without, remove `COMInterfaceMeta.__new__` entirely.
From what I can tell, this does not cause any issues.

This change should be tested on other versions than just 3.13 and 3.12.
I only tried to play audio through XAudio2 on both Python versions in a virtual machine, as well as run the `text.advanced_font` example, which both worked equally well.
