### PR TITLE
Simplify docs version handling

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,13 +1,9 @@
 pyglet Documentation
 ====================
 
-.. ATTENTION::
-   This documentation is for the pyglet 2.1 series, which has a few small API
-   changes from the 2.0 series. Previous documentation can be found at:
-   `2.0 maintenance <https://pyglet.readthedocs.io/en/pyglet-2.0-maintenance/>`_.
-   Documentation for the 1.5 series, which is the last to support legacy OpenGL,
-   can be found here:
-   `1.5 maintenance <https://pyglet.readthedocs.io/en/pyglet-1.5-maintenance/>`_.
+.. note::
+   This is the documentation for pyglet version |version|.
+   If you need a different one use the docs version selector.
 
 **pyglet** is a cross-platform windowing and multimedia library for Python,
 intended for developing games and other visually rich applications. It supports

--- a/doc/programming_guide/installation.rst
+++ b/doc/programming_guide/installation.rst
@@ -1,10 +1,8 @@
 Installation
 ============
 
-.. note:: These instructions apply to pyglet |version|.
-
 pyglet is a pure Python library, with no hard dependencies on other modules.
-No special steps or complitation are required for installation. You can install
+No special steps or compilation are required for installation. You can install
 from `on PyPI <https://pypi.python.org/pypi/pyglet>`_ via **pip**. For example:
 
 .. code-block:: sh


### PR DESCRIPTION
This is a proposal to simplify the docs version display and version cross-linking on RTD so that it's zero maintenance, no manual edits in RST docs needed as you push new versions.

Note that currently you have a link to v1.5 docs but that gives a 404 "not found" error. I see you have that branch on Github, so if you think users need those old docs you could go to the RTD config and build it and it would show up In the RTD version selector widget.

<img width="1048" alt="Screenshot 2025-02-11 at 23 43 03" src="https://github.com/user-attachments/assets/cb53e212-ebcd-4646-b3ca-708e147fe496" />

I've tried to maintain many-version docs with cross links pointing out older and newer releases before and it was always painful, especially pointing to newer releases. I see e.g. https://docs.astropy.org/en/stable/ and other projects also have settled on the simple solution to just show the version on the landing page.

