### PR TITLE
Remove docs references to deleted astraea

### DIFF
--- a/doc/programming_guide/examplegame.rst
+++ b/doc/programming_guide/examplegame.rst
@@ -1147,11 +1147,3 @@ I’m going to leave it as an exercise for you to do the following::
 Good luck!  With a little effort, you should be able to figure out most of
 these things on your own. If you have trouble, join us on the pyglet
 `Discord server <https://discord.gg/QXyegWe>`_.
-
-Also, in addition to this example game, there is yet *another* Asteroids clone
-available in the `/examples/astraea/` folder in the pyglet source directory.
-In comparison to this example game excercise we've just completed,
-Astraea is a complete game with a proper menu, score system, and additional
-graphical effects.  No step-by-step documentation is available for Astraea,
-but the code itself should be easy to understand and illustrates some nice
-techniques.

--- a/doc/programming_guide/image.rst
+++ b/doc/programming_guide/image.rst
@@ -582,8 +582,8 @@ Image grids
 ^^^^^^^^^^^
 
 An "image grid" is a single image which is divided into several smaller images
-by drawing an imaginary grid over it.  The following image shows an image used
-for the explosion animation in the *Astraea* example.
+by drawing an imaginary grid over it.  The following image shows an image that
+can be used for an asteroid explosion animation.
 
 .. figure:: img/explosion.png
 


### PR DESCRIPTION
@benmoran56 - looks like you removed the `astraea` example in b9a63ea
This PR removes two remaining mentions of it in the docs.