### PR TITLE
Add x and y attributes to MouseStateHandler with __getattr__

### DIFF
--- a/pyglet/window/mouse.py
+++ b/pyglet/window/mouse.py
@@ -23,7 +23,8 @@ class MouseStateHandler:
         False
 
 
-    Mouse coordinates can be retrieved by using the ``'x'`` and ``'y'`` strings.
+    Mouse coordinates can be retrieved by using the ``'x'`` and ``'y'`` strings
+    or by using ``'mouse_state.x'`` and ``'mouse_state.y`` attributes
 
     For example::
 
@@ -36,6 +37,12 @@ class MouseStateHandler:
         >>> mouse_state['x']
         20
         >>> mouse_state['y']
+        50
+        
+        # Or...
+        >>> mouse_state.x
+        20
+        >>> mouse_state.y
         50
     """
 
@@ -64,6 +71,9 @@ class MouseStateHandler:
 
     def __getitem__(self, key: str) -> int | bool:
         return self.data.get(key, False)
+    
+    def __getattr__(self, item: str) -> int:
+        return self.data[item]
 
 
 def buttons_string(buttons: int) -> str:

--- a/pyglet/window/mouse.py
+++ b/pyglet/window/mouse.py
@@ -73,7 +73,7 @@ class MouseStateHandler:
         return self.data.get(key, False)
     
     def __getattr__(self, item: str) -> int:
-        return self.data[item]
+        return self.data.get(item, default=0)
 
 
 def buttons_string(buttons: int) -> str:

--- a/pyglet/window/mouse.py
+++ b/pyglet/window/mouse.py
@@ -73,7 +73,7 @@ class MouseStateHandler:
         return self.data.get(key, False)
     
     def __getattr__(self, item: str) -> int:
-        return self.data.get(item, default=0)
+        return self.data[item]
 
 
 def buttons_string(buttons: int) -> str:


### PR DESCRIPTION
Please see issue #1309 for more info.

I have added the `__getattr__` function to the class and have tested to see that it does what I want as described in the issue.
I have also updated the documentation in the docstrings for that class. 