### PR TITLE
Simplify super().__init__ calls using Python 3

### DIFF
--- a/doc/programming_guide/examplegame.rst
+++ b/doc/programming_guide/examplegame.rst
@@ -526,7 +526,7 @@ same behavior as a PhysicalObject plus a little extra, so we’ll need to call
 PhysicalObject's `update()` method and then respond to input::
 
     def update(self, dt):
-        super(Player, self).update(dt)
+        super().update(dt)
 
         if self.keys['left']:
             self.rotation -= self.rotate_speed * dt
@@ -699,7 +699,7 @@ gracefully, we must write a simple but slightly enhanced `delete()` method::
 
     def delete(self):
         self.engine_sprite.delete()
-        super(Player, self).delete()
+        super().delete()
 
 The Player class is now cleaned up and ready to go.
 
@@ -890,7 +890,7 @@ subclass of PhysicalObject::
         """Bullets fired by the player"""
 
         def __init__(self, *args, **kwargs):
-            super(Bullet, self).__init__(
+            super().__init__(
                 resources.bullet_image, *args, **kwargs)
 
 To get bullets to disappear after a time, we could keep track of our own
@@ -906,7 +906,7 @@ We can do this as soon as the object is initialized by adding a call to
 :meth:`pyglet.clock.schedule_once` to the constructor::
 
     def __init__(self, *args, **kwargs):
-        super(Bullet, self).__init__(resources.bullet_image, *args, **kwargs)
+        super().__init__(resources.bullet_image, *args, **kwargs)
         pyglet.clock.schedule_once(self.die, 0.5)
 
 There’s still more work to be done on the Bullet class, but before we
@@ -924,7 +924,7 @@ to its constructor::
 
     class Player(physicalobject.PhysicalObject):
         def __init__(self, *args, **kwargs):
-            super(Player, self).__init__(img=resources.player_image, *args, **kwargs)
+            super().__init__(img=resources.player_image, *args, **kwargs)
             ...
             self.bullet_speed = 700.0
 
@@ -1065,7 +1065,7 @@ to pass a specific image to the superclass, passing along any other parameters::
 
     class Asteroid(physicalobject.PhysicalObject):
         def __init__(self, *args, **kwargs):
-            super(Asteroid, self).__init__(resources.asteroid_image, *args, **kwargs)
+            super().__init__(resources.asteroid_image, *args, **kwargs)
 
 Now we need to write a new `handle_collision_with()` method.  It should create
 a random number of new, smaller asteroids with random velocities.  However,
@@ -1077,7 +1077,7 @@ We want to keep the old behavior of ignoring other asteroids, so start the
 method with a call to the superclass’s method::
 
     def handle_collision_with(self, other_object):
-        super(Asteroid, self).handle_collision_with(other_object)
+        super().handle_collision_with(other_object)
 
 Now we can say that if it’s supposed to die, and it’s big enough, then we
 should create two or three new asteroids with random rotations and velocities.
@@ -1088,7 +1088,7 @@ like they come from the same object::
 
     class Asteroid:
         def handle_collision_with(self, other_object):
-            super(Asteroid, self).handle_collision_with(other_object)
+            super().handle_collision_with(other_object)
             if self.dead and self.scale > 0.25:
                 num_asteroids = random.randint(2, 3)
                 for i in range(num_asteroids):
@@ -1107,13 +1107,13 @@ rotation every frame.
 Add the attribute in the constructor::
 
     def __init__(self, *args, **kwargs):
-        super(Asteroid, self).__init__(resources.asteroid_image, *args, **kwargs)
+        super().__init__(resources.asteroid_image, *args, **kwargs)
         self.rotate_speed = random.random() * 100.0 - 50.0
 
 Then write the update() method::
 
     def update(self, dt):
-        super(Asteroid, self).update(dt)
+        super().update(dt)
         self.rotation += self.rotate_speed * dt
 
 The last thing we need to do is go over to load.py and have the asteroid()

--- a/examples/game/version2/game/physicalobject.py
+++ b/examples/game/version2/game/physicalobject.py
@@ -5,7 +5,7 @@ class PhysicalObject(pyglet.sprite.Sprite):
     """A sprite with physical properties such as velocity"""
 
     def __init__(self, *args, **kwargs):
-        super(PhysicalObject, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # In addition to position, we have velocity
         self.velocity_x, self.velocity_y = 0.0, 0.0

--- a/examples/game/version2/game/player.py
+++ b/examples/game/version2/game/player.py
@@ -7,7 +7,7 @@ class Player(physicalobject.PhysicalObject):
     """Physical object that responds to user input"""
 
     def __init__(self, *args, **kwargs):
-        super(Player, self).__init__(img=resources.player_image, *args, **kwargs)
+        super().__init__(img=resources.player_image, *args, **kwargs)
 
         # Set some easy-to-tweak constants
         self.thrust = 300.0
@@ -33,7 +33,7 @@ class Player(physicalobject.PhysicalObject):
 
     def update(self, dt):
         # Do all the normal physics stuff
-        super(Player, self).update(dt)
+        super().update(dt)
 
         if self.keys['left']:
             self.rotation -= self.rotate_speed * dt

--- a/examples/game/version3/game/physicalobject.py
+++ b/examples/game/version3/game/physicalobject.py
@@ -6,7 +6,7 @@ class PhysicalObject(pyglet.sprite.Sprite):
     """A sprite with physical properties such as velocity"""
 
     def __init__(self, *args, **kwargs):
-        super(PhysicalObject, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # In addition to position, we have velocity
         self.velocity_x, self.velocity_y = 0.0, 0.0

--- a/examples/game/version3/game/player.py
+++ b/examples/game/version3/game/player.py
@@ -8,7 +8,7 @@ class Player(physicalobject.PhysicalObject):
     """Physical object that responds to user input"""
 
     def __init__(self, *args, **kwargs):
-        super(Player, self).__init__(img=resources.player_image, *args, **kwargs)
+        super().__init__(img=resources.player_image, *args, **kwargs)
 
         # Create a child sprite to show when the ship is thrusting
         self.engine_sprite = pyglet.sprite.Sprite(img=resources.engine_image, *args, **kwargs)
@@ -23,7 +23,7 @@ class Player(physicalobject.PhysicalObject):
 
     def update(self, dt):
         # Do all the normal physics stuff
-        super(Player, self).update(dt)
+        super().update(dt)
 
         if self.key_handler[key.LEFT]:
             self.rotation -= self.rotate_speed * dt
@@ -50,4 +50,4 @@ class Player(physicalobject.PhysicalObject):
         # We have a child sprite which must be deleted when this object
         # is deleted from batches, etc.
         self.engine_sprite.delete()
-        super(Player, self).delete()
+        super().delete()

--- a/examples/game/version4/game/asteroid.py
+++ b/examples/game/version4/game/asteroid.py
@@ -6,17 +6,17 @@ class Asteroid(physicalobject.PhysicalObject):
     """An asteroid that divides a little before it dies"""
 
     def __init__(self, *args, **kwargs):
-        super(Asteroid, self).__init__(resources.asteroid_image, *args, **kwargs)
+        super().__init__(resources.asteroid_image, *args, **kwargs)
 
         # Slowly rotate the asteroid as it moves
         self.rotate_speed = random.random() * 100.0 - 50.0
 
     def update(self, dt):
-        super(Asteroid, self).update(dt)
+        super().update(dt)
         self.rotation += self.rotate_speed * dt
 
     def handle_collision_with(self, other_object):
-        super(Asteroid, self).handle_collision_with(other_object)
+        super().handle_collision_with(other_object)
 
         # Superclass handles deadness already
         if self.dead and self.scale > 0.25:

--- a/examples/game/version4/game/bullet.py
+++ b/examples/game/version4/game/bullet.py
@@ -6,7 +6,7 @@ class Bullet(physicalobject.PhysicalObject):
     """Bullets fired by the player"""
 
     def __init__(self, *args, **kwargs):
-        super(Bullet, self).__init__(resources.bullet_image, *args, **kwargs)
+        super().__init__(resources.bullet_image, *args, **kwargs)
 
         # Bullets shouldn't stick around forever
         pyglet.clock.schedule_once(self.die, 0.5)

--- a/examples/game/version4/game/physicalobject.py
+++ b/examples/game/version4/game/physicalobject.py
@@ -6,7 +6,7 @@ class PhysicalObject(pyglet.sprite.Sprite):
     """A sprite with physical properties such as velocity"""
 
     def __init__(self, *args, **kwargs):
-        super(PhysicalObject, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Velocity
         self.velocity_x, self.velocity_y = 0.0, 0.0

--- a/examples/game/version4/game/player.py
+++ b/examples/game/version4/game/player.py
@@ -8,7 +8,7 @@ class Player(physicalobject.PhysicalObject):
     """Physical object that responds to user input"""
 
     def __init__(self, *args, **kwargs):
-        super(Player, self).__init__(img=resources.player_image, *args, **kwargs)
+        super().__init__(img=resources.player_image, *args, **kwargs)
 
         # Create a child sprite to show when the ship is thrusting
         self.engine_sprite = pyglet.sprite.Sprite(img=resources.engine_image, *args, **kwargs)
@@ -28,7 +28,7 @@ class Player(physicalobject.PhysicalObject):
 
     def update(self, dt):
         # Do all the normal physics stuff
-        super(Player, self).update(dt)
+        super().update(dt)
 
         if self.key_handler[key.LEFT]:
             self.rotation -= self.rotate_speed * dt
@@ -81,4 +81,4 @@ class Player(physicalobject.PhysicalObject):
         # We have a child sprite which must be deleted when this object
         # is deleted from batches, etc.
         self.engine_sprite.delete()
-        super(Player, self).delete()
+        super().delete()

--- a/examples/game/version5/game/asteroid.py
+++ b/examples/game/version5/game/asteroid.py
@@ -6,17 +6,17 @@ class Asteroid(physicalobject.PhysicalObject):
     """An asteroid that divides a little before it dies"""
 
     def __init__(self, *args, **kwargs):
-        super(Asteroid, self).__init__(resources.asteroid_image, *args, **kwargs)
+        super().__init__(resources.asteroid_image, *args, **kwargs)
 
         # Slowly rotate the asteroid as it moves
         self.rotate_speed = random.random() * 100.0 - 50.0
 
     def update(self, dt):
-        super(Asteroid, self).update(dt)
+        super().update(dt)
         self.rotation += self.rotate_speed * dt
 
     def handle_collision_with(self, other_object):
-        super(Asteroid, self).handle_collision_with(other_object)
+        super().handle_collision_with(other_object)
 
         # Superclass handles deadness already
         if self.dead and self.scale > 0.25:

--- a/examples/game/version5/game/bullet.py
+++ b/examples/game/version5/game/bullet.py
@@ -6,7 +6,7 @@ class Bullet(physicalobject.PhysicalObject):
     """Bullets fired by the player"""
 
     def __init__(self, *args, **kwargs):
-        super(Bullet, self).__init__(resources.bullet_image, *args, **kwargs)
+        super().__init__(resources.bullet_image, *args, **kwargs)
 
         # Bullets shouldn't stick around forever
         pyglet.clock.schedule_once(self.die, 0.5)

--- a/examples/game/version5/game/physicalobject.py
+++ b/examples/game/version5/game/physicalobject.py
@@ -6,7 +6,7 @@ class PhysicalObject(pyglet.sprite.Sprite):
     """A sprite with physical properties such as velocity"""
 
     def __init__(self, *args, **kwargs):
-        super(PhysicalObject, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Velocity
         self.velocity_x, self.velocity_y = 0.0, 0.0

--- a/examples/game/version5/game/player.py
+++ b/examples/game/version5/game/player.py
@@ -8,7 +8,7 @@ class Player(physicalobject.PhysicalObject):
     """Physical object that responds to user input"""
 
     def __init__(self, *args, **kwargs):
-        super(Player, self).__init__(img=resources.player_image, *args, **kwargs)
+        super().__init__(img=resources.player_image, *args, **kwargs)
 
         # Create a child sprite to show when the ship is thrusting
         self.engine_sprite = pyglet.sprite.Sprite(img=resources.engine_image, *args, **kwargs)
@@ -28,7 +28,7 @@ class Player(physicalobject.PhysicalObject):
 
     def update(self, dt):
         # Do all the normal physics stuff
-        super(Player, self).update(dt)
+        super().update(dt)
 
         if self.key_handler[key.LEFT]:
             self.rotation -= self.rotate_speed * dt
@@ -81,4 +81,4 @@ class Player(physicalobject.PhysicalObject):
         # We have a child sprite which must be deleted when this object
         # is deleted from batches, etc.
         self.engine_sprite.delete()
-        super(Player, self).delete()
+        super().delete()

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -58,7 +58,7 @@ class Control(pyglet.event.EventDispatcher):
     width = height = 10
 
     def __init__(self, parent):
-        super(Control, self).__init__()
+        super().__init__()
         self.parent = weakref.proxy(parent)
 
     def hit_test(self, x, y):
@@ -101,7 +101,7 @@ Button.register_event_type('on_press')
 
 class TextButton(Button):
     def __init__(self, *args, **kwargs):
-        super(TextButton, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._text = pyglet.text.Label('', anchor_x='center', anchor_y='center')
 
     def draw_label(self):
@@ -123,7 +123,7 @@ class Slider(Control):
     RESPONSIVNESS = 0.3
 
     def __init__(self, *args, **kwargs):
-        super(Slider, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.seek_value = None
 
     def draw(self):
@@ -183,7 +183,7 @@ class PlayerWindow(pyglet.window.Window):
     GUI_BUTTON_HEIGHT = 16
 
     def __init__(self, player):
-        super(PlayerWindow, self).__init__(caption='Media Player',
+        super().__init__(caption='Media Player',
                                            visible=False,
                                            resizable=True)
         # We only keep a weakref to player as we are about to push ourself
@@ -285,7 +285,7 @@ class PlayerWindow(pyglet.window.Window):
 
     def on_resize(self, width, height):
         """Position and size video image."""
-        super(PlayerWindow, self).on_resize(width, height)
+        super().on_resize(width, height)
         self.slider.width = width - self.GUI_PADDING * 2
 
         height -= self.GUI_HEIGHT

--- a/examples/media/noisy/noisy.py
+++ b/examples/media/noisy/noisy.py
@@ -37,7 +37,7 @@ class Ball(pyglet.sprite.Sprite):
         x = random.random() * (window.width - self.width)
         y = random.random() * (window.height - self.height)
 
-        super(Ball, self).__init__(self.ball_image, x, y, batch=balls_batch)
+        super().__init__(self.ball_image, x, y, batch=balls_batch)
 
         self.dx = (random.random() - 0.5) * 1000
         self.dy = (random.random() - 0.5) * 1000

--- a/examples/text/text_input.py
+++ b/examples/text/text_input.py
@@ -29,7 +29,7 @@ class TextWidget:
 
 class Window(pyglet.window.Window):
     def __init__(self, *args, **kwargs):
-        super(Window, self).__init__(400, 140, caption='Text entry', *args, **kwargs)
+        super().__init__(400, 140, caption='Text entry', *args, **kwargs)
 
         self.batch = pyglet.graphics.Batch()
         self.labels = [
@@ -52,7 +52,7 @@ class Window(pyglet.window.Window):
         self.set_focus(self.widgets[0])
 
     def on_resize(self, width, height):
-        super(Window, self).on_resize(width, height)
+        super().on_resize(width, height)
         for widget in self.widgets:
             widget.width = width - 110
 

--- a/pyglet/app/xlib.py
+++ b/pyglet/app/xlib.py
@@ -54,7 +54,7 @@ class NotificationDevice(XlibSelectDevice):
 
 class XlibEventLoop(PlatformEventLoop):
     def __init__(self):
-        super(XlibEventLoop, self).__init__()
+        super().__init__()
         self._notification_device = NotificationDevice()
         self.select_devices = set()
         self.select_devices.add(self._notification_device)

--- a/pyglet/display/cocoa.py
+++ b/pyglet/display/cocoa.py
@@ -31,7 +31,7 @@ class CocoaScreen(Screen):
         # http://www.cocoabuilder.com/archive/cocoa/233492-ns-cg-rect-conversion-and-screen-coordinates.html
         x, y = bounds.origin.x, bounds.origin.y
         width, height = bounds.size.width, bounds.size.height
-        super(CocoaScreen, self).__init__(display, int(x), int(y), int(width), int(height))
+        super().__init__(display, int(x), int(y), int(width), int(height))
         self._cg_display_id = displayID
         # Save the default mode so we can restore to it.
         self._default_mode = self.get_mode()
@@ -111,7 +111,7 @@ class CocoaScreen(Screen):
 class CocoaScreenMode(ScreenMode):
 
     def __init__(self, screen, cgmode):
-        super(CocoaScreenMode, self).__init__(screen)
+        super().__init__(screen)
         quartz.CGDisplayModeRetain(cgmode)
         self.cgmode = cgmode
         self.width = int(quartz.CGDisplayModeGetWidth(cgmode))

--- a/pyglet/display/win32.py
+++ b/pyglet/display/win32.py
@@ -63,7 +63,7 @@ class Win32Screen(Screen):
     _initial_mode = None
 
     def __init__(self, display, handle, x, y, width, height):
-        super(Win32Screen, self).__init__(display, x, y, width, height)
+        super().__init__(display, x, y, width, height)
         self._handle = handle
 
     def get_matching_configs(self, template):
@@ -145,7 +145,7 @@ class Win32Screen(Screen):
 
 class Win32ScreenMode(ScreenMode):
     def __init__(self, screen, mode):
-        super(Win32ScreenMode, self).__init__(screen)
+        super().__init__(screen)
         self._mode = mode
         self.width = mode.dmPelsWidth
         self.height = mode.dmPelsHeight
@@ -158,6 +158,6 @@ class Win32ScreenMode(ScreenMode):
 
 class Win32Canvas(Canvas):
     def __init__(self, display, hwnd, hdc):
-        super(Win32Canvas, self).__init__(display)
+        super().__init__(display)
         self.hwnd = hwnd
         self.hdc = hdc

--- a/pyglet/display/xlib.py
+++ b/pyglet/display/xlib.py
@@ -96,7 +96,7 @@ class XlibDisplay(XlibSelectDevice, Display):
         if x_screen >= screen_count:
             raise NoSuchDisplayException(f'Display "{name}" has no screen {x_screen:d}')
 
-        super(XlibDisplay, self).__init__()
+        super().__init__()
         self.name = name
         self.x_screen = x_screen
 

--- a/pyglet/image/codecs/dds.py
+++ b/pyglet/image/codecs/dds.py
@@ -86,7 +86,7 @@ class DDSURFACEDESC2(_FileStruct):
     ]
 
     def __init__(self, data):
-        super(DDSURFACEDESC2, self).__init__(data)
+        super().__init__(data)
         self.ddpfPixelFormat = DDPIXELFORMAT(self.ddpfPixelFormat)
 
 

--- a/pyglet/input/linux/x11_xinput.py
+++ b/pyglet/input/linux/x11_xinput.py
@@ -43,7 +43,7 @@ class DeviceResponder:
 
 class XInputDevice(DeviceResponder, Device):
     def __init__(self, display, device_info):
-        super(XInputDevice, self).__init__(display, asstr(device_info.name))
+        super().__init__(display, asstr(device_info.name))
 
         self._device_id = device_info.id
         self._device = None
@@ -104,7 +104,7 @@ class XInputDevice(DeviceResponder, Device):
     def open(self, window=None, exclusive=False):
         # Checks for is_open and raises if already open.
         # TODO allow opening on multiple windows.
-        super(XInputDevice, self).open(window, exclusive)
+        super().open(window, exclusive)
 
         if window is None:
             self._is_open = False
@@ -126,7 +126,7 @@ class XInputDevice(DeviceResponder, Device):
         self._install_events(window)
 
     def close(self):
-        super(XInputDevice, self).close()
+        super().close()
 
         if not self._device:
             return

--- a/pyglet/input/linux/x11_xinput_tablet.py
+++ b/pyglet/input/linux/x11_xinput_tablet.py
@@ -23,7 +23,7 @@ class XInputTablet(Tablet):
 
 class XInputTabletCanvas(DeviceResponder, TabletCanvas):
     def __init__(self, window, cursors):
-        super(XInputTabletCanvas, self).__init__(window)
+        super().__init__(window)
         self.cursors = cursors
 
         dispatcher = XInputWindowEventDispatcher.get_dispatcher(window)
@@ -71,7 +71,7 @@ class XInputTabletCanvas(DeviceResponder, TabletCanvas):
 
 class XInputTabletCursor(TabletCursor):
     def __init__(self, device):
-        super(XInputTabletCursor, self).__init__(device.name)
+        super().__init__(device.name)
         self.device = device
 
 

--- a/pyglet/input/win32/directinput.py
+++ b/pyglet/input/win32/directinput.py
@@ -64,7 +64,7 @@ def _create_control(object_instance):
 class DirectInputDevice(base.Device):
     def __init__(self, display, device, device_instance):
         name = device_instance.tszInstanceName
-        super(DirectInputDevice, self).__init__(display, name)
+        super().__init__(display, name)
 
         self._type = device_instance.dwDevType & 0xff
         self._subtype = device_instance.dwDevType & 0xff00

--- a/pyglet/input/win32/wintab.py
+++ b/pyglet/input/win32/wintab.py
@@ -86,7 +86,7 @@ class WintabTabletCanvas(TabletCanvas):
     override_keys = False
 
     def __init__(self, device, window, msg_base=wintab.WT_DEFBASE):
-        super(WintabTabletCanvas, self).__init__(window)
+        super().__init__(window)
 
         self.device = device
         self.msg_base = msg_base

--- a/tests/base/interactive.py
+++ b/tests/base/interactive.py
@@ -166,7 +166,7 @@ class InteractiveTestCase(PygletTestCase):
     allow_missing_screenshots = False
 
     def __init__(self, methodName):
-        super(InteractiveTestCase, self).__init__(methodName=methodName)
+        super().__init__(methodName=methodName)
         self._screenshots = []
 
     def check_screenshots(self):

--- a/tests/integration/text/test_empty_document.py
+++ b/tests/integration/text/test_empty_document.py
@@ -12,7 +12,7 @@ def text_window(request):
 
     class _TestWindow(window.Window):
         def __init__(self, doctype, *args, **kwargs):
-            super(_TestWindow, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
             self.batch = graphics.Batch()
             self.document = doctype()

--- a/tests/interactive/image/test_image.py
+++ b/tests/interactive/image/test_image.py
@@ -9,7 +9,7 @@ from ...base.event_loop import EventLoopFixture
 
 class ImageTestFixture(EventLoopFixture):
     def __init__(self, request, test_data):
-        super(ImageTestFixture, self).__init__(request)
+        super().__init__(request)
         self.test_data = test_data
 
         self.show_checkerboard = True

--- a/tests/interactive/text/test_caret_color.py
+++ b/tests/interactive/text/test_caret_color.py
@@ -24,7 +24,7 @@ class TestWindow(window.Window):
         caret_color=(0, 0, 0, 255),
         **kwargs
     ):
-        super(TestWindow, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.batch = graphics.Batch()
         self.document = text.decode_text(
@@ -43,7 +43,7 @@ class TestWindow(window.Window):
         self.set_mouse_cursor(self.get_system_mouse_cursor('text'))
 
     def on_resize(self, width, height):
-        super(TestWindow, self).on_resize(width, height)
+        super().on_resize(width, height)
         self.layout.begin_update()
         self.layout.x = self.margin
         self.layout.y = self.margin
@@ -61,7 +61,7 @@ class TestWindow(window.Window):
         self.batch.draw()
 
     def on_key_press(self, symbol, modifiers):
-        super(TestWindow, self).on_key_press(symbol, modifiers)
+        super().on_key_press(symbol, modifiers)
         if symbol == key.TAB:
             self.caret.on_text('\t')
 
@@ -112,7 +112,7 @@ class SetterTestWindow(TestWindow):
         "changed to {0}, then close the window."
 
     def on_key_press(self, symbol, modifiers):
-        super(SetterTestWindow, self).on_key_press(symbol, modifiers)
+        super().on_key_press(symbol, modifiers)
         if symbol == key.TAB:
             self.caret.color = (0, 255, 0, 10)
 

--- a/tests/interactive/text/test_content_valign.py
+++ b/tests/interactive/text/test_content_valign.py
@@ -26,7 +26,7 @@ Duis arcu eros, iaculis ut, vehicula in, elementum a, sapien. Phasellus ut tellu
 
 class TestWindow(window.Window):
     def __init__(self, content_valign, *args, **kwargs):
-        super(TestWindow, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.batch = graphics.Batch()
         self.document = text.decode_text(doctext)
@@ -42,7 +42,7 @@ class TestWindow(window.Window):
         self.set_mouse_cursor(self.get_system_mouse_cursor('text'))
 
     def on_resize(self, width, height):
-        super(TestWindow, self).on_resize(width, height)
+        super().on_resize(width, height)
         self.layout.begin_update()
         self.layout.x = self.margin
         self.layout.y = self.margin
@@ -60,7 +60,7 @@ class TestWindow(window.Window):
         self.batch.draw()
 
     def on_key_press(self, symbol, modifiers):
-        super(TestWindow, self).on_key_press(symbol, modifiers)
+        super().on_key_press(symbol, modifiers)
         if symbol == key.TAB:
             self.caret.on_text('\t')
 

--- a/tests/interactive/text/test_html.py
+++ b/tests/interactive/text/test_html.py
@@ -192,7 +192,7 @@ Hard line breaks
 
 class TestWindow(pyglet.window.Window):
     def __init__(self, *args, **kwargs):
-        super(TestWindow, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.batch = pyglet.graphics.Batch()
         self.document = pyglet.text.decode_html(doctext)
@@ -207,7 +207,7 @@ class TestWindow(pyglet.window.Window):
         self.set_mouse_cursor(self.get_system_mouse_cursor('text'))
 
     def on_resize(self, width, height):
-        super(TestWindow, self).on_resize(width, height)
+        super().on_resize(width, height)
         self.layout.begin_update()
         self.layout.x = self.margin
         self.layout.y = self.margin
@@ -225,7 +225,7 @@ class TestWindow(pyglet.window.Window):
         self.batch.draw()
 
     def on_key_press(self, symbol, modifiers):
-        super(TestWindow, self).on_key_press(symbol, modifiers)
+        super().on_key_press(symbol, modifiers)
         if symbol == pyglet.window.key.TAB:
             self.caret.on_text('\t')
 

--- a/tests/interactive/text/test_inline_elements_style_change.py
+++ b/tests/interactive/text/test_inline_elements_style_change.py
@@ -91,7 +91,7 @@ class TestElement(document.InlineElement):
 
 class TestWindow(pyglet.window.Window):
     def __init__(self, *args, **kwargs):
-        super(TestWindow, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.batch = pyglet.graphics.Batch()
         self.document = pyglet.text.decode_attributed(doctext)
@@ -113,7 +113,7 @@ class TestWindow(pyglet.window.Window):
         self.batch.draw()
 
     def on_key_press(self, symbol, modifiers):
-        super(TestWindow, self).on_key_press(symbol, modifiers)
+        super().on_key_press(symbol, modifiers)
         if symbol == pyglet.window.key.TAB:
             self.caret.on_text('\t')
 

--- a/tests/interactive/text/test_multiline_wrap.py
+++ b/tests/interactive/text/test_multiline_wrap.py
@@ -32,7 +32,7 @@ And, because the parameter wrap_lines=True the {font_size 16}long lines are brok
 
 class BaseTestWindow(window.Window):
     def __init__(self, multiline, wrap_lines, msg, *args, **kwargs):
-        super(BaseTestWindow, self).__init__(*args, width=640, height=480, **kwargs)
+        super().__init__(*args, width=640, height=480, **kwargs)
 
         self.batch = graphics.Batch()
         self.document = text.decode_attributed(msg)
@@ -51,7 +51,7 @@ class BaseTestWindow(window.Window):
         self.set_mouse_cursor(self.get_system_mouse_cursor('text'))
 
     def on_resize(self, width, height):
-        super(BaseTestWindow, self).on_resize(width, height)
+        super().on_resize(width, height)
         self.layout.begin_update()
         self.layout.x = self.margin
         self.layout.y = self.margin
@@ -70,7 +70,7 @@ class BaseTestWindow(window.Window):
         self.batch.draw()
 
     def on_key_press(self, symbol, modifiers):
-        super(BaseTestWindow, self).on_key_press(symbol, modifiers)
+        super().on_key_press(symbol, modifiers)
         if symbol == key.TAB:
             self.caret.on_text('\t')
 

--- a/tests/interactive/window/test_window_events.py
+++ b/tests/interactive/window/test_window_events.py
@@ -83,7 +83,7 @@ class KeyPressWindowEventTestCase(WindowEventsTestCase):
     mod_meta = key.MOD_SHIFT | key.MOD_ALT
 
     def setUp(self):
-        super(KeyPressWindowEventTestCase, self).setUp()
+        super().setUp()
         self.chosen_symbol = None
         self.chosen_modifiers = None
         self.completely_pressed = False
@@ -242,7 +242,7 @@ class TextWindowEventsTest(WindowEventsTestCase):
     text = '`1234567890-=~!@#$%^&*()_+qwertyuiop[]\\QWERTYUIOP{}|asdfghjkl;\'ASDFGHJKL:"zxcvbnm,./ZXCVBNM<>?'
 
     def setUp(self):
-        super(TextWindowEventsTest, self).setUp()
+        super().setUp()
         self.chosen_text = None
         self.checks_passed = 0
 
@@ -284,7 +284,7 @@ class TextMotionWindowEventsTest(WindowEventsTestCase):
                    key.MOTION_DELETE)
 
     def setUp(self):
-        super(TextMotionWindowEventsTest, self).setUp()
+        super().setUp()
         self.chosen_key = None
         self.checks_passed = 0
 
@@ -332,7 +332,7 @@ class TextMotionSelectWindowEventsTest(WindowEventsTestCase):
                    key.MOTION_DELETE)
 
     def setUp(self):
-        super(TextMotionSelectWindowEventsTest, self).setUp()
+        super().setUp()
         self.chosen_key = None
         self.checks_passed = 0
 
@@ -389,7 +389,7 @@ class ActivateDeactivateWindowEventsTest(WindowEventsTestCase):
     number_of_checks = 3
 
     def setUp(self):
-        super(ActivateDeactivateWindowEventsTest, self).setUp()
+        super().setUp()
         self.window_active = None
         self.checks_passed = 0
 
@@ -434,7 +434,7 @@ class ExposeWindowEventsTest(WindowEventsTestCase):
     number_of_checks = 5
 
     def setUp(self):
-        super(ExposeWindowEventsTest, self).setUp()
+        super().setUp()
         self.checks_passed = 0
 
     def on_expose(self):
@@ -458,7 +458,7 @@ class ShowHideWindowEventsTest(WindowEventsTestCase):
     number_of_checks = 5
 
     def setUp(self):
-        super(ShowHideWindowEventsTest, self).setUp()
+        super().setUp()
         self.checks_passed = 0
         self.visible = False
 

--- a/tests/interactive/window/test_window_multisample.py
+++ b/tests/interactive/window/test_window_multisample.py
@@ -5,6 +5,7 @@ from pyglet.gl import *
 from pyglet import window
 from pyglet import clock
 from pyglet.window import key
+import pyglet
 
 
 @pytest.mark.requires_user_action

--- a/tools/ffmpeg/mpexceptions.py
+++ b/tools/ffmpeg/mpexceptions.py
@@ -29,7 +29,7 @@ class ExceptionPlaylistFileDoNotExists(ExceptionPygletMediaPlayerTesting):
 class ExceptionBadSampleInPlaylist(ExceptionPygletMediaPlayerTesting):
     def __init__(self, rejected):
         self.rejected = rejected
-        super(ExceptionBadSampleInPlaylist, self).__init__()
+        super().__init__()
 
 class ExceptionUnknownReport(ExceptionPygletMediaPlayerTesting):
     def __init__(self, rpt_name):

--- a/tools/wraptypes/cparser.py
+++ b/tools/wraptypes/cparser.py
@@ -104,15 +104,14 @@ class Declarator(object):
 class Pointer(Declarator):
     pointer = None
     def __init__(self):
-        super(Pointer, self).__init__()
+        super().__init__()
         self.qualifiers = []
 
     def __repr__(self):
         q = ''
         if self.qualifiers:
             q = '<%s>' % ' '.join(self.qualifiers)
-        return 'POINTER%s(%r)' % (q, self.pointer) + \
-            super(Pointer, self).__repr__()
+        return 'POINTER%s(%r)' % (q, self.pointer) + super().__repr__()
 
 class Array(object):
     def __init__(self):


### PR DESCRIPTION
When reading the tutorial I saw that you still had a few cases of the old Python 2 syntax to call `super()` in `__init__` methods. This PR updates all such cases to the modern Python 3 syntax. Should behave identically.