### PR TITLE
Use dotclock instead of rate in xlib vidmoderestore set_initial_mode

### DIFF
--- a/pyglet/display/xlib_vidmoderestore.py
+++ b/pyglet/display/xlib_vidmoderestore.py
@@ -165,7 +165,7 @@ def set_initial_mode(mode):
     if (display, screen) in _restorable_screens:
         return
 
-    packet = ModePacket(display, screen, mode.width, mode.height, mode.rate)
+    packet = ModePacket(display, screen, mode.width, mode.height, mode.info.dotclock)
 
     os.write(_mode_write_pipe, packet.encode())
     _restorable_screens.add((display, screen))


### PR DESCRIPTION
- Since now the mode.rate is the actual hz value on Xlib, its not the dotclock. It was only used in xlib videmoderestore in the code, so replacing with dotclock fixes the issue.

Fixes #1284 