### PR TITLE
Fix text interactive tests.

### DIFF
--- a/tests/interactive/text/test_caret_color.py
+++ b/tests/interactive/text/test_caret_color.py
@@ -34,7 +34,8 @@ class TestWindow(window.Window):
         self.margin = 2
         self.layout = layout.IncrementalTextLayout(
             self.document,
-            self.width - self.margin * 2, self.height - self.margin * 2,
+            width=self.width - self.margin * 2,
+            height=self.height - self.margin * 2,
             multiline=True,
             batch=self.batch)
         self.caret = caret.Caret(self.layout, color=caret_color)

--- a/tests/interactive/text/test_content_valign.py
+++ b/tests/interactive/text/test_content_valign.py
@@ -32,7 +32,8 @@ class TestWindow(window.Window):
         self.document = text.decode_text(doctext)
         self.margin = 2
         self.layout = layout.IncrementalTextLayout(self.document,
-                                                   self.width - self.margin * 2, self.height - self.margin * 2,
+                                                   width=self.width - self.margin * 2,
+                                                   height=self.height - self.margin * 2,
                                                    multiline=True,
                                                    batch=self.batch)
         self.layout.content_valign = content_valign

--- a/tests/interactive/text/test_html.py
+++ b/tests/interactive/text/test_html.py
@@ -198,7 +198,8 @@ class TestWindow(pyglet.window.Window):
         self.document = pyglet.text.decode_html(doctext)
         self.margin = 2
         self.layout = layout.IncrementalTextLayout(self.document,
-                                                   self.width - self.margin * 2, self.height - self.margin * 2,
+                                                   width=self.width - self.margin * 2,
+                                                   height=self.height - self.margin * 2,
                                                    multiline=True,
                                                    batch=self.batch)
         self.caret = caret.Caret(self.layout)

--- a/tests/interactive/text/test_inline_elements.py
+++ b/tests/interactive/text/test_inline_elements.py
@@ -121,7 +121,9 @@ class BaseTestWindow(pyglet.window.Window):
             self.document.insert_element(i, TestElement(60, -10, 70))
         self.margin = 2
         self.layout = IncrementalTextLayout(
-            self.document, self.width - self.margin * 2, self.height - self.margin * 2,
+            self.document,
+            width=self.width - self.margin * 2,
+            height=self.height - self.margin * 2,
             multiline=True,
             batch=self.batch)
         self.caret = caret.Caret(self.layout)

--- a/tests/interactive/text/test_inline_elements_style_change.py
+++ b/tests/interactive/text/test_inline_elements_style_change.py
@@ -99,7 +99,9 @@ class TestWindow(pyglet.window.Window):
             self.document.insert_element(i, TestElement(60, -10, 70))
         self.margin = 2
         self.layout = IncrementalTextLayout(
-            self.document, self.width - self.margin * 2, self.height - self.margin * 2,
+            self.document,
+            width=self.width - self.margin * 2,
+            height=self.height - self.margin * 2,
             multiline=True,
             batch=self.batch)
         self.caret = caret.Caret(self.layout)

--- a/tests/interactive/text/test_multiline_wrap.py
+++ b/tests/interactive/text/test_multiline_wrap.py
@@ -38,8 +38,8 @@ class BaseTestWindow(window.Window):
         self.document = text.decode_attributed(msg)
         self.margin = 2
         self.layout = layout.IncrementalTextLayout(self.document,
-                                                   (self.width - self.margin * 2),
-                                                   self.height - self.margin * 2,
+                                                   width=(self.width - self.margin * 2),
+                                                   height=self.height - self.margin * 2,
                                                    multiline=multiline,
                                                    wrap_lines=wrap_lines,
                                                    batch=self.batch)

--- a/tests/interactive/text/test_plain.py
+++ b/tests/interactive/text/test_plain.py
@@ -33,7 +33,8 @@ class BaseTestWindow(window.Window):
         self.document = text.decode_text(doctext)
         self.margin = 2
         self.layout = layout.IncrementalTextLayout(self.document,
-                                                   self.width - self.margin * 2, self.height - self.margin * 2,
+                                                   width=self.width - self.margin * 2,
+                                                   height=self.height - self.margin * 2,
                                                    multiline=True,
                                                    batch=self.batch)
         self.caret = caret.Caret(self.layout)

--- a/tests/interactive/text/test_style.py
+++ b/tests/interactive/text/test_style.py
@@ -168,7 +168,8 @@ class BaseTestWindow(window.Window):
         self.document = text.decode_attributed(doctext)
         self.margin = 2
         self.layout = layout.IncrementalTextLayout(self.document,
-                                                   self.width - self.margin * 2, self.height - self.margin * 2,
+                                                   width=self.width - self.margin * 2,
+                                                   height=self.height - self.margin * 2,
                                                    multiline=True,
                                                    batch=self.batch)
         self.caret = caret.Caret(self.layout)


### PR DESCRIPTION
Interactive text tests fail due to width and height arguments not being specified.