### PR TITLE
Fix X11 clipboard selection by not setting `XlibWindow._clipboard_str` in `get_clipboard_text`

### DIFF
--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -899,8 +899,6 @@ class XlibWindow(BaseWindow):
 
             text = text_bytes.decode('utf-8')
 
-        self._clipboard_str = text
-
         xlib.XFree(data)
         return text
 


### PR DESCRIPTION
The implementation assumed that `_clipboard_str` would remain unchanged for as long as a pyglet window owned the selection, but also when it received the data from another X client.
Perhaps this was done in assumption the `SelectionClear` event is global and a read would be followed by this event too once the data would change. But `SelectionClear` it is only ever received by the selection's previous owner (There is an [X extension](https://www.x.org/releases/X11R7.6/doc/fixesproto/fixesproto.txt) that provides functionality for global notification ("Selection Tracking"), but XFixes (or X extensions in general) seem to be unused by pyglet.)

The selection ownership never changes when reading from the clipboard, remaining with the other client (often a clipboard manager), so the pyglet window has no way of knowing when the data changes externally.
Without this patch, you could simply read the clipboard, then change the data in an external clipboard manager or copy different text partitions in a browser and pyglet would keep echoing the string it initially read.