### PR TITLE
PR Draft for discussion: optional border for RoundedRectangle

### DIFF
--- a/pyglet/app/base.py
+++ b/pyglet/app/base.py
@@ -40,7 +40,9 @@ class PlatformEventLoop:
         If the method is called from the :py:meth:`run` method's thread (for
         example, from within an event handler), the event may be dispatched
         within the same runloop iteration or the next one; the choice is
-        nondeterministic.
+        nondeterministic. However unlike `EventDispatcher.dispatch_event`,
+        the event will always be queued and never will control be passed
+        directly to callbacks registered for the event.
         """
         self._event_queue.put((dispatcher, event, args))
         self.notify()

--- a/pyglet/event.py
+++ b/pyglet/event.py
@@ -333,6 +333,10 @@ class EventDispatcher:
         ``EVENT_UNHANDLED``. If there were no events registered to
         receive this event, ``False`` is returned.
 
+        Note that this method may queue the event, or it may immediately
+        pass control to the callbacks registered for it, before this
+        method returns to the caller.
+
         Returns:
             ``EVENT_HANDLED`` if any event handler returned ``EVENT_HANDLED``;
             ``EVENT_UNHANDLED`` if one or more event handlers were invoked


### PR DESCRIPTION
I have played with a first and admiteddly rough cut, of adding the mentioned feature to the RoundedRectangle class. My changes are to `RoundedRectangle` inside pyglet.shapes.ShapeBase. 

Thinking about it, I'm not sure why a bordered rectangle needs a Shape class, people can overlay lines and a rectangle. Performance? With a rounded rectangle, the border requires some humble math for making the arcs of the border parallel to those of the rectangle's inner (unbordered) part, which kind of makes a good excuse for having a Shape class for it. 

This PR draft is only in order to get your feedback on whether you'd rather have a separate class for a rounded rectangle with a border, rather than having a border be an option for the rounded rectangle class as in this PR draft. I assume you get the combinatorial nature of splitting or merging a border feature into every shape, which the current PR touches on. 

It also raises the question of whether it is preferred to have borders be inside or go beyond, the shape's input dimensions, which may have been only arbitrarily decided insofar by the merge of the original RoundedRectangle shape not so long ago, or more likely, follows the common design choice in shape api out there. On this ocassion thanks again for the RoundedRectangle work!

I apologize that one commit adding an old and unimportant unrelated docstring update spilled through my PR but can be ignored.