### PR TITLE
Fix top-left version display and copyright auto-generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -217,7 +217,10 @@ copyright = "2006-2008, Alex Holkner. 2008-2023 pyglet contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.0"
+if pyglet.version.count(".") == 1:
+    version = pyglet.version
+else:
+    version = pyglet.version.rsplit('.', 1)[0]
 # The full version, including alpha/beta/rc tags.
 release = pyglet.version
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -210,7 +210,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "pyglet"
-copyright = "2006-2008, Alex Holkner. 2008-2023 pyglet contributors"
+copyright = f"2006-2008, Alex Holkner. 2008-{now.year} pyglet contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
These commit should also be cherry-pickable for development branch.

### Changes:

1. Fix this so 2.1 shows 2.1 in the left-hand sidebar:
![image](https://github.com/user-attachments/assets/6a2ea58d-e327-4cca-94c8-d5773e3a4adf)

2. Make the copyright year auto-update at the bottom of the page