### PR TITLE
Small fixed in quickstart docs and examples

### DIFF
--- a/doc/programming_guide/quickstart.rst
+++ b/doc/programming_guide/quickstart.rst
@@ -190,8 +190,8 @@ Specify ``streaming=False`` in this case::
     sound = pyglet.resource.media('shot.wav', streaming=False)
     sound.play()
 
-The `examples/media_player.py` example demonstrates playback of streaming
-audio and video using pyglet.  The `examples/noisy/noisy.py` example
+The `examples/media/media_player.py` example demonstrates playback of streaming
+audio and video using pyglet.  The `examples/media/noisy/noisy.py` example
 demonstrates playing many short audio samples simultaneously, as in a game.
 
 .. [#mp3] MP3 and other compressed audio formats require FFmpeg to be installed.
@@ -222,7 +222,7 @@ bit, the `graphics` module provides higher level objects for the most common
 OpenGL constructs. The :ref:`guide_graphics` section goes into more detail.
 
 There are numerous examples of pyglet applications in the ``examples/``
-directory of the documentation and source distributions.  If you get
+directory of the documentation.  If you get
 stuck, or have any questions, join us on the `mailing list`_ or `Discord`_!
 
 .. _mailing list: http://groups.google.com/group/pyglet-users

--- a/examples/input/input.py
+++ b/examples/input/input.py
@@ -1,12 +1,5 @@
-#!/usr/bin/env python
-
 """Print the details of all available input devices to stdout.
 """
-
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id: $'
-
 import pyglet
 
 window = pyglet.window.Window()

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Usage
 
@@ -14,11 +13,6 @@ Options
 The raw data captured in the .dbg can be rendered as human readable
 using the script report.py
 """
-
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id: $'
-
 import os
 import sys
 import weakref

--- a/examples/media/video.py
+++ b/examples/media/video.py
@@ -7,11 +7,6 @@ Usage::
 
 See the Programming Guide for a partial list of supported video formats.
 """
-
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import sys
 import pyglet
 

--- a/examples/programming_guide/animation.py
+++ b/examples/programming_guide/animation.py
@@ -7,10 +7,6 @@ Usage::
 
 If the filename is omitted, a sample animation is loaded
 """
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 # The dinosaur.gif file packaged alongside this script is in the public
 # domain, it was obtained from http://www.gifanimations.com/.
 

--- a/examples/programming_guide/events.py
+++ b/examples/programming_guide/events.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python
-"""
-"""
-
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import pyglet
 from pyglet.window import key
 from pyglet.window import mouse

--- a/examples/programming_guide/image_viewer.py
+++ b/examples/programming_guide/image_viewer.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-"""
-"""
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import pyglet
 
 window = pyglet.window.Window()

--- a/experimental/svg_test.py
+++ b/experimental/svg_test.py
@@ -1,12 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: latin-1 -*-
-
-"""
-"""
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import re
 import os.path
 import pyglet

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -1258,8 +1258,6 @@ class Texture(AbstractImage):
 
         return cls(width, height, target, tex_id.value, min_filter, mag_filter)
 
-        return texture
-
     def get_image_data(self, z: int = 0) -> ImageData:
         """Get the image data of this texture.
 

--- a/tests/integration/platform/test_win_multicore_clock.py
+++ b/tests/integration/platform/test_win_multicore_clock.py
@@ -7,11 +7,6 @@
 due to the underlaying use of win32 QueryPerformanceCounter.
 If your update is seeing a negative dt, then time.clock is probably the culprit.
 AMD or Intel Patches for multicore may fix this problem (if you see it at all)"""
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
-
 import time
 import sys
 from tests.annotations import require_platform, Platform

--- a/tools/al_info.py
+++ b/tools/al_info.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
-
 """Print OpenAL driver information.
 
 Options:
   -d <device>   Optionally specify device to query.
 """
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import ctypes
 import optparse
 import sys

--- a/tools/genwrappers.py
+++ b/tools/genwrappers.py
@@ -1,12 +1,4 @@
 #!/usr/bin/env python
-
-'''
-'''
-from __future__ import print_function
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 from wraptypes.wrap import main as wrap
 import os.path
 import sys

--- a/tools/gl_info.py
+++ b/tools/gl_info.py
@@ -1,10 +1,4 @@
 #!/usr/bin/env python
-'''
-'''
-
-__docformat__ = 'restructuredtext'
-__version__ = '1.2'
-
 import sys
 import textwrap
 

--- a/tools/wraptypes/__init__.py
+++ b/tools/wraptypes/__init__.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
+"""A package for generating ctypes wrappers from a C header file.
 
-'''A package for generating ctypes wrappers from a C header file.  See the
-docstring for wrap.py for usage.
+See the docstring for wrap.py for usage.
 
 The files 'lex.py' and 'yacc.py' are from PLY (http://www.dabeaz.com/ply),
 which was written by David M. Beazley but have been modified slightly
 for this tool.
-'''
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
-
+"""

--- a/tools/wraptypes/cparser.py
+++ b/tools/wraptypes/cparser.py
@@ -13,11 +13,6 @@ Reference is C99:
   * http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1124.pdf
 
 '''
-from __future__ import print_function
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import cPickle
 import operator
 import os.path

--- a/tools/wraptypes/ctypesparser.py
+++ b/tools/wraptypes/ctypesparser.py
@@ -1,11 +1,4 @@
 #!/usr/bin/env python
-
-'''
-'''
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 from cparser import *
 
 ctypes_type_map = {

--- a/tools/wraptypes/preprocessor.py
+++ b/tools/wraptypes/preprocessor.py
@@ -13,11 +13,6 @@ Reference is C99:
   * Also understands GNU #include_next
 
 '''
-from __future__ import print_function
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import operator
 import os.path
 import cPickle

--- a/tools/wraptypes/wrap.py
+++ b/tools/wraptypes/wrap.py
@@ -7,10 +7,6 @@ Usage example::
 
 """
 from __future__ import annotations
-
-__docformat__ = 'restructuredtext'
-__version__ = '$Id$'
-
 import sys
 import textwrap
 
@@ -62,10 +58,6 @@ class CtypesWrapper(CtypesParser, CtypesTypeVisitor):
 
             Do not modify this file.
             '''
-
-            __docformat__ =  'restructuredtext'
-            __version__ = '$Id$'
-
             import ctypes
             from ctypes import *
 


### PR DESCRIPTION
I think the `__docformat__` and `__version__` in the examples is useless?
(git blame shows it wasn't touched since 17 years)

If correct I could send another PR to systematically remove it from all example files or add that here if you prefer.