### PR TITLE
Proofreading and fixes for Weight and other 2.1 migration

### DIFF
--- a/doc/modules/text/index.rst
+++ b/doc/modules/text/index.rst
@@ -12,6 +12,16 @@ pyglet.text
 
 .. rubric:: Details
 
+.. force the Enum to be documented by excluding and manually adding it
+
 .. automodule:: pyglet.text
+  :exclude-members: Weight
   :members:
   :undoc-members:
+
+  .. keep the members ordered from lightest to heaviest
+
+  .. autoclass:: Weight
+     :member-order: bysource
+     :members:
+     :undoc-members:

--- a/doc/programming_guide/migration.rst
+++ b/doc/programming_guide/migration.rst
@@ -8,7 +8,7 @@ of the code base. If you are upgrading from pyglet 2.0 and your game or project
 has suddenly stopped working, this is the place for you. The following sections
 should hopefully get you up and running again without too much effort. If you
 are having an issue that is not covered here, please open up an issue ticket on
-`Github <https://github.com/pyglet/pyglet/issues>`_ so that we can add it.
+`GitHub <https://github.com/pyglet/pyglet/issues>`_ so that we can add it.
 
 Window "HiDPI" support
 ----------------------

--- a/doc/programming_guide/migration.rst
+++ b/doc/programming_guide/migration.rst
@@ -23,29 +23,54 @@ Labels & Text Layouts
 Argument Consistency
 ^^^^^^^^^^^^^^^^^^^^
 
-The positional argument order for text Labels and Layouts was not consistent
-in previous pyglet releases. This has been refactored to make things more
-uniform, with the goal of making it easier to switch between Layouts or
-create custom subclasses. All layouts now _start_ with the same positional
-argument ordering::
+The positional arguments for creating :py:class:`pyglet.text` layouts
+and labels now all *start* with similar argument orders. This helps
+you:
+
+* switch between labels and layouts
+* create custom subclasses
+
+The order *after* the initial arguments may differ. Please see any
+relevant API documentation to learn more.
+
+Layout Arguments
+""""""""""""""""
+All :py:mod:`pyglet.text.layout` types now *start* with the same positional
+argument order::
 
     TextLayout(document, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
     ScrollableTextLayout(document, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
     IncrementalTextLayout(document, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
 
-The label classes also follow a similar default argument ordering, with one
-small exception: :py:class:`~Label` and :py:class:`~HTMLLabel` take a string as
-their first ``text`` argument instead of a :py:class:`~Document` instance.
+These types all take a concrete instance of an
+:py:class:`~pyglet.text.layout.AbstractDocument` subclass as their
+first argument. Subsequent arguments may differ.
 
-Other than that, the rest of the positional arguments line up::
+Please see the following to learn more:
+
+* :py:class:`pyglet.text.layout.TextLayout`
+* :py:class:`pyglet.text.layout.ScrollableTextLayout`
+* :py:class:`pyglet.text.layout.IncrementalTextLayout`
+
+Label Arguments
+"""""""""""""""
+The label classes now also share similar early argument orders.
+
+Only :py:class:`~pyglet.text.DocumentLabel` is identical to layouts in
+its initial arguments. The others both take a string ``text`` argument
+as their first argument::
 
     DocumentLabel(document, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
     Label(text, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
     HTMLLabel(text, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
 
-The layouts and labels don't share all of the same argument, so the rest of the
-arguments will need to be provided as usual, where they differ. Please see the
-API documents for full details.
+As with layouts, the subsequent arguments may vary. Please see the following
+to learn more:
+
+* :py:class:`pyglet.text.DocumentLabel`
+* :py:class:`pyglet.text.Label`
+* :py:class:`pyglet.text.HTMLLabel`
+
 
 Replace Bold With Weight
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/programming_guide/migration.rst
+++ b/doc/programming_guide/migration.rst
@@ -19,6 +19,10 @@ zoom or scale (such as 4K displays). This is exposed as new pyglet options. See
 
 Labels & Text Layouts
 ---------------------
+
+Argument Consistency
+^^^^^^^^^^^^^^^^^^^^
+
 The positional argument order for text Labels and Layouts was not consistent
 in previous pyglet releases. This has been refactored to make things more
 uniform, with the goal of making it easier to switch between Layouts or
@@ -29,9 +33,11 @@ argument ordering::
     ScrollableTextLayout(document, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
     IncrementalTextLayout(document, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
 
-The Label classes also follow a similar default argument ordering, with one
-small exception: Label and HTMLLabel take "text" as the first argument instead
-of "document". Other than that, the rest of the positional arguments line up::
+The label classes also follow a similar default argument ordering, with one
+small exception: :py:class:`~Label` and :py:class:`~HTMLLabel` take a string as
+their first ``text`` argument instead of a :py:class:`~Document` instance.
+
+Other than that, the rest of the positional arguments line up::
 
     DocumentLabel(document, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
     Label(text, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
@@ -40,6 +46,9 @@ of "document". Other than that, the rest of the positional arguments line up::
 The layouts and labels don't share all of the same argument, so the rest of the
 arguments will need to be provided as usual, where they differ. Please see the
 API documents for full details.
+
+Replace Bold With Weight
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 In addition to argument ordering, the ``bold`` argument has been replaced with
 ``weight``. Rather than a single True/False boolean, you can now pass a string

--- a/doc/programming_guide/migration.rst
+++ b/doc/programming_guide/migration.rst
@@ -37,7 +37,7 @@ of "document". Other than that, the rest of the positional arguments line up::
     Label(text, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
     HTMLLabel(text, x, y, z, width, height, anchor_x, anchor_y, rotation, ...)
 
-The layouts and lables don't share all of the same argument, so the rest of the
+The layouts and labels don't share all of the same argument, so the rest of the
 arguments will need to be provided as usual, where they differ. Please see the
 API documents for full details.
 

--- a/doc/programming_guide/migration.rst
+++ b/doc/programming_guide/migration.rst
@@ -75,13 +75,14 @@ to learn more:
 Replace Bold With Weight
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-In addition to argument ordering, the ``bold`` argument has been replaced with
-``weight``. Rather than a single True/False boolean, you can now pass a string
-for the desired font weight. An enum (:py:class:`~pyglet.text.Weight`) exists
-to provide a reference to all valid cross platform weights (though individual
-font backends _can_ support more names that what is provided there). The valid
-weight names mimic those in CSS, such as "thin", "normal", "bold", "extrabold",
-etc..
+The string ``weight`` argument is more flexible than the ``bold`` argument it replaces.
+
+The ``weight`` argument now allows you too choose a desired font weight from
+those your specific font and rendering back-end support. For known cross-platform
+``weight`` strings, please see :py:class:`pyglet.text.Weight`.
+
+* The names and values mimic OpenType and CSS (``"bold"``, ``"thin"``, ``extrabold``, etc)
+* Some rendering back-ends *may* support more names than listed there
 
 Shapes
 ------

--- a/doc/programming_guide/migration.rst
+++ b/doc/programming_guide/migration.rst
@@ -10,12 +10,32 @@ should hopefully get you up and running again without too much effort. If you
 are having an issue that is not covered here, please open up an issue ticket on
 `GitHub <https://github.com/pyglet/pyglet/issues>`_ so that we can add it.
 
-Window "HiDPI" support
+Setting pyglet Options
 ----------------------
+
+The :py:attr:`pyglet.options` attribute now uses a dedicated class with new features.
+
+The Options Object
+^^^^^^^^^^^^^^^^^^
+The :py:attr:`pyglet.options` attribute now uses a :py:class:`pyglet.Options` class.
+
+Although it is now a :py:class:`dataclass <dataclasses.dataclass>` instead of a
+:py:class:`dict`, it supports both of the following access approaches:
+
+* attribute style (:py:attr:`pyglet.debug_gl <pyglet.Options.debug_gl>`)
+* subscript / :py:class:`dict` style (``pyglet.options['debug_gl'`)
+
+
+Window "HiDPI" support
+^^^^^^^^^^^^^^^^^^^^^^
 The v2.1 release now provides a lot more control over how modern 'HiDPI' displays
 are treated. This includes "retina" displays, or any display that has a non-100%
-zoom or scale (such as 4K displays). This is exposed as new pyglet options. See
-``pyglet.options.dpi_scaling`` for more information.
+zoom or scale (such as 4K displays). This is exposed as new pyglet option. Please
+see the following to learn more:
+
+* :py:attr:`pyglet.options.dpi_scaling <pyglet.Options.dpi_scaling>`
+* :py:attr:`pyglet.Options`
+
 
 Labels & Text Layouts
 ---------------------

--- a/doc/programming_guide/options.rst
+++ b/doc/programming_guide/options.rst
@@ -30,9 +30,9 @@ For options requiring a tuple of values, separate each value with a comma.
 Environment settings
 --------------------
 
-Options in the :py:attr:`pyglet.options` dictionary can have defaults set
-through the operating system's environment variable.  The following table
-shows which environment variable is used for each option:
+The default :py:class:`pyglet.Options` instance (:py:attr:`pyglet.options`)
+can read default values from the operating system's environment variable. The
+following table shows which environment variable is used for each option:
 
     .. list-table::
         :header-rows: 1

--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -341,7 +341,11 @@ class DocumentLabel(layout.TextLayout):
 
     @property
     def weight(self) -> str:
-        """The font weight (boldness), as a string."""
+        """The font weight (boldness or thickness), as a string.
+
+        See the :py:class:`~Weight` enum for valid cross-platform
+        string values.
+        """
         return self.document.get_style("weight")
 
     @weight.setter

--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -437,8 +437,8 @@ class Label(DocumentLabel):
             font_size:
                 Font size, in points.
             weight:
-                The 'weight' of the font (boldness). See the :py:class:~`Weight`
-                enum for valid weight names.
+                The 'weight' of the font (boldness). See the :py:class:`~Weight`
+                enum for valid cross-platform weight names.
             italic:
                 Italic font style.
             stretch:

--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -80,15 +80,40 @@ SupportedMimeTypes = Literal["text/plain", "text/html", "text/vnd.pyglet-attribu
 
 
 class Weight(str, Enum):
-    """Valid font weights."""
+    """An :py:class:`~enum.Enum` of known cross-platform font weight strings.
+
+    Each value is both an :py:class:`~enum.Enum` and a :py:class:`str`.
+    This is not a built-in Python :py:class:`~enum.StrEnum` to ensure
+    compatibility with Python < 3.11.
+
+    .. important:: Fonts will use the closest match if they lack a weight!
+
+    The values of this enum imitate the string names for font weights
+    as used in CSS and the OpenType specification. Numerical font weights
+    are not supported because:
+
+    * Integer font weight support and behavior varies by back-end
+    * Some font renderers do not support or round :py:class:`float` values
+    * Some font renderers lack support for variable-width fonts
+
+    Additional weight strings may be supported by certain font-rendering
+    back-ends. To learn more, please see your platform's API documentation
+    and the following:
+
+    #. `The MDN article on CSS font weights <https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight>`_
+    #. `The OpenType specification <https://learn.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass>`_
+
+    """
 
     THIN = 'thin'
     EXTRALIGHT = 'extralight'
     LIGHT = 'light'
     NORMAL = 'normal'
+    """The default weight for a font."""
     MEDIUM = 'medium'
     SEMIBOLD = 'semibold'
     BOLD = 'bold'
+    """The default **bold** style for a font."""
     EXTRABOLD = 'extrabold'
     ULTRABOLD = 'ultrabold'
 


### PR DESCRIPTION
* Allow `Weight` to render in the doc and be cross-referenced
* Fix typo in `Weight` enum cross-ref
* Add cross-refs to `weight` from `Label` object
* Add outbound info links for `Weight`
* Rephrase and clarify existing migration guide sections:
   * Added headings
   * Added cross-refs to API doc
   * Added `Options` object
* Update env variable doc to cross-ref `Options` object and other items
* Make sure various other cross-refs actually work