### PR TITLE
Fix outbound link, cross-refs, and formatting for programming guide image page

### DIFF
--- a/doc/programming_guide/image.rst
+++ b/doc/programming_guide/image.rst
@@ -975,7 +975,7 @@ corresponding variables of :py:class:`pyglet.image.Texture` to
    pyglet.image.Texture.default_min_filter = GL_LINEAR
    pyglet.image.Texture.default_mag_filter = GL_LINEAR
 
-Afterward, all textures pyglet creatures will default
+Afterward, all textures pyglet creates will default
 to nearest-neighbor sampling.
 
 Saving an image


### PR DESCRIPTION
Changes:

* Fix broken formatting and cross-refs
* Replace broken link with new OpenGL book page (old URL points to squatted domain)
* s/colour/color/ for consistency
* Simpler phrasing in a number of places