### PR TITLE
Improve missing or underdeveloped math doc

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1396,7 +1396,17 @@ class Mat4(_typing.NamedTuple):
 
 
 class Quaternion(_typing.NamedTuple):
-    """Quaternion."""
+    """Quaternions are special 4-dimensional vectors useful for 3D rotations.
+
+    This type is separate from the :py:class:`Vec4` type for clarity when:
+
+    * organizing helper methods
+    * annotating types
+
+    .. tip:: Store method results if you will need them more than once.
+
+             Otherwise, you will be re-calculating values wastefully.
+    """
 
     w: float = 1.0
     x: float = 0.0
@@ -1412,6 +1422,8 @@ class Quaternion(_typing.NamedTuple):
         raise NotImplementedError
 
     def to_mat4(self) -> Mat4:
+        """Calculate a 4 by 4 transform matrix which applies a rotation."""
+
         w = self.w
         x = self.x
         y = self.y
@@ -1437,6 +1449,8 @@ class Quaternion(_typing.NamedTuple):
         return Mat4(a, b, c, 0.0, e, f, g, 0.0, i, j, k, 0.0, 0.0, 0.0, 0.0, 1.0)
 
     def to_mat3(self) -> Mat3:
+        """Convert the quaternion to a 3 by 3 rotation matrix."""
+
         w = self.w
         x = self.x
         y = self.y
@@ -1462,21 +1476,38 @@ class Quaternion(_typing.NamedTuple):
         return Mat3(*(a, b, c, e, f, g, i, j, k))
 
     def length(self) -> float:
-        """Calculate the length of the Quaternion.
-
-        The distance between the coordinates and the origin.
-        """
+        """Calculate the length of the quaternion from the origin."""
         return _math.sqrt(self.w**2 + self.x**2 + self.y**2 + self.z**2)
 
     def conjugate(self) -> Quaternion:
+        """Return the conjugate of this quaternion.
+
+        This operation:
+        #. leaves the :py:attr:`.w` component alone
+        #. inverts the sign of the :py:attr:`.x`, :py:attr:`.y`, and :py:attr:`.z` components
+
+        """
         return Quaternion(self.w, -self.x, -self.y, -self.z)
 
     def dot(self, other: Quaternion) -> float:
+        """Calculate the dot product with another quaternion.
+
+        """
+
         a, b, c, d = self
         e, f, g, h = other
         return a * e + b * f + c * g + d * h
 
     def normalize(self) -> Quaternion:
+        """Calculate a unit quaternion from the instance.
+
+        The returned quaternion will be a scaled-down version
+        of the instance which has:
+
+        * a length of ``1``
+        * the same relative of its components
+
+        """
         m = self.length()
         if m == 0:
             return self

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1396,16 +1396,9 @@ class Mat4(_typing.NamedTuple):
 
 
 class Quaternion(_typing.NamedTuple):
-    """Quaternions are special 4-dimensional vectors useful for 3D rotations.
+    """Quaternion
 
-    This type is separate from the :py:class:`Vec4` type for clarity when:
-
-    * organizing helper methods
-    * annotating types
-
-    .. tip:: Store method results if you will need them more than once.
-
-             Otherwise, you will be re-calculating values wastefully.
+    Quaternions are 4-dimensional complex numbers, useful for describing 3D rotations.
     """
 
     w: float = 1.0

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1483,10 +1483,7 @@ class Quaternion(_typing.NamedTuple):
         return Quaternion(self.w, -self.x, -self.y, -self.z)
 
     def dot(self, other: Quaternion) -> float:
-        """Calculate the dot product with another quaternion.
-
-        """
-
+        """Calculate the dot product with another quaternion."""
         a, b, c, d = self
         e, f, g, h = other
         return a * e + b * f + c * g + d * h
@@ -1499,7 +1496,6 @@ class Quaternion(_typing.NamedTuple):
 
         * a length of ``1``
         * the same relative of its components
-
         """
         m = self.length()
         if m == 0:

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1415,7 +1415,7 @@ class Quaternion(_typing.NamedTuple):
         raise NotImplementedError
 
     def to_mat4(self) -> Mat4:
-        """Calculate a 4 by 4 transform matrix which applies a rotation."""
+        """Calculate a 4x4 transform matrix which applies a rotation."""
 
         w = self.w
         x = self.x
@@ -1442,7 +1442,7 @@ class Quaternion(_typing.NamedTuple):
         return Mat4(a, b, c, 0.0, e, f, g, 0.0, i, j, k, 0.0, 0.0, 0.0, 0.0, 1.0)
 
     def to_mat3(self) -> Mat3:
-        """Convert the quaternion to a 3 by 3 rotation matrix."""
+        """Create a 3x3 rotation matrix."""
 
         w = self.w
         x = self.x
@@ -1473,7 +1473,7 @@ class Quaternion(_typing.NamedTuple):
         return _math.sqrt(self.w**2 + self.x**2 + self.y**2 + self.z**2)
 
     def conjugate(self) -> Quaternion:
-        """Return the conjugate of this quaternion.
+        """Calculate the conjugate of this quaternion.
 
         This operation:
         #. leaves the :py:attr:`.w` component alone

--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1396,7 +1396,7 @@ class Mat4(_typing.NamedTuple):
 
 
 class Quaternion(_typing.NamedTuple):
-    """Quaternion
+    """Quaternion.
 
     Quaternions are 4-dimensional complex numbers, useful for describing 3D rotations.
     """


### PR DESCRIPTION
This is a prelude to a much bigger series of programming guide updates.

- [ ] Quaternion doc
- [ ] `Vec2` fixes:
  - [ ] Explain what `Vec2`-like means somewhere to avoid [uncrossreferenced vagueness](https://github.com/pyglet/pyglet/blob/81552da62c1df4539620205e493c4f40ba79a743/pyglet/math.py#L270)
  - [ ] Cross-ref or explain [`.rotate()` direction](https://github.com/pyglet/pyglet/blob/master/pyglet/math.py#L280)
  - [ ] Rephrase clamp for clarity
- [ ] `Vec3` fixes:
  - [ ] Rephrase [top-level docstring](https://github.com/pyglet/pyglet/blob/81552da62c1df4539620205e493c4f40ba79a743/pyglet/math.py#L371-L378)
    - [ ] cross-ref `len`
    - [ ] swamp note to `.. important::`
  - [ ]  [`s/simply//`](https://github.com/pyglet/pyglet/blob/81552da62c1df4539620205e493c4f40ba79a743/pyglet/math.py#L548-L553)
  - [ ] cross-ref [`lerp` method with a lerp explanation](https://github.com/pyglet/pyglet/blob/81552da62c1df4539620205e493c4f40ba79a743/pyglet/math.py#L576-L584)
  - [ ] explain distance [func args](https://github.com/pyglet/pyglet/blob/81552da62c1df4539620205e493c4f40ba79a743/pyglet/math.py#L591-L597) better 

## In The follow-up PR to come

1. Centralize "unit vector" summary with cross-refs to external math for:
   -  [`Vec2.normalize()`](https://github.com/pyglet/pyglet/blob/81552da62c1df4539620205e493c4f40ba79a743/pyglet/math.py#L298-L302), as well as for `Vec3` and `Vec4`
 2. Matrix explanations of:
   - (briefly) how to matmul in Python / why
   - cross-refs to external info