### PR TITLE
Fix run(None) crashing on macOS

### DIFF
--- a/pyglet/app/cocoa.py
+++ b/pyglet/app/cocoa.py
@@ -113,8 +113,10 @@ class CocoaAlternateEventLoop(EventLoop):
         super().__init__()
         self.platform_event_loop = None
 
-    def run(self, interval=1/60):
-        if not interval:
+    def run(self, interval: float | None = 1/60):
+        if interval is None:
+            pass  # do not schedule redraws
+        elif not interval:
             self.clock.schedule(self._redraw_windows)
         else:
             self.clock.schedule_interval(self._redraw_windows, interval)
@@ -133,7 +135,8 @@ class CocoaAlternateEventLoop(EventLoop):
 
         self.dispatch_event('on_enter')
         self.is_running = True
-        self.platform_event_loop.nsapp_start(interval)
+
+        self.platform_event_loop.nsapp_start(interval or 0)
 
     def exit(self):
         """Safely exit the event loop at the end of the current iteration.


### PR DESCRIPTION
Arcade plans to call run(None) to keep update and draw calls in sync.
This results in a crash on MacOS:

```
Traceback (most recent call last):
  File "/arcade/temp/2025-02-02-text-alpha-bleeding.py", line 111, in <module>
    arcade.run()
  File "/arcade/arcade/window_commands.py", line 151, in run
    pyglet.app.run(None)
  File "/arcade/.venv/lib/python3.10/site-packages/pyglet/app/__init__.py", line 79, in run
    event_loop.run(interval)
  File "/arcade/.venv/lib/python3.10/site-packages/pyglet/app/cocoa.py", line 136, in run
    self.platform_event_loop.nsapp_start(interval)
  File "/arcade/.venv/lib/python3.10/site-packages/pyglet/app/cocoa.py", line 215, in nsapp_start
    self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
  File "/arcade/.venv/lib/python3.10/site-packages/pyglet/libs/darwin/cocoapy/runtime.py", line 1094, in __call__
    return self.method(self.objc_id, *args)
  File "/arcade/.venv/lib/python3.10/site-packages/pyglet/libs/darwin/cocoapy/runtime.py", line 1058, in __call__
    result = f(objc_id, self.selector, *args)
ctypes.ArgumentError: ('argument 3: TypeError: wrong type', "selector = b'scheduledTimerWithTimeInterval:target:selector:userInfo:repeats:'", "argtypes =[<class 'ctypes.c_void_p'>, <class 'ctypes.c_void_p'>, <class 'ctypes.c_double'>, <class 'ctypes.c_void_p'>, <class 'ctypes.c_void_p'>, <class 'ctypes.c_void_p'>, <class 'ctypes.c_bool'>]", "encoding = b'@52@0:8d16@24:32@40B48'")
```

The changes fix this.