### PR TITLE
Pyglet Clipboard Support

### DIFF
--- a/examples/text/text_input.py
+++ b/examples/text/text_input.py
@@ -8,7 +8,7 @@ import pyglet
 
 
 class TextWidget:
-    def __init__(self, text, x, y, width, batch):
+    def __init__(self, text, x, y, width, batch, window):
         self.document = pyglet.text.document.UnformattedDocument(text)
         self.document.set_style(0, len(self.document.text), dict(color=(0, 0, 0, 255)))
         font = self.document.get_font()
@@ -16,7 +16,7 @@ class TextWidget:
 
         self.layout = pyglet.text.layout.IncrementalTextLayout(self.document, x, y, 0, width, height,
                                                                batch=batch)
-        self.caret = pyglet.text.caret.Caret(self.layout)
+        self.caret = pyglet.text.caret.Caret(self.layout, window=window)
         # Rectangular outline
         pad = 2
         self.rectangle = pyglet.shapes.Rectangle(x - pad, y - pad, width + pad, height + pad,
@@ -42,9 +42,9 @@ class Window(pyglet.window.Window):
                               batch=self.batch),
         ]
         self.widgets = [
-            TextWidget('This is a test', 200, 100, self.width - 210, self.batch),
-            TextWidget('This is a test', 200, 60, self.width - 210, self.batch),
-            TextWidget('This is a test', 200, 20, self.width - 210, self.batch),
+            TextWidget('This is a test', 200, 100, self.width - 210, self.batch, self),
+            TextWidget('This is a test', 200, 60, self.width - 210, self.batch, self),
+            TextWidget('This is a test', 200, 20, self.width - 210, self.batch, self),
         ]
         self.text_cursor = self.get_system_mouse_cursor('text')
 

--- a/pyglet/text/caret.py
+++ b/pyglet/text/caret.py
@@ -18,16 +18,17 @@ from typing import TYPE_CHECKING, Any, Pattern
 
 from pyglet import clock, event
 from pyglet.window import key
+from pyglet.event import EventDispatcher
 
 if TYPE_CHECKING:
     from pyglet.graphics import Batch
+    from pyglet.window import Window
     from pyglet.text.layout import IncrementalTextLayout
 
-
-class Caret:
+class Caret(EventDispatcher):
     """Visible text insertion marker for `pyglet.text.layout.IncrementalTextLayout`.
 
-    The caret is drawn as a single vertical bar at the document `position` 
+    The caret is drawn as a single vertical bar at the document `position`
     on a text layout object.  If ``mark`` is not None, it gives the unmoving
     end of the current text selection.  The visible text selection on the
     layout is updated along with ``mark`` and ``position``.
@@ -38,6 +39,9 @@ class Caret:
 
     Updates to the document (and so the layout) are automatically propagated
     to the caret.
+
+    If the window argument is supplied, the caret object dispatches the on_clipboard_copy event when copying text and copies the text.
+    Pasting also works, which will dispatch the on_clipboard_paste event, and pastes the text to the current position of the caret, overriding selection.
 
     The caret object can be pushed onto a window event handler stack with
     ``Window.push_handlers``.  The caret will respond correctly to keyboard,
@@ -70,7 +74,7 @@ class Caret:
     _next_attributes: dict[str, Any]
 
     def __init__(self, layout: IncrementalTextLayout, batch: Batch | None = None,
-                 color: tuple[int, int, int, int] = (0, 0, 0, 255)) -> None:
+                 color: tuple[int, int, int, int] = (0, 0, 0, 255), window: Window | None = None) -> None:
         """Create a caret for a layout.
 
         By default the layout's batch is used, so the caret does not need to
@@ -84,7 +88,8 @@ class Caret:
             `color` : (int, int, int, int)
                 An RGBA or RGB tuple with components in the range [0, 255].
                 RGB colors will be treated as having an opacity of 255.
-
+            `window` : `~pyglet.window.Window`
+                For the clipboard feature to work, a window object is needed to be passed in to access and set clipboard content.
         """
         from pyglet import gl
         self._layout = layout
@@ -110,6 +115,7 @@ class Caret:
 
         self.visible = True
 
+        self._window = window
         layout.push_handlers(self)
 
     @property
@@ -467,7 +473,26 @@ class Caret:
                 self.position = 0
             else:
                 self.position = m.start()
+        elif motion == key.MOTION_COPY and self._window:
+            pos = self._position
+            mark = self._mark
+            if pos > mark:
+                text = self._layout.document.text[mark:pos]
+            else:
+                text = self._layout.document.text[pos:mark]
 
+            self._window.set_clipboard_text(text)
+            self.dispatch_event("on_clipboard_copy", text)
+        elif motion == key.MOTION_PASTE and self._window:
+            if self._mark is not None:
+                self._delete_selection()
+
+            text = self._window.get_clipboard_text().replace("\r", "\n")
+            pos = self._position
+            self._position += len(text)
+            self._layout.document.insert_text(pos, text, self._next_attributes)
+            self._nudge()
+            self.dispatch_event("on_clipboard_paste", text)
         if self._mark is not None and not select:
             self._mark = None
             self._layout.set_selection(0, 0)
@@ -564,3 +589,17 @@ class Caret:
         self._active = False
         self.visible = self._active
         return event.EVENT_HANDLED
+
+    def on_clipboard_copy(self, text: str) -> bool:
+        """Dispatched when text is copied.
+        This default handler does nothing.
+        """
+        return event.EVENT_HANDLED
+    def on_clipboard_paste(self, text: str) -> bool:
+        """Dispatched when text is pasted.
+        The default handler does nothing.
+        """
+        return event.EVENT_HANDLED
+
+Caret.register_event_type("on_clipboard_copy")
+Caret.register_event_type("on_clipboard_paste")

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1691,6 +1691,8 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
             * MOTION_END_OF_FILE
             * MOTION_BACKSPACE
             * MOTION_DELETE
+            * MOTION_COPY
+            * MOTION_PASTE
 
             :event:
             """
@@ -1721,6 +1723,8 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
             * MOTION_PREVIOUS_PAGE
             * MOTION_BEGINNING_OF_FILE
             * MOTION_END_OF_FILE
+            * MOTION_COPY
+            * MOTION_PASTE
 
             :event:
             """


### PR DESCRIPTION
This Draft adds clipboard support to pyglet.

First, it adds the `on_clipboard_copy` and `on_clipboard_paste` events to `Caret`.

Then, the `Caret` is now an `EventDispatcher`, and is registered for these events. There is a new optional window argument, which sets _window and will be used to set the clipboard content.

In `on_text_motion`, if the motion is `MOTION_COPY`, it will dispatch `on_clipboard_copy`, and will copy the text.

If the motion is `MOTION_PASTE`, it will paste the text inside the layout, overriding if something else was selected, and then dispatching `on_clipboard_paste` to the window that was passed in.

Please, feel free to correct my code or even push your local changes if you want to.