### PR TITLE
Add new window minimum size for xlib configurenotify event

### DIFF
--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -1600,8 +1600,8 @@ class XlibWindow(BaseWindow):
         w, h = ev.xconfigure.width, ev.xconfigure.height
         x, y = ev.xconfigure.x, ev.xconfigure.y
         if self._width != w or self._height != h:
-            self._width = w
-            self._height = h
+            self._width = max(1, w)
+            self._height = max(1, h)
             self._update_view_size()
             self.dispatch_event('_on_internal_resize', self._width, self._height)
         if self._x != x or self._y != y:


### PR DESCRIPTION
Platform
------------------------------------------------------------------------------
platform:  Linux-6.12.10-arch1-1-x86_64-with-glibc2.40
release:   6.12.10-arch1-1
machine:   x86_64

Python
------------------------------------------------------------------------------
implementation: CPython
sys.version: 3.13.1 (main, Dec  4 2024, 18:05:56) [GCC 14.2.1 20240910]
sys.maxint: 9223372036854775807
os.getcwd(): /home/csd4ni3l/Documents/Python3/EndlZ/src

pyglet
------------------------------------------------------------------------------
pyglet.version: 2.1.2
pyglet.compat_platform: linux

Adds a minimum window size for the event. This fixes my issue, where Xlib/XWayland returns the window size as 0, 0 in the configure event, which should be invalid. This crashes pyglet because when setting a new projection triggered by _on_internal_resize, it will result in a DivisionByZero error.

The fix is just using the max funcion with 1 for the width and height.