### PR TITLE
Fix WMFDecoder delivering audio data as float (#1315)

### DIFF
--- a/pyglet/media/codecs/wave.py
+++ b/pyglet/media/codecs/wave.py
@@ -25,6 +25,9 @@ class WaveSource(StreamingSource):
 
         nchannels, sampwidth, framerate, nframes, comptype, compname = self._wave.getparams()
 
+        if nchannels not in (1, 2):
+            raise WAVEDecodeException(f"incompatible channel count {nchannels}")
+
         if sampwidth not in (1, 2):
             raise WAVEDecodeException(f"incompatible sample width {sampwidth}")
 

--- a/pyglet/media/codecs/wave.py
+++ b/pyglet/media/codecs/wave.py
@@ -25,6 +25,9 @@ class WaveSource(StreamingSource):
 
         nchannels, sampwidth, framerate, nframes, comptype, compname = self._wave.getparams()
 
+        if sampwidth not in (1, 2):
+            raise WAVEDecodeException(f"incompatible sample width {sampwidth}")
+
         self.audio_format = AudioFormat(channels=nchannels, sample_size=sampwidth * 8, sample_rate=framerate)
 
         self._bytes_per_frame = nchannels * sampwidth

--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -542,10 +542,10 @@ class WMFSource(Source):
             guid_compressed = com.GUID(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
             imfmedia.GetGUID(MF_MT_SUBTYPE, byref(guid_compressed))
 
-            if guid_compressed == MFAudioFormat_PCM or guid_compressed == MFAudioFormat_Float:
-                assert _debug(f'WMFAudioDecoder: Found Uncompressed Audio: {guid_compressed}')
+            if guid_compressed == MFAudioFormat_PCM:
+                assert _debug(f'WMFAudioDecoder: Found PCM Audio: {guid_compressed}')
             else:
-                assert _debug(f'WMFAudioDecoder: Found Compressed Audio: {guid_compressed}')
+                assert _debug(f'WMFAudioDecoder: Found Non-PCM Audio: {guid_compressed}')
                 # If audio is compressed, attempt to decompress it by forcing source reader to use PCM
                 mf_mediatype = IMFMediaType()
 

--- a/pyglet/media/drivers/directsound/interface.py
+++ b/pyglet/media/drivers/directsound/interface.py
@@ -5,6 +5,7 @@ import ctypes
 import weakref
 from collections import namedtuple
 
+from pyglet.media.exceptions import MediaException
 from pyglet.util import debug_print
 from pyglet.window.win32 import _user32
 
@@ -20,6 +21,9 @@ def _check(hresult):
 
 
 def _create_wave_format(audio_format):
+    if audio_format.channels > 2 or audio_format.sample_size not in (8, 16):
+        raise MediaException(f'Unsupported audio format: {audio_format}')
+
     wfx = lib.WAVEFORMATEX()
     wfx.wFormatTag = lib.WAVE_FORMAT_PCM
     wfx.nChannels = audio_format.channels

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -8,6 +8,7 @@ import pyglet
 from pyglet.libs.win32 import com
 from pyglet.media.devices import get_audio_device_manager
 from pyglet.media.devices.base import DeviceFlow
+from pyglet.media.exceptions import MediaException
 from pyglet.util import debug_print
 
 from . import lib_xaudio2 as lib
@@ -27,6 +28,9 @@ def create_xa2_buffer(audio_data):
 
 
 def create_xa2_waveformat(audio_format):
+    if audio_format.channels > 2 or audio_format.sample_size not in (8, 16):
+        raise MediaException(f'Unsupported audio format: {audio_format}')
+
     wfx = lib.WAVEFORMATEX()
     wfx.wFormatTag = lib.WAVE_FORMAT_PCM
     wfx.nChannels = audio_format.channels


### PR DESCRIPTION
- Do not consider float data to be uncompressed [EDIT: bit misleading, of course it's still "uncompressed", but indigestable by pyglet], change the debug messages accordingly
- Additionally safeguard `WAVEFORMATEX` structs (this might cause breakage in isolated cases, but worth it to prevent further ear-splitting audio incidents).