### PR TITLE
DocString indicating arc_start is in radians instead of degrees

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -814,7 +814,7 @@ class Arc(ShapeBase):
                 The angle of the arc, in degrees. Defaults to 360.0, which is
                 a full circle.
             start_angle:
-                The start angle of the arc, in radians. Defaults to 0.
+                The start angle of the arc, in degrees. Defaults to 0.
             closed:
                 If ``True``, the ends of the arc will be connected with a line.
                 defaults to ``False``.


### PR DESCRIPTION
I noticed when updating my usage of pyglet to the 2.1 series, I think arc was switched to utilize degrees publicly, but the start_angle is still listed as being in radians in one place.

Correct the docstring for the start_angle of an arc to indicate it is in degrees and not radians

Thanks,
~Brett