### PR TITLE
Fix window transparency for Windows OS.

### DIFF
--- a/pyglet/libs/win32/__init__.py
+++ b/pyglet/libs/win32/__init__.py
@@ -249,6 +249,10 @@ _dwmapi.DwmIsCompositionEnabled.restype = c_int
 _dwmapi.DwmIsCompositionEnabled.argtypes = [POINTER(INT)]
 _dwmapi.DwmFlush.restype = c_int
 _dwmapi.DwmFlush.argtypes = []
+_dwmapi.DwmGetColorizationColor.restype = HRESULT
+_dwmapi.DwmGetColorizationColor.argtypes = [POINTER(DWORD), POINTER(BOOL)]
+_dwmapi.DwmEnableBlurBehindWindow.restype = HRESULT
+_dwmapi.DwmEnableBlurBehindWindow.argtypes = [HWND, POINTER(DWM_BLURBEHIND)]
 
 # _shell32
 _shell32.DragAcceptFiles.restype = c_void

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -510,10 +510,15 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
         if not screen:
             screen = display.get_default_screen()
 
+        # Ensure the framebuffer is large enough to support transparency.
+        alpha_size = 8 if style in ('transparent', 'overlay') else None
+
         if not config:
-            for template_config in [gl.Config(double_buffer=True, depth_size=24, major_version=3, minor_version=3),
-                                    gl.Config(double_buffer=True, depth_size=16, major_version=3, minor_version=3),
-                                    None]:
+            for template_config in [
+                gl.Config(double_buffer=True, depth_size=24, major_version=3, minor_version=3, alpha_size=alpha_size),
+                gl.Config(double_buffer=True, depth_size=16, major_version=3, minor_version=3, alpha_size=alpha_size),
+                None,
+            ]:
                 try:
                     config = screen.get_best_config(template_config)
                     break
@@ -522,10 +527,9 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
             if not config:
                 msg = 'No standard config is available.'
                 raise NoSuchConfigException(msg)
-
-        # Necessary on Windows. More investigation needed:
-        if style in ('transparent', 'overlay'):
-            config.alpha = 8
+        else:
+            # Override config setting if they are requesting transparency.
+            config.alpha_size = alpha_size
 
         if not config.is_complete():
             config = screen.get_best_config(config)

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -171,10 +171,8 @@ class Win32Window(BaseWindow):
                 self.WINDOW_STYLE_TOOL: (constants.WS_OVERLAPPED | constants.WS_CAPTION | constants.WS_SYSMENU,
                                          constants.WS_EX_TOOLWINDOW),
                 self.WINDOW_STYLE_BORDERLESS: (constants.WS_POPUP, 0),
-                self.WINDOW_STYLE_TRANSPARENT: (constants.WS_OVERLAPPEDWINDOW,
-                                                constants.WS_EX_LAYERED),
-                self.WINDOW_STYLE_OVERLAY: (constants.WS_POPUP,
-                                            constants.WS_EX_LAYERED | constants.WS_EX_TRANSPARENT),
+                self.WINDOW_STYLE_TRANSPARENT: (constants.WS_OVERLAPPEDWINDOW, 0),
+                self.WINDOW_STYLE_OVERLAY: (constants.WS_POPUP, constants.WS_EX_TRANSPARENT),
             }
             self._ws_style, self._ex_ws_style = styles[self._style]
 
@@ -299,7 +297,7 @@ class Win32Window(BaseWindow):
             _user32.SetWindowPos(self._hwnd, hwnd_after,
                                  self._screen.x, self._screen.y, width, height, constants.SWP_FRAMECHANGED)
         elif self.style == 'transparent' or self.style == 'overlay':
-            _user32.SetLayeredWindowAttributes(self._hwnd, 0, 254, constants.LWA_ALPHA)
+            self._set_transparency()
             if self.style == 'overlay':
                 _user32.SetWindowPos(self._hwnd, constants.HWND_TOPMOST, 0,
                                      0, width, height, constants.SWP_NOMOVE | constants.SWP_NOSIZE)
@@ -382,7 +380,7 @@ class Win32Window(BaseWindow):
     def switch_to(self) -> None:
         self.context.set_current()
 
-    def update_transparency(self) -> None:
+    def _set_transparency(self) -> None:
         region = _gdi32.CreateRectRgn(0, 0, -1, -1)
         bb = DWM_BLURBEHIND()
         bb.dwFlags = constants.DWM_BB_ENABLE | constants.DWM_BB_BLURREGION
@@ -397,9 +395,6 @@ class Win32Window(BaseWindow):
 
         if not self._fullscreen and (self._always_dwm or self._dwm_composition_enabled()) and self._interval:
             _dwmapi.DwmFlush()
-
-        if self.style in ('overlay', 'transparent'):
-            self.update_transparency()
 
         self.context.flip()
 


### PR DESCRIPTION
Enforce an alpha_size on configs if using a transparent or overlay window.
Add missing DWM definition.
Tested on Windows 10 x64.

This will allow a transparent framebuffer without having to do NVIDIA GDI compatibility tricks mentioned here https://github.com/pyglet/pyglet/issues/693