### PR TITLE
Split Player into AudioPlayer and VideoPlayer

### DIFF
--- a/doc/modules/media.rst
+++ b/doc/modules/media.rst
@@ -17,7 +17,7 @@ pyglet.media
 Classes
 -------
 
-.. autoclass:: pyglet.media.player.Player
+.. autoclass:: pyglet.media.player.AudioPlayer
   :members: loop
 
   .. rubric:: Methods

--- a/doc/programming_guide/events.rst
+++ b/doc/programming_guide/events.rst
@@ -200,7 +200,7 @@ Creating your own event dispatcher
 ----------------------------------
 
 pyglet provides the :py:class:`~pyglet.window.Window`,
-:py:class:`~pyglet.media.player.Player`, and other event dispatchers,
+:py:class:`~pyglet.media.player.AudioPlayer`, and other event dispatchers,
 but exposes a public interface for creating and dispatching your own events.
 
 The steps for creating an event dispatcher are:
@@ -251,7 +251,7 @@ There is zero instance overhead on objects that have no event handlers
 attached (the event stack is created only when required).  This makes
 :py:class:`~pyglet.event.EventDispatcher` suitable for use even on light-weight
 objects that may not always have handlers.  For example,
-:py:class:`~pyglet.media.player.Player` is an
+:py:class:`~pyglet.media.player.AudioPlayer` is an
 :py:class:`~pyglet.event.EventDispatcher` even though potentially hundreds
 of these objects may be created and destroyed each second, and most will
 not need an event handler.

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -609,7 +609,7 @@ You can call :py:meth:`~pyglet.media.Source.play` on any
 :py:class:`~pyglet.media.StaticSource`.
 
 The return value of :py:meth:`~pyglet.media.Source.play` is a
-:py:class:`~pyglet.media.player.Player`, which can either be
+:py:class:`~pyglet.media.player.AudioPlayer`, which can either be
 discarded, or retained to maintain control over the sound's playback.
 
 .. _guide-media-controllingplayback:
@@ -618,11 +618,11 @@ Controlling playback
 --------------------
 
 You can implement many functions common to a media player using the
-:py:class:`~pyglet.media.player.Player`
+:py:class:`~pyglet.media.player.AudioPlayer`
 class. Use of this class is also necessary for video playback. There are no
 parameters to its construction::
 
-    player = pyglet.media.Player()
+    player = pyglet.media.AudioPlayer()
 
 A player will play any source that is *queued* on it. Any number of sources
 can be queued on a single player, but once queued, a source can never be
@@ -630,7 +630,7 @@ dequeued (until it is removed automatically once complete). The main use of
 this queueing mechanism is to facilitate "gapless" transitions between
 playback of media files.
 
-The :py:meth:`~pyglet.media.player.Player.queue` method is used to queue
+The :py:meth:`~pyglet.media.player.AudioPlayer.queue` method is used to queue
 a media on the player - a :py:class:`~pyglet.media.StreamingSource` or a
 :py:class:`~pyglet.media.StaticSource`. Either you pass one instance, or you
 can also pass an iterable of sources. This provides great flexibility. For
@@ -662,7 +662,7 @@ In the following example, two sounds are queued onto a player::
     player.queue(source1)
     player.queue(source2)
 
-Playback begins with the player's :py:meth:`~pyglet.media.Player.play` method
+Playback begins with the player's :py:meth:`~pyglet.media.AudioPlayer.play` method
 is called::
 
     player.play()
@@ -674,18 +674,18 @@ Standard controls for controlling playback are provided by these methods:
 
         * - Method
           - Description
-        * - :py:meth:`~pyglet.media.Player.play`
+        * - :py:meth:`~pyglet.media.AudioPlayer.play`
           - Begin or resume playback of the current source.
-        * - :py:meth:`~pyglet.media.Player.pause`
+        * - :py:meth:`~pyglet.media.AudioPlayer.pause`
           - Pause playback of the current source.
-        * - :py:meth:`~pyglet.media.Player.next_source`
+        * - :py:meth:`~pyglet.media.AudioPlayer.next_source`
           - Dequeue the current source and move to the next one immediately.
-        * - :py:meth:`~pyglet.media.Player.seek`
+        * - :py:meth:`~pyglet.media.AudioPlayer.seek`
           - Seek to a specific time within the current source.
 
 Note that there is no `stop` method. If you do not need to resume playback,
 simply pause playback and discard the player and source objects. Using the
-:meth:`~pyglet.media.Player.next_source` method does not guarantee gapless
+:meth:`~pyglet.media.AudioPlayer.next_source` method does not guarantee gapless
 playback.
 
 There are several properties that describe the player's current state:
@@ -695,20 +695,20 @@ There are several properties that describe the player's current state:
 
         * - Property
           - Description
-        * - :py:attr:`~pyglet.media.Player.time`
+        * - :py:attr:`~pyglet.media.AudioPlayer.time`
           - The current playback position within the current source, in
-            seconds. This is read-only (but see the :py:meth:`~pyglet.media.Player.seek` method).
-        * - :py:attr:`~pyglet.media.Player.playing`
+            seconds. This is read-only (but see the :py:meth:`~pyglet.media.AudioPlayer.seek` method).
+        * - :py:attr:`~pyglet.media.AudioPlayer.playing`
           - True if the player is currently playing, False if there are no
             sources queued or the player is paused. This is read-only (but
-            see the :py:meth:`~pyglet.media.Player.pause` and :py:meth:`~pyglet.media.Player.play` methods).
-        * - :py:attr:`~pyglet.media.Player.source`
+            see the :py:meth:`~pyglet.media.AudioPlayer.pause` and :py:meth:`~pyglet.media.AudioPlayer.play` methods).
+        * - :py:attr:`~pyglet.media.AudioPlayer.source`
           - A reference to the current source being played. This is
-            read-only (but see the :py:meth:`~pyglet.media.Player.queue` method).
-        * - :py:attr:`~pyglet.media.Player.volume`
+            read-only (but see the :py:meth:`~pyglet.media.AudioPlayer.queue` method).
+        * - :py:attr:`~pyglet.media.AudioPlayer.volume`
           - The audio level, expressed as a float from 0 (mute) to 1 (normal
             volume). This can be set at any time.
-        * - :py:attr:`~pyglet.media.player.Player.loop`
+        * - :py:attr:`~pyglet.media.player.AudioPlayer.loop`
           - ``True`` if the current source should be repeated when reaching
             the end. If set to ``False``, playback will continue to the next
             queued source.
@@ -719,14 +719,14 @@ There are several properties that describe the player's current state:
 Handling playback events
 ------------------------
 
-When a player reaches the end of the current source, an :py:meth:`~pyglet.media.Player.on_eos`
+When a player reaches the end of the current source, an :py:meth:`~pyglet.media.AudioPlayer.on_eos`
 (on end-of-source) event is dispatched. Players have a default handler for this event,
-which will either repeat the current source (if the :py:attr:`~pyglet.media.player.Player.loop`
+which will either repeat the current source (if the :py:attr:`~pyglet.media.player.AudioPlayer.loop`
 attribute has been set to ``True``), or move to the next queued source immediately.
-When there are no more queued sources, the :py:meth:`~pyglet.media.Player.on_player_eos`
+When there are no more queued sources, the :py:meth:`~pyglet.media.AudioPlayer.on_player_eos`
 event is dispatched, and playback stops until another source is queued.
 
-For loop control you can change the :py:attr:`~pyglet.media.player.Player.loop` attribute
+For loop control you can change the :py:attr:`~pyglet.media.player.AudioPlayer.loop` attribute
 at any time, but be aware that unless sufficient time is given for the future
 data to be decoded and buffered there may be a stutter or gap in playback.
 If set well in advance of the end of the source (say, several seconds), there
@@ -758,8 +758,8 @@ on a Player as if it was a single source.
 Incorporating video
 -------------------
 
-When a :py:class:`~pyglet.media.player.Player` is playing back a source with
-video, use the :attr:`~pyglet.media.Player.texture` property to obtain the
+When a :py:class:`~pyglet.media.player.AudioPlayer` is playing back a source with
+video, use the :attr:`~pyglet.media.AudioPlayer.texture` property to obtain the
 video frame image. This can be used to display the current video image
 syncronised with the audio track, for example::
 
@@ -782,11 +782,11 @@ pyglet includes features for positioning sound within a 3D space. This is
 particularly effective with a surround-sound setup, but is also applicable to
 stereo systems.
 
-A :py:class:`~pyglet.media.player.Player` in pyglet has an associated position
+A :py:class:`~pyglet.media.player.AudioPlayer` in pyglet has an associated position
 in 3D space -- that is, it is equivalent to an OpenAL "source". The properties
 for setting these parameters are described in more detail in the API
-documentation; see for example :py:attr:`~pyglet.media.Player.position` and
-:py:attr:`~pyglet.media.Player.pitch`.
+documentation; see for example :py:attr:`~pyglet.media.AudioPlayer.position` and
+:py:attr:`~pyglet.media.AudioPlayer.pitch`.
 
 A "listener" object is provided by the audio driver. To obtain the listener
 for the current audio driver::

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -362,7 +362,7 @@ class PlayerWindow(pyglet.window.Window):
 def main(target, dbg_file, debug):
     set_logging_parameters(target, dbg_file, debug)
 
-    player = pyglet.media.Player()
+    player = pyglet.media.AudioPlayer()
     window = PlayerWindow(player)
 
     player.queue(pyglet.media.load(filename) for filename in sys.argv[1:])

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -1,80 +1,176 @@
+"""Plays the audio / video files listed as arguments.
+
+Key Controls Available:
+    Space - Play/Pause
+    ESC - Close
+    Left - Seek to beginning of source
+    Right - Next Source
 """
-Usage
+from __future__ import annotations
 
-    media_player.py [options] <filename> [<filename> ...]
-
-Plays the audio / video files listed as arguments, optionally
-collecting debug info
-
-Options
-    --debug : saves sequence of internal state as a binary *.dbg
-    --outfile : filename to store the debug info, defaults to filename.dbg
-
-The raw data captured in the .dbg can be rendered as human readable
-using the script report.py
-"""
-import os
-import sys
+import warnings
 import weakref
 
-from pyglet.graphics.api.gl import (
-    glEnable,
-    glBlendFunc,
-    GL_BLEND,
-    GL_LINE_LOOP,
-    GL_ONE_MINUS_SRC_ALPHA,
-    GL_SRC_ALPHA,
-)
+import os as _os
+from functools import partial
+
 import pyglet
-from pyglet.window import key
 
 pyglet.options.debug_media = False
-# pyglet.options.audio = ('openal', 'pulse', 'silent')
-from pyglet.media import buffered_logger as bl
+
+from pyglet.media.exceptions import MediaException
+
+from concurrent.futures import ProcessPoolExecutor as _ProcessPoolExecutor
+
+from pyglet.event import EventDispatcher as _EventDispatcher
+from pyglet.window import key
 
 
-def draw_rect(x, y, width, height, color=(1, 1, 1, 1)):
-    pyglet.graphics.draw(
-        4,
-        GL_LINE_LOOP,
-        position=('f', (x, y, 0,
-                        x + width, y, 0,
-                        x + width, y + height, 0,
-                        x, y + height, 0,
-                        ),
-                  ),
-        colors=('f', color * 4),
-    )
+
+class _Dialog(_EventDispatcher):
+    """Dialog base class
+
+    This base class sets up a ProcessPoolExecutor with a single
+    background Process. This allows the Dialog to display in
+    the background without blocking or interfering with the main
+    application Process. This also limits to a single open Dialog
+    at a time.
+    """
+
+    executor = _ProcessPoolExecutor(max_workers=1)
+    _dialog = None
+
+    @staticmethod
+    def _open_dialog(dialog):
+        import tkinter as tk
+        root = tk.Tk()
+        root.withdraw()
+        return dialog.show()
+
+    def open(self):
+        future = self.executor.submit(self._open_dialog, self._dialog)
+        future.add_done_callback(self._dispatch_event)
+
+    def _dispatch_event(self, future):
+        raise NotImplementedError
+
+
+class FileOpenDialog(_Dialog):
+    def __init__(self, title="Open File", initial_dir=_os.path.curdir, filetypes=None, multiple=False):
+        """
+        :Parameters:
+            `title` : str
+                The Dialog Window name. Defaults to "Open File".
+            `initial_dir` : str
+                The directory to start in.
+            `filetypes` : list of tuple
+                An optional list of tuples containing (name, extension) to filter by.
+                If none are given, all files will be shown and selectable.
+                For example: `[("PNG", ".png"), ("24-bit Bitmap", ".bmp")]`
+            `multiple` : bool
+                True if multiple files can be selected. Defaults to False.
+        """
+        from tkinter import filedialog
+        self._dialog = filedialog.Open(title=title,
+                                       initialdir=initial_dir,
+                                       filetypes=filetypes or (),
+                                       multiple=multiple)
+
+    def _dispatch_event(self, future):
+        pyglet.app.platform_event_loop.post_event(self, "on_dialog_open", future.result())
+
+    def on_dialog_open(self, filenames):
+        """Event for filename choices"""
+
+
+FileOpenDialog.register_event_type('on_dialog_open')
 
 
 class Control(pyglet.event.EventDispatcher):
-    x = y = 0
-    width = height = 10
 
     def __init__(self, parent):
         super().__init__()
+        self._x = 0
+        self._y = 0
+        self._width = 10
+        self._height = 10
+        self.batch = parent.batch
         self.parent = weakref.proxy(parent)
+
+    @property
+    def x(self):
+        return self._x
+
+    @x.setter
+    def x(self, value):
+        self._x = value
+        self._update_control()
+
+    @property
+    def y(self):
+        return self._y
+
+    @y.setter
+    def y(self, value):
+        self._y = value
+        self._update_control()
+
+    @property
+    def width(self):
+        return self._width
+
+    @width.setter
+    def width(self, value):
+        self._width = value
+        self._update_control()
+
+    @property
+    def height(self):
+        return self._height
+
+    @height.setter
+    def height(self, value):
+        self._height = value
+        self._update_control()
+
+    def _update_control(self):
+        raise NotImplementedError()
 
     def hit_test(self, x, y):
         return (self.x < x < self.x + self.width and
                 self.y < y < self.y + self.height)
 
     def capture_events(self):
-        self.parent.push_handlers(self)
+        self.parent.window.push_handlers(self)
 
     def release_events(self):
-        self.parent.remove_handlers(self)
+        self.parent.window.remove_handlers(self)
 
 
 class Button(Control):
-    charged = False
+    def __init__(self, parent):
+        super().__init__(parent)
+        self._charged = False
+        self.rect = pyglet.shapes.Rectangle(self.x, self.y, self.width, self.height, color=(255, 255, 255, 255), batch=self.batch)
 
-    def draw(self):
-        if self.charged:
-            draw_rect(self.x, self.y, self.width, self.height)
+    @property
+    def charged(self) -> bool:
+        return self._charged
+
+    @charged.setter
+    def charged(self, value: bool) -> None:
+        self._charged = value
+        self._update_control()
+
+    def _update_control(self):
+        if self._charged is True:
+            self.rect.color = (255, 255, 255)
         else:
-            draw_rect(self.x, self.y, self.width, self.height, color=(1, 0, 0, 1))
-        self.draw_label()
+            self.rect.color = (128, 128, 128)
+
+        self.rect.width = self.width
+        self.rect.height = self.height
+        self.rect.position = (self.x, self.y)
 
     def on_mouse_press(self, x, y, button, modifiers):
         self.capture_events()
@@ -96,19 +192,19 @@ Button.register_event_type('on_press')
 class TextButton(Button):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._text = pyglet.text.Label('', anchor_x='center', anchor_y='center')
+        self._text = pyglet.text.Label('.', anchor_x='center', anchor_y='center', batch=self.batch)
 
-    def draw_label(self):
-        self._text.x = self.x + self.width / 2
-        self._text.y = self.y + self.height / 2
-        self._text.draw()
+    def _update_control(self) -> None:
+        super()._update_control()
+        self._text.position = (self.x + self.width // 2, self.y + self.height // 2, 0)
 
-    def set_text(self, text):
+    @property
+    def text(self) -> str:
+        return self._text.text
+
+    @text.setter
+    def text(self, text: str) -> None:
         self._text.text = text
-
-    text = property(lambda self: self._text.text,
-                    set_text)
-
 
 class Slider(Control):
     THUMB_WIDTH = 6
@@ -116,17 +212,41 @@ class Slider(Control):
     GROOVE_HEIGHT = 2
     RESPONSIVNESS = 0.3
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, parent):
+        super().__init__(parent)
         self.seek_value = None
+        self.min = 0
+        self.max = 1
+        self.value = 0.0
+        self.groove_rect = pyglet.shapes.Rectangle(self.x, self.y, self.width, self.height, color=(255, 0, 0, 255), batch=self.batch)
+        self.thumb_rect = pyglet.shapes.Rectangle(self.x, self.y, self.width, self.height, color=(255, 0, 0, 255), batch=self.batch)
 
-    def draw(self):
+    def update_timestamp(self, value: float):
+        self.value = value
+        self._update_rects()
+
+    def _update_control(self):
+        self._update_rects()
+
+    def _get_groove(self):
         center_y = self.y + self.height / 2
-        draw_rect(self.x, center_y - self.GROOVE_HEIGHT / 2,
-                  self.width, self.GROOVE_HEIGHT)
-        pos = self.x + self.value * self.width / (self.max - self.min)
-        draw_rect(pos - self.THUMB_WIDTH / 2, center_y - self.THUMB_HEIGHT / 2,
-                  self.THUMB_WIDTH, self.THUMB_HEIGHT)
+        return self.x, center_y - self.GROOVE_HEIGHT // 2, self.width, self.GROOVE_HEIGHT
+
+    def _get_thumb(self):
+        center_y = self.y + self.height // 2
+        pos = self.x + self.value * self.width // (self.max - self.min)
+        return pos - self.THUMB_WIDTH // 2, center_y - self.THUMB_HEIGHT // 2, self.THUMB_WIDTH, self.THUMB_HEIGHT
+
+    def _update_rects(self):
+        gx, gy, gw, gh = self._get_groove()
+        self.groove_rect.position = (gx, gy)
+        self.groove_rect.width = gw
+        self.groove_rect.height = gh
+
+        tx, ty, tw, th = self._get_thumb()
+        self.thumb_rect.position = (tx, ty)
+        self.thumb_rect.width = tw
+        self.thumb_rect.height = th
 
     def coordinate_to_value(self, x):
         value = float(x - self.x) / self.width * (self.max - self.min) + self.min
@@ -170,66 +290,104 @@ Slider.register_event_type('on_end_scroll')
 Slider.register_event_type('on_change')
 
 
-class PlayerWindow(pyglet.window.Window):
-    GUI_WIDTH = 400
+class MediaPlayer:
+    GUI_WIDTH = 500
     GUI_HEIGHT = 40
     GUI_PADDING = 4
     GUI_BUTTON_HEIGHT = 16
 
-    def __init__(self, player):
-        super().__init__(caption='Media Player',
-                                           visible=False,
-                                           resizable=True)
-        # We only keep a weakref to player as we are about to push ourself
-        # as a handler which would then create a circular reference between
-        # player and window.
-        self.player = weakref.proxy(player)
-        self._player_playing = False
+    def __init__(self, window: pyglet.window.Window):
+        self.window = window
+
+        self.batch = pyglet.graphics.Batch()
+
+        try:
+            self.player = pyglet.media.VideoPlayer(self.batch)
+            print("FFmpeg detected, video playback enabled.")
+        except MediaException:
+            warnings.warn('Could not create a video player, ensure FFmpeg is installed and detected.')
+            self.player = pyglet.media.AudioPlayer()
+
+        # Register this class to get callbacks from player.
         self.player.push_handlers(self)
+        self._player_playing = False
 
         self.slider = Slider(self)
         self.slider.push_handlers(self)
         self.slider.x = self.GUI_PADDING
         self.slider.y = self.GUI_PADDING * 2 + self.GUI_BUTTON_HEIGHT
 
+        self.open_button = TextButton(self)
+        self.open_button.text = 'Open Media'
+        self.open_button.x = self.GUI_PADDING
+        self.open_button.y = self.GUI_PADDING
+        self.open_button.height = self.GUI_BUTTON_HEIGHT
+        self.open_button.width = 100
+
+        audio_types = [("Common Audio Files", "*.wav *.mp3")]
+        additional_types = []
+        if isinstance(self.player, pyglet.media.VideoPlayer):
+            audio_types = [("Audio Files", "*.wav *.mp3 *.flv *.mov .*ogg")]
+            additional_types.append(("Video/Container Files", "*.mp4 *.mkv *.avi"))
+
+        file_types = audio_types + additional_types + [("All Files", "*.*")]
+        open_dialog = FileOpenDialog(filetypes=file_types, multiple=True)
+
+        @open_dialog.event
+        def on_dialog_open(filenames):
+            self.add_tracks(filenames)
+
+        self.open_button.on_press = lambda: open_dialog.open()
+
         self.play_pause_button = TextButton(self)
-        self.play_pause_button.x = self.GUI_PADDING
+        self.play_pause_button.x = self.GUI_PADDING + self.open_button.x + self.open_button.width
         self.play_pause_button.y = self.GUI_PADDING
         self.play_pause_button.height = self.GUI_BUTTON_HEIGHT
         self.play_pause_button.width = 45
         self.play_pause_button.on_press = self.on_play_pause
 
         self.window_button = TextButton(self)
-        self.window_button.x = self.play_pause_button.x + \
-                               self.play_pause_button.width + self.GUI_PADDING
+        self.window_button.x = self.play_pause_button.x + self.play_pause_button.width + self.GUI_PADDING
         self.window_button.y = self.GUI_PADDING
         self.window_button.height = self.GUI_BUTTON_HEIGHT
         self.window_button.width = 90
         self.window_button.text = 'Windowed'
-        self.window_button.on_press = lambda: self.set_fullscreen(False)
+        self.window_button.on_press = lambda: window.set_fullscreen(False)
 
         self.controls = [
+            self.open_button,
             self.slider,
             self.play_pause_button,
             self.window_button,
         ]
 
         x = self.window_button.x + self.window_button.width + self.GUI_PADDING
+
         i = 0
-        for screen in self.display.get_screens():
+        for screen in window.display.get_screens():
             screen_button = TextButton(self)
             screen_button.x = x
             screen_button.y = self.GUI_PADDING
             screen_button.height = self.GUI_BUTTON_HEIGHT
             screen_button.width = 80
             screen_button.text = f'Screen {i + 1}'
-            screen_button.on_press = lambda screen=screen: self.set_fullscreen(True, screen)
+            screen_button.on_press = partial(window.set_fullscreen, True, screen=screen)
             self.controls.append(screen_button)
             i += 1
             x += screen_button.width + self.GUI_PADDING
 
-        glEnable(GL_BLEND)
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+    def play(self):
+        self.gui_update_source()
+        self.set_default_video_size()
+        self.player.play()
+
+    def add_tracks(self, filename_list: list[str]):
+        for filename in filename_list:
+            media = pyglet.media.load(filename)
+            self.player.queue(media)
+
+        self.gui_update_source()
+        self.set_default_video_size()
 
     def on_player_next_source(self):
         self.gui_update_state()
@@ -270,16 +428,17 @@ class PlayerWindow(pyglet.window.Window):
     def set_default_video_size(self):
         """Make the window size just big enough to show the current
         video and the GUI."""
+        if self.window.fullscreen:
+            self.window.set_fullscreen(False)
         width = self.GUI_WIDTH
         height = self.GUI_HEIGHT
         video_width, video_height = self.get_video_size()
         width = max(width, video_width)
         height += video_height
-        self.set_size(int(width), int(height))
+        self.window.set_size(int(width), int(height))
 
     def on_resize(self, width, height):
         """Position and size video image."""
-        super().on_resize(width, height)
         self.slider.width = width - self.GUI_PADDING * 2
 
         height -= self.GUI_HEIGHT
@@ -297,8 +456,13 @@ class PlayerWindow(pyglet.window.Window):
         else:
             self.video_height = height
             self.video_width = height * video_aspect
-        self.video_x = (width - self.video_width) / 2
-        self.video_y = (height - self.video_height) / 2 + self.GUI_HEIGHT
+
+        video_x = (width - self.video_width) / 2
+        video_y = (height - self.video_height) / 2 + self.GUI_HEIGHT
+
+        self.player.position = (video_x, video_y)
+        self.player.width = self.video_width
+        self.player.height = self.video_height
 
     def on_mouse_press(self, x, y, button, modifiers):
         for control in self.controls:
@@ -309,7 +473,7 @@ class PlayerWindow(pyglet.window.Window):
         if symbol == key.SPACE:
             self.on_play_pause()
         elif symbol == key.ESCAPE:
-            self.dispatch_event('on_close')
+            self.window.dispatch_event('on_close')
         elif symbol == key.LEFT:
             self.player.seek(0)
         elif symbol == key.RIGHT:
@@ -317,10 +481,10 @@ class PlayerWindow(pyglet.window.Window):
 
     def on_close(self):
         self.player.pause()
-        self.close()
+        self.window.close()
 
     def auto_close(self, dt):
-        self.close()
+        self.window.close()
 
     def on_play_pause(self):
         if self.player.playing:
@@ -332,20 +496,11 @@ class PlayerWindow(pyglet.window.Window):
         self.gui_update_state()
 
     def on_draw(self):
-        self.clear()
+        self.window.clear()
 
-        # Video
-        if self.player.source and self.player.source.video_format:
-            video_texture = self.player.texture
-            video_texture.blit(self.video_x,
-                               self.video_y,
-                               width=self.video_width,
-                               height=self.video_height)
+        self.slider.update_timestamp(self.player.time)
 
-        # GUI
-        self.slider.value = self.player.time
-        for control in self.controls:
-            control.draw()
+        self.batch.draw()
 
     def on_begin_scroll(self):
         self._player_playing = self.player.playing
@@ -359,74 +514,17 @@ class PlayerWindow(pyglet.window.Window):
             self.player.play()
 
 
-def main(target, dbg_file, debug):
-    set_logging_parameters(target, dbg_file, debug)
+def main():
+    window = pyglet.window.Window(caption="Media Player", resizable=True, visible=False)
 
-    player = pyglet.media.AudioPlayer()
-    window = PlayerWindow(player)
+    media_player = MediaPlayer(window)
+    window.push_handlers(media_player)
 
-    player.queue(pyglet.media.load(filename) for filename in sys.argv[1:])
-
-    window.gui_update_source()
     window.set_visible(True)
-    window.set_default_video_size()
-
-    # this is an async call
-    player.play()
-    window.gui_update_state()
+    media_player.play()
 
     pyglet.app.run()
 
-
-def set_logging_parameters(target_file, dbg_file, debug):
-    if not debug:
-        bl.logger = None
-        return
-    if dbg_file is None:
-        dbg_file = target_file + ".dbg"
-    else:
-        dbg_dir = os.path.dirname(dbg_file)
-        if dbg_dir and not os.path.isdir(dbg_dir):
-            os.mkdir(dbg_dir)
-    bl.logger = bl.BufferedLogger(dbg_file)
-    from pyglet.media.instrumentation import mp_events
-    # allow to detect crashes by prewriting a crash file, if no crash
-    # it will be overwrited by the captured data
-    sample = os.path.basename(target_file)
-    bl.logger.log("version", mp_events["version"])
-    bl.logger.log("crash", sample)
-    bl.logger.save_log_entries_as_pickle()
-    bl.logger.clear()
-    # start the real capture data
-    bl.logger.log("version", mp_events["version"])
-    bl.logger.log("mp.im", sample)
-
-
-def usage():
-    print(__doc__)
-    sys.exit(1)
-
-
-def sysargs_to_mainargs():
-    """builds main args from sys.argv"""
-    if len(sys.argv) < 2:
-        usage()
-    debug = False
-    dbg_file = None
-    for i in range(2):
-        if sys.argv[1].startswith("--"):
-            a = sys.argv.pop(1)
-            if a.startswith("--debug"):
-                debug = True
-            elif a.startswith("--outfile="):
-                dbg_file = a[len("--outfile="):]
-            else:
-                print("Error unknown option:", a)
-                usage()
-    target_file = sys.argv[1]
-    return target_file, dbg_file, debug
-
-
 if __name__ == '__main__':
-    target_file, dbg_file, debug = sysargs_to_mainargs()
-    main(target_file, dbg_file, debug)
+    print(__doc__)
+    main()

--- a/examples/media/soundspace/reader.py
+++ b/examples/media/soundspace/reader.py
@@ -105,7 +105,7 @@ class SpaceReader:
                 if parts[0] == 'loop':
                     if len(parts) < 2:
                         raise ReaderException('No loop filename line %d' % lineno)
-                    player = media.Player()
+                    player = media.AudioPlayer()
                     player.loop = True
                     player.queue(self.source(parts[1], streaming=False))
                     reader = PlayerReader(player)

--- a/examples/media/video.py
+++ b/examples/media/video.py
@@ -20,7 +20,7 @@ if not fmt:
     print('No video track in this source.')
     sys.exit(1)
 
-player = pyglet.media.Player()
+player = pyglet.media.AudioPlayer()
 player.queue(source)
 player.play()
 

--- a/examples/media/video.py
+++ b/examples/media/video.py
@@ -20,7 +20,7 @@ if not fmt:
     print('No video track in this source.')
     sys.exit(1)
 
-player = pyglet.media.AudioPlayer()
+player = pyglet.media.VideoPlayer()
 player.queue(source)
 player.play()
 
@@ -29,7 +29,7 @@ window = pyglet.window.Window(width=fmt.width, height=fmt.height)
 
 @window.event
 def on_draw():
-    player.texture.blit(0, 0)
+    player.draw()
 
 
 pyglet.app.run()

--- a/pyglet/graphics/api/gl/lib.py
+++ b/pyglet/graphics/api/gl/lib.py
@@ -68,7 +68,7 @@ def errcheck(result: Any, func: Callable, arguments: Sequence) -> Any:
             name = repr(func)
         if _debug_api_trace_args:
             trace_args = ', '.join([repr(arg) for arg in arguments])
-            print(f'{name}({trace_args})')
+            print(f'{name}({trace_args[:255]})')
         else:
             print(name)
 

--- a/pyglet/graphics/api/gl/texture.py
+++ b/pyglet/graphics/api/gl/texture.py
@@ -669,7 +669,7 @@ class TextureRegion(Texture):
 
     def upload(self, source: _AbstractImage, x: int, y: int, z: int) -> None:
         assert source.width <= self._width and source.height <= self._height, f"{source} is larger than {self}"
-        self.owner.blit_into(source, x + self.x, y + self.y, z + self.z)
+        self.owner.upload(source, x + self.x, y + self.y, z + self.z)
 
     def __repr__(self) -> str:
         return (f"{self.__class__.__name__}(id={self.id},"

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -3,12 +3,12 @@
 pyglet can play WAV files, and if FFmpeg is installed, many other audio and
 video formats.
 
-Playback is handled by the :class:`.Player` class, which reads raw data from
+Playback is handled by the :class:`pyglet.media.player.AudioPlayer` class, which reads raw data from
 :class:`Source` objects and provides methods for pausing, seeking, adjusting
-the volume, and so on. The :class:`.Player` class implements the best
+the volume, and so on. The :class:`pyglet.media.player.AudioPlayer` class implements the best
 available audio device. ::
 
-    player = Player()
+    player = AudioPlayer()
 
 A :class:`Source` is used to decode arbitrary audio and video files. It is
 associated with a single player by "queueing" it::
@@ -16,7 +16,7 @@ associated with a single player by "queueing" it::
     source = load('background_music.mp3')
     player.queue(source)
 
-Use the :class:`.Player` to control playback.
+Use the :class:`pyglet.media.player.AudioPlayer` to control playback.
 
 If the source contains video, the :py:meth:`Source.video_format` attribute
 will be non-None, and the :py:attr:`Player.texture` attribute will contain the

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, BinaryIO
 
 from .drivers import get_audio_driver
-from .player import Player, PlayerGroup
+from .player import AudioPlayer, PlayerGroup
 from .codecs import registry as _codec_registry
 from .codecs import add_default_codecs as _add_default_codecs
 from .codecs import Source, StaticSource, StreamingSource, SourceGroup, have_ffmpeg
@@ -55,7 +55,7 @@ from . import synthesis
 if TYPE_CHECKING:
     from .codecs import MediaDecoder
 
-__all__ = 'load', 'get_audio_driver', 'Player', 'PlayerGroup', 'SourceGroup', 'StaticSource', 'StreamingSource'
+__all__ = 'load', 'get_audio_driver', 'AudioPlayer', 'PlayerGroup', 'SourceGroup', 'StaticSource', 'StreamingSource'
 
 
 def load(filename: str, file: BinaryIO | None = None,
@@ -89,7 +89,7 @@ _add_default_codecs()
 
 
 __all__ = [
-    'Player', 
+    'AudioPlayer',
     'PlayerGroup', 
     'Source', 
     'StaticSource', 

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, BinaryIO
 
 from .drivers import get_audio_driver
-from .player import AudioPlayer, PlayerGroup
+from .player import AudioPlayer, VideoPlayer, PlayerGroup
 from .codecs import registry as _codec_registry
 from .codecs import add_default_codecs as _add_default_codecs
 from .codecs import Source, StaticSource, StreamingSource, SourceGroup, have_ffmpeg
@@ -54,8 +54,6 @@ from . import synthesis
 
 if TYPE_CHECKING:
     from .codecs import MediaDecoder
-
-__all__ = 'load', 'get_audio_driver', 'AudioPlayer', 'PlayerGroup', 'SourceGroup', 'StaticSource', 'StreamingSource'
 
 
 def load(filename: str, file: BinaryIO | None = None,
@@ -87,11 +85,12 @@ def load(filename: str, file: BinaryIO | None = None,
 
 _add_default_codecs()
 
-
 __all__ = [
     'AudioPlayer',
+    'VideoPlayer',
     'PlayerGroup', 
-    'Source', 
+    'Source',
+    'SourceGroup',
     'StaticSource', 
     'StreamingSource',
     'load', 

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import ctypes
 import io
 from typing import TYPE_CHECKING, BinaryIO, List, Optional, Union
 
+from pyglet.graphics import Texture
+from pyglet.graphics.api.gl.texture import TextureRegion
 from pyglet.media.exceptions import MediaException, CannotSeekException
-from pyglet.util import next_or_equal_power_of_two
 
 if TYPE_CHECKING:
     from pyglet.image import _AbstractImage
@@ -19,15 +22,20 @@ class AudioFormat:
     An instance of this class is provided by sources with audio tracks.  You
     should not modify the fields, as they are used internally to describe the
     format of data provided by the source.
-
-    Args:
-        channels (int): The number of channels: 1 for mono or 2 for stereo
-            (pyglet does not yet support surround-sound sources).
-        sample_size (int): Bits per sample; only 8 or 16 are supported.
-        sample_rate (int): Samples per second (in Hertz).
     """
 
     def __init__(self, channels: int, sample_size: int, sample_rate: int) -> None:
+        """Specify the audio format properties.
+
+        Args:
+            channels:
+                The number of channels: 1 for mono or 2 for stereo
+                (pyglet does not yet support surround-sound sources).
+            sample_size:
+                Bits per sample; only 8 or 16 are supported.
+            sample_rate:
+                Samples per second (in Hertz).
+        """
         self.channels = channels
         self.sample_size = sample_size
         self.sample_rate = sample_rate
@@ -88,22 +96,31 @@ class VideoFormat:
     video image.  For example, a video image of 640x480 with sample aspect 2.0
     should be displayed at 1280x480.  It is the responsibility of the
     application to perform this scaling.
-
-    Args:
-        width (int): Width of video image, in pixels.
-        height (int): Height of video image, in pixels.
-        sample_aspect (float): Aspect ratio (width over height) of a single
-            video pixel.
-        frame_rate (float): Frame rate (frames per second) of the video.
-
-            .. versionadded:: 1.2
     """
+    width: int
+    height: int
+    sample_aspect: float
+    frame_rate: float | None
 
-    def __init__(self, width: int, height: int, sample_aspect: float = 1.0) -> None:
+    def __init__(self, width: int, height: int, sample_aspect: float = 1.0, frame_rate: float | None = None) -> None:
+        """Define the video format information.
+
+        Args:
+            width:
+                Width of video image, in pixels.
+            height:
+                Height of video image, in pixels.
+            sample_aspect:
+                Aspect ratio (width over height) of a single video pixel.
+            frame_rate:
+                Frame rate (frames per second) of the video or ``None`` if not known.
+
+        .. versionadded:: 1.2
+        """
         self.width = width
         self.height = height
         self.sample_aspect = sample_aspect
-        self.frame_rate = None
+        self.frame_rate = frame_rate
 
     def __eq__(self, other) -> bool:
         if isinstance(other, VideoFormat):
@@ -118,18 +135,6 @@ class AudioData:
     """A single packet of audio data.
 
     This class is used internally by pyglet.
-
-    Args:
-        data (bytes, ctypes array, or supporting buffer protocol): Sample data.
-        length (int): Size of sample data, in bytes.
-        timestamp (float): Time of the first sample, in seconds.
-        duration (float): Total data duration, in seconds.
-        events (List[:class:`pyglet.media.drivers.base.MediaEvent`]): List of events
-            contained within this packet. Events are timestamped relative to
-            this audio packet.
-
-    .. deprecated:: 2.0.10
-            `timestamp` and `duration` are unused and will be removed eventually.
     """
 
     __slots__ = 'data', 'length', 'timestamp', 'duration', 'events', 'pointer'
@@ -139,8 +144,25 @@ class AudioData:
                  length: int,
                  timestamp: float = 0.0,
                  duration: float = 0.0,
-                 events: Optional[List['MediaEvent']] = None) -> None:
+                 events: list[MediaEvent] | None = None) -> None:
+        """
+        events (List[:class:`pyglet.media.drivers.base.MediaEvent`]):
 
+        Args:
+            data:
+                (bytes, ctypes array, or supporting buffer protocol): Sample data.
+            length:
+                Size of sample data, in bytes.
+            timestamp:
+                Time of the first sample, in seconds.
+            duration:
+                Total data duration, in seconds.
+            events:
+                List of events contained within this packet. Events are timestamped relative to this audio packet.
+
+        .. deprecated:: 2.0.10
+        `timestamp` and `duration` are unused and will be removed eventually.
+        """
         if isinstance(data, bytes):
             # bytes are treated specially by ctypes and can be cast to a void pointer, get
             # their content's address like this
@@ -208,21 +230,21 @@ class Source:
         is_player_source (bool): Determine if this source is a player
             current source.
 
-            Check on a :py:class:`~pyglet.media.player.Player` if this source
+            Check on a :py:class:`~pyglet.media.player.AudioPlayer` if this source
             is the current source.
     """
 
     _duration = None
-    _players: List['AudioPlayer'] = []  # Players created through Source.play
+    _players: list[AudioPlayer] = []  # Players created through Source.play
 
-    audio_format = None
-    video_format = None
-    info = None
-    is_player_source = False
+    audio_format: AudioFormat | None = None
+    video_format: VideoFormat | None = None
+    info: SourceInfo | None = None
+    is_player_source: bool = False
 
     @property
     def duration(self) -> float:
-        """float: The length of the source, in seconds.
+        """The length of the source, in seconds.
 
         Not all source durations can be determined; in this case the value
         is ``None``.
@@ -231,7 +253,7 @@ class Source:
         """
         return self._duration
 
-    def play(self) -> 'AudioPlayer':
+    def play(self) -> AudioPlayer:
         """Play the source.
 
         This is a convenience method which creates a Player for
@@ -255,9 +277,8 @@ class Source:
         player.on_player_eos = _on_player_eos
         return player
 
-    def get_animation(self) -> 'Animation':
-        """
-        Import all video frames into memory.
+    def get_animation(self) -> Animation:
+        """Import all video frames into memory.
 
         An empty animation will be returned if the source has no video.
         Otherwise, the animation will contain all unplayed video frames (the
@@ -268,9 +289,6 @@ class Source:
         few seconds.
 
         .. versionadded:: 1.1
-
-        Returns:
-            :class:`pyglet.image.Animation`
         """
         from pyglet.image import Animation, AnimationFrame
         if not self.video_format:
@@ -289,7 +307,7 @@ class Source:
                 next_ts = self.get_next_video_timestamp()
             return Animation(frames)
 
-    def get_next_video_timestamp(self) -> Optional[float]:
+    def get_next_video_timestamp(self) -> float | None:
         """Get the timestamp of the next video frame.
 
         .. versionadded:: 1.1
@@ -300,7 +318,7 @@ class Source:
         """
         pass
 
-    def get_next_video_frame(self) -> Optional['_AbstractImage']:
+    def get_next_video_frame(self) -> Texture | TextureRegion | None:
         """Get the next video frame.
 
         .. versionadded:: 1.1
@@ -314,17 +332,17 @@ class Source:
 
     def save(self,
              filename: str,
-             file: Optional[BinaryIO] = None,
-             encoder: Optional['MediaEncoder'] = None) -> None:
+             file: BinaryIO | None= None,
+             encoder: MediaEncoder | None = None) -> None:
         """Save this Source to a file.
 
-        :Parameters:
-            `filename` : str
+        Args:
+            filename
                 Used to set the file format, and to open the output file
                 if `file` is unspecified.
-            `file` : file-like object or None
+            file:
                 File to write audio data to.
-            `encoder` : MediaEncoder or None
+            encoder:
                 If unspecified, all encoders matching the filename extension
                 are tried.  If all fail, the exception from the first one
                 attempted is raised.
@@ -339,7 +357,7 @@ class Source:
     # Internal methods that Player calls on the source:
 
     def is_precise(self) -> bool:
-        """bool: Whether this source is considered precise.
+        """Whether this source is considered precise.
 
         ``x`` bytes on source ``s`` are considered aligned if
         ``x % s.audio_format.bytes_per_frame == 0``, so there'd be no partial
@@ -371,8 +389,8 @@ class Source:
         negatively impacted at best and memory access violations occur at
         worst.
 
-        :Returns:
-            bool: Whether the source is precise.
+        Returns:
+            Whether the source is precise.
         """
         return False
 
@@ -385,7 +403,7 @@ class Source:
         """
         raise CannotSeekException()
 
-    def get_queue_source(self) -> 'Source':
+    def get_queue_source(self) -> Source:
         """Return the ``Source`` to be used as the queue source for a player.
 
         Default implementation returns ``self``.
@@ -395,7 +413,7 @@ class Source:
         """
         return self
 
-    def get_audio_data(self, num_bytes: int, compensation_time=0.0) -> Optional[AudioData]:
+    def get_audio_data(self, num_bytes: int, compensation_time=0.0) -> AudioData | None:
         """Get next packet of audio data.
 
         Args:
@@ -418,10 +436,10 @@ class StreamingSource(Source):
     """A source that is decoded as it is being played.
 
     The source can only be played once at a time on any
-    :class:`~pyglet.media.player.Player`.
+    :class:`~pyglet.media.player.AudioPlayer`.
     """
 
-    def get_queue_source(self) -> 'StreamingSource':
+    def get_queue_source(self) -> StreamingSource:
         """Return the ``Source`` to be used as the source for a player.
 
         Default implementation returns self.
@@ -487,7 +505,7 @@ class StaticSource(Source):
         """The StaticSource does not provide audio data.
 
         When the StaticSource is queued on a
-        :class:`~pyglet.media.player.Player`, it creates a
+        :class:`~pyglet.media.player.AudioPlayer`, it creates a
         :class:`.StaticMemorySource` containing its internal audio data and
         audio format.
 
@@ -585,7 +603,7 @@ class SourceGroup:
     def has_next(self) -> bool:
         return len(self._sources) > 1
 
-    def get_queue_source(self) -> 'SourceGroup':
+    def get_queue_source(self) -> SourceGroup:
         return self
 
     def _advance(self) -> None:
@@ -601,12 +619,12 @@ class SourceGroup:
     def get_audio_data(self, num_bytes: float, compensation_time=0.0) -> Optional[AudioData]:
         """Get next audio packet.
 
-        :Parameters:
+        Args:
             `num_bytes` : int
                 Hint for preferred size of audio packet; may be ignored.
 
-        :rtype: `AudioData`
-        :return: Audio data, or None if there is no more data.
+        Returns:
+            Audio data, or ``None`` if there is no more data.
         """
 
         if not self._sources:

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pyglet.image.animation import Animation
     from pyglet.media.codecs import MediaEncoder
     from pyglet.media.drivers.base import MediaEvent
-    from pyglet.media.player import Player
+    from pyglet.media.player import AudioPlayer
 
 
 class AudioFormat:
@@ -213,7 +213,7 @@ class Source:
     """
 
     _duration = None
-    _players: List['Player'] = []  # Players created through Source.play
+    _players: List['AudioPlayer'] = []  # Players created through Source.play
 
     audio_format = None
     video_format = None
@@ -231,7 +231,7 @@ class Source:
         """
         return self._duration
 
-    def play(self) -> 'Player':
+    def play(self) -> 'AudioPlayer':
         """Play the source.
 
         This is a convenience method which creates a Player for
@@ -240,8 +240,8 @@ class Source:
         Returns:
             :class:`.Player`
         """
-        from pyglet.media.player import Player  # XXX Nasty circular dependency
-        player = Player()
+        from pyglet.media.player import AudioPlayer  # XXX Nasty circular dependency
+        player = AudioPlayer()
         player.queue(self)
         player.play()
         Source._players.append(player)

--- a/pyglet/media/drivers/base.py
+++ b/pyglet/media/drivers/base.py
@@ -409,7 +409,7 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         pass
 
     def set_position(self, position):
-        """See :py:attr:`~pyglet.media.Player.position`."""
+        """See :py:attr:`~pyglet.media.AudioPlayer.position`."""
         pass
 
     def set_min_distance(self, min_distance):
@@ -421,7 +421,7 @@ class AbstractAudioPlayer(metaclass=ABCMeta):
         pass
 
     def set_pitch(self, pitch):
-        """See :py:attr:`~pyglet.media.Player.pitch`."""
+        """See :py:attr:`~pyglet.media.AudioPlayer.pitch`."""
         pass
 
     def set_cone_orientation(self, cone_orientation):
@@ -459,7 +459,7 @@ class MediaEvent:
     """Representation of a media event.
 
     These events are used internally by some audio driver implementation to
-    communicate events to the :class:`~pyglet.media.player.Player`.
+    communicate events to the :class:`~pyglet.media.player.AudioPlayer`.
     One example is the ``on_eos`` event.
 
     Args:

--- a/pyglet/media/drivers/openal/adaptation.py
+++ b/pyglet/media/drivers/openal/adaptation.py
@@ -9,7 +9,7 @@ from pyglet.media.player_worker_thread import PlayerWorkerThread
 from pyglet.util import debug_print
 
 if TYPE_CHECKING:
-    from pyglet.media import Source, Player
+    from pyglet.media import Source, AudioPlayer
 
 
 _debug = debug_print('debug_media')
@@ -28,7 +28,7 @@ class OpenALDriver(AbstractAudioDriver):
         self.worker = PlayerWorkerThread()
         self.worker.start()
 
-    def create_audio_player(self, source: 'Source', player: 'Player') -> 'OpenALAudioPlayer':
+    def create_audio_player(self, source: 'Source', player: 'AudioPlayer') -> 'OpenALAudioPlayer':
         assert self.device is not None, 'Device was closed'
         return OpenALAudioPlayer(self, source, player)
 
@@ -91,7 +91,7 @@ class OpenALListener(AbstractListener):
 
 
 class OpenALAudioPlayer(AbstractAudioPlayer):
-    def __init__(self, driver: 'OpenALDriver', source: 'Source', player: 'Player') -> None:
+    def __init__(self, driver: 'OpenALDriver', source: 'Source', player: 'AudioPlayer') -> None:
         super().__init__(source, player)
         self.driver = driver
         self.alsource = driver.context.create_source()

--- a/pyglet/media/drivers/pulse/adaptation.py
+++ b/pyglet/media/drivers/pulse/adaptation.py
@@ -14,7 +14,7 @@ from .interface import PulseAudioMainloop
 
 if TYPE_CHECKING:
     from pyglet.media.codecs import AudioData, AudioFormat, Source
-    from pyglet.media.player import Player
+    from pyglet.media.player import AudioPlayer
 
 
 _debug = debug_print('debug_media')
@@ -31,7 +31,7 @@ class PulseAudioDriver(AbstractAudioDriver):
         self._players = weakref.WeakSet()
         self._listener = PulseAudioListener(self)
 
-    def create_audio_player(self, source: 'Source', player: 'Player') -> 'PulseAudioPlayer':
+    def create_audio_player(self, source: 'Source', player: 'AudioPlayer') -> 'PulseAudioPlayer':
         assert self.context is not None
         player = PulseAudioPlayer(source, player, self)
         self._players.add(player)
@@ -148,7 +148,7 @@ class _AudioDataBuffer:
 
 
 class PulseAudioPlayer(AbstractAudioPlayer):
-    def __init__(self, source: 'Source', player: 'Player', driver: 'PulseAudioDriver') -> None:
+    def __init__(self, source: 'Source', player: 'AudioPlayer', driver: 'PulseAudioDriver') -> None:
         super().__init__(source, player)
         self.driver = driver
 

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -11,7 +11,7 @@ from . import interface
 
 if TYPE_CHECKING:
     from pyglet.media.codecs import AudioData, AudioFormat, Source
-    from pyglet.media.player import Player
+    from pyglet.media.player import AudioPlayer
 
 
 _debug = debug_print('debug_media')
@@ -35,7 +35,7 @@ class XAudio2Driver(AbstractAudioDriver):
         assert self._xa2_driver is not None
         return self._xa2_driver.get_performance()
 
-    def create_audio_player(self, source: 'Source', player: 'Player') -> 'XAudio2AudioPlayer':
+    def create_audio_player(self, source: 'Source', player: 'AudioPlayer') -> 'XAudio2AudioPlayer':
         assert self._xa2_driver is not None
         return XAudio2AudioPlayer(self, source, player)
 
@@ -79,7 +79,7 @@ class XAudio2Listener(AbstractListener):
 
 
 class XAudio2AudioPlayer(AbstractAudioPlayer):
-    def __init__(self, driver: 'XAudio2Driver', source: 'Source', player: 'Player') -> None:
+    def __init__(self, driver: 'XAudio2Driver', source: 'Source', player: 'AudioPlayer') -> None:
         super().__init__(source, player)
         # We keep here a strong reference because the AudioDriver is anyway
         # a singleton object which will only be deleted when the application

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -515,10 +515,10 @@ class VideoPlayer(AudioPlayer):
 
         self._context = pyglet.graphics.api.core.current_context
 
-        # Check if source is FFmpeg instead?
-        from pyglet.media import have_ffmpeg
-        if not have_ffmpeg():
-            raise MediaException("VideoPlayer requires FFmpeg to be installed.")
+        # # Check if source is FFmpeg instead?
+        # from pyglet.media import have_ffmpeg
+        # if not have_ffmpeg():
+        #     raise MediaException("VideoPlayer requires FFmpeg to be installed.")
 
     @property
     def position(self) -> tuple[int, int]:

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -515,10 +515,14 @@ class VideoPlayer(AudioPlayer):
 
         self._context = pyglet.graphics.api.core.current_context
 
-        # # Check if source is FFmpeg instead?
-        # from pyglet.media import have_ffmpeg
-        # if not have_ffmpeg():
-        #     raise MediaException("VideoPlayer requires FFmpeg to be installed.")
+        self._check_ffmpeg_availability()
+
+    @staticmethod
+    def _check_ffmpeg_availability() -> None:
+        # Check if a source is FFmpeg instead?
+        from pyglet.media import have_ffmpeg
+        if not have_ffmpeg():
+            raise MediaException("VideoPlayer requires FFmpeg to be installed.")
 
     @property
     def position(self) -> tuple[int, int]:

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -9,6 +9,7 @@ import pyglet
 from pyglet.media import buffered_logger as bl
 from pyglet.media.codecs.base import Source, SourceGroup
 from pyglet.media.drivers import get_audio_driver
+from pyglet.media.exceptions import MediaException
 
 _debug = pyglet.options.debug_media
 
@@ -90,8 +91,8 @@ class _PlayerProperty:
             getattr(obj._audio_player, self.setter_name)(value)
 
 
-class Player(pyglet.event.EventDispatcher):
-    """High-level sound and video player."""
+class AudioPlayer(pyglet.event.EventDispatcher):
+    """High-level sound player."""
 
     # Spacialisation attributes, preserved between audio players
     _volume = 1.0
@@ -113,7 +114,6 @@ class Player(pyglet.event.EventDispatcher):
         self._audio_player = None
 
         self._context = pyglet.graphics.api.core.current_context
-        self._texture = None
 
         # Desired play state (not an indication of actual state).
         self._playing = False
@@ -160,6 +160,41 @@ class Player(pyglet.event.EventDispatcher):
         else:
             self._source = new_source.get_queue_source()
 
+    def _check_resource_reuse(self, old_source: Source) -> None:
+        """Determine if a resource can be re-used based on the old source."""
+        if self._audio_player is not None:
+            # If current source format properties match the old source, then the resource can be re-used.
+            if self._source.audio_format == old_source.audio_format:
+                self._audio_player.set_source(self._source)
+            else:
+                # Delete the resource so a matching resource can be created.
+                self._audio_player.delete()
+                self._audio_player = None
+
+    def _create_player_resources(self, starting: bool):
+        """Creates driver resources for the particular format."""
+        if self._source.audio_format is not None:
+            if was_created := self._audio_player is None:
+                self._create_audio_player()
+            if self._audio_player is not None and (was_created or starting):
+                self._audio_player.prefill_audio()
+
+    def _start_player_resources(self):
+        """Start any driver related resources required for playback."""
+        if self._audio_player is not None:
+            self._audio_player.play()
+
+    def _stop_player_resources(self):
+        """Stop any driver related resources required for playback."""
+        if self._audio_player is not None:
+            self._audio_player.stop()
+
+    def _seek_player_resources(self):
+        if self._audio_player is not None:
+            # XXX: According to docstring in AbstractAudioPlayer this cannot
+            # be called when the player is not stopped
+            self._audio_player.clear()
+
     def _set_playing(self, playing: bool) -> None:
         # stopping = self._playing and not playing
         starting = not self._playing and playing
@@ -168,44 +203,22 @@ class Player(pyglet.event.EventDispatcher):
         source = self.source
 
         if playing and source:
-            if source.audio_format is not None:
-                if (was_created := self._audio_player is None):
-                    self._create_audio_player()
-                if self._audio_player is not None and (was_created or starting):
-                    self._audio_player.prefill_audio()
-
-            if bl.logger is not None:
-                bl.logger.init_wall_time()
-                bl.logger.log("p.P._sp", 0.0)
-
-            if source.video_format is not None:
-                if self._texture is None:
-                    self._create_texture()
-
-            if self._audio_player is not None:
-                self._audio_player.play()
-            if source.video_format is not None:
-                pyglet.clock.schedule_once(self.update_texture, 0)
-            # For audio synchronization tests, the following will
-            # add a delay to de-synchronize the audio.
-            # Negative number means audio runs ahead.
-            # self._mclock._systime += -0.3
+            self._create_player_resources(starting)
+            self._start_player_resources()
             self._timer.start()
+
+            # If the driver is silent, it will not create any players, dispatch an end event.
             if self._audio_player is None and source.video_format is None:
                 pyglet.clock.schedule_once(lambda dt: self.dispatch_event("on_eos"), source.duration)
-
         else:
-            if self._audio_player is not None:
-                self._audio_player.stop()
-
-            pyglet.clock.unschedule(self.update_texture)
+            self._stop_player_resources()
             self._timer.pause()
 
     @property
     def playing(self) -> bool:
         """The current playing state.
 
-        The *playing* property is irrespective of whether or not there is
+        The *playing* property is irrespective of whether there is
         actually a source to play. If *playing* is ``True`` and a source is
         queued, it will begin to play immediately. If *playing* is ``False``,
         it is implied that the player is paused. There is no other possible
@@ -237,8 +250,6 @@ class Player(pyglet.event.EventDispatcher):
         if self._audio_player is not None:
             self._audio_player.delete()
             self._audio_player = None
-        if self._texture is not None:
-            self._texture = None
 
     def next_source(self) -> None:
         """Move immediately to the next source in the current playlist.
@@ -281,15 +292,7 @@ class Player(pyglet.event.EventDispatcher):
             old_source = self._source
             self._set_source(new_source)
 
-            if self._audio_player is not None:
-                if self._source.audio_format == old_source.audio_format:
-                    self._audio_player.set_source(self._source)
-                else:
-                    self._audio_player.delete()
-                    self._audio_player = None
-            if self._source.video_format != old_source.video_format:
-                self._texture = None
-                pyglet.clock.unschedule(self.update_texture)
+            self._check_resource_reuse(old_source)
 
             del old_source
 
@@ -308,9 +311,6 @@ class Player(pyglet.event.EventDispatcher):
         if self.source is None:
             return
 
-        if bl.logger is not None:
-            bl.logger.log("p.P.sk", timestamp)
-
         timestamp = max(timestamp, 0.0)
         if self._source.duration is not None:
             # TODO: If the duration is reported as None and the source clamps anyways,
@@ -322,13 +322,8 @@ class Player(pyglet.event.EventDispatcher):
         self._source.seek(timestamp)
         self.last_seek_time = timestamp
 
-        if self._audio_player is not None:
-            # XXX: According to docstring in AbstractAudioPlayer this cannot
-            # be called when the player is not stopped
-            self._audio_player.clear()
-        if self.source.video_format is not None:
-            self.update_texture()
-            pyglet.clock.unschedule(self.update_texture)
+        self._seek_player_resources()
+
         self._set_playing(playing)
 
     def _create_audio_player(self) -> None:
@@ -365,109 +360,6 @@ class Player(pyglet.event.EventDispatcher):
         and the video.
         """
         return self._timer.get_time()
-
-    def _create_texture(self) -> None:
-        video_format = self.source.video_format
-        self._texture = pyglet.graphics.Texture.create(video_format.width, video_format.height)
-        self._texture = self._texture.get_transform(flip_y=True)
-        # After flipping the texture along the y axis, the anchor_y is set
-        # to the top of the image. We want to keep it at the bottom.
-        self._texture.anchor_y = 0
-        return self._texture
-
-    @property
-    def texture(self) -> Texture | None:
-        """Get the texture for the current video frame, if any.
-
-        You should query this property every time you display a frame of video,
-        as multiple textures might be used. This property will be ``None`` if
-        the current Source does not contain video.
-        """
-        return self._texture
-
-    def seek_next_frame(self) -> None:
-        """Step forwards one video frame in the current source."""
-        time = self.source.get_next_video_timestamp()
-        if time is None:
-            return
-        self.seek(time)
-
-    def update_texture(self, dt: float | None = None) -> None:
-        """Manually update the texture from the current source.
-
-        This happens automatically, so you shouldn't need to call this method.
-
-        Args:
-            dt:
-                The time elapsed since the last call to ``update_texture``.
-        """
-        # self.pr.disable()
-        # if dt > 0.05:
-        #     print("update_texture dt:", dt)
-        #     import pstats
-        #     ps = pstats.Stats(self.pr).sort_stats("cumulative")
-        #     ps.print_stats()
-        source = self.source
-        time = self.time
-        if bl.logger is not None:
-            bl.logger.log(
-                "p.P.ut.1.0", dt, time,
-                self._audio_player.get_time() if self._audio_player else 0,
-                bl.logger.rebased_wall_time(),
-            )
-
-        frame_rate = source.video_format.frame_rate
-        frame_duration = 1 / frame_rate
-        ts = source.get_next_video_timestamp()
-        # Allow up to frame_duration difference
-        while ts is not None and ts + frame_duration < time:
-            source.get_next_video_frame()  # Discard frame
-            if bl.logger is not None:
-                bl.logger.log("p.P.ut.1.5", ts)
-            ts = source.get_next_video_timestamp()
-
-        if bl.logger is not None:
-            bl.logger.log("p.P.ut.1.6", ts)
-
-        if ts is None:
-            # No more video frames to show. End of video stream.
-            if bl.logger is not None:
-                bl.logger.log("p.P.ut.1.7", frame_duration)
-
-            pyglet.clock.schedule_once(self._video_finished, 0)
-            return
-        if ts > time:
-            # update_texture called too early (probably manually!)
-            pyglet.clock.schedule_once(self.update_texture, ts - time)
-            return
-
-
-        image = source.get_next_video_frame()
-        if image is not None:
-            with self._context:
-                if self._texture is None:
-                    self._create_texture()
-                else:
-                    self._texture.bind()
-                self._texture.upload(image, 0, 0, 0)
-        elif bl.logger is not None:
-            bl.logger.log("p.P.ut.1.8")
-
-        ts = source.get_next_video_timestamp()
-        if ts is None:
-            delay = frame_duration
-        else:
-            delay = ts - time
-
-        delay = max(0.0, delay)
-        if bl.logger is not None:
-            bl.logger.log("p.P.ut.1.9", delay, ts)
-        pyglet.clock.schedule_once(self.update_texture, delay)
-        # self.pr.enable()
-
-    def _video_finished(self, _dt: float) -> None:
-        if self._audio_player is None:
-            self.dispatch_event("on_eos")
 
     volume = _PlayerProperty('volume', doc="""
     The volume level of sound playback.
@@ -558,9 +450,6 @@ class Player(pyglet.event.EventDispatcher):
         """
         if _debug:
             print('Player.on_eos')
-        if bl.logger is not None:
-            bl.logger.log("p.P.oe")
-            bl.logger.close()
 
         if self.loop:
             was_playing = self._playing
@@ -605,14 +494,135 @@ class Player(pyglet.event.EventDispatcher):
             self._audio_player.play()
 
 
-Player.register_event_type('on_eos')
-Player.register_event_type('on_player_eos')
-Player.register_event_type('on_player_next_source')
-Player.register_event_type('on_driver_reset')
+AudioPlayer.register_event_type('on_eos')
+AudioPlayer.register_event_type('on_player_eos')
+AudioPlayer.register_event_type('on_player_next_source')
+AudioPlayer.register_event_type('on_driver_reset')
 
 
 def _one_item_playlist(source: Source) -> Generator:
     yield source
+
+
+class VideoPlayer(AudioPlayer):
+    """High-level sound and video player."""
+    def __init__(self) -> None:
+        from pyglet.media import have_ffmpeg
+        if not have_ffmpeg():
+            raise MediaException("VideoPlayer requires FFmpeg to be installed.")
+
+        super().__init__()
+        self._texture = None
+
+    def _seek_player_resources(self) -> None:
+        super()._seek_player_resources()
+        if self.source.video_format is not None:
+            self.update_texture()
+            pyglet.clock.unschedule(self.update_texture)
+
+    def _check_resource_reuse(self, old_source: Source) -> None:
+        super()._check_resource_reuse(old_source)
+        if self._source.video_format != old_source.video_format:
+            self._texture = None
+            pyglet.clock.unschedule(self.update_texture)
+
+    def _create_player_resources(self, starting: bool) -> None:
+        super()._create_player_resources(starting)
+        if self._source.video_format is not None:
+            if self._texture is None:
+                self._create_texture()
+
+    def _start_player_resources(self) -> None:
+        super()._start_player_resources()
+        if self._source.video_format is not None:
+            pyglet.clock.schedule_once(self.update_texture, 0)
+
+    def _stop_player_resources(self):
+        super()._stop_player_resources()
+        pyglet.clock.unschedule(self.update_texture)
+
+    def update_texture(self, dt: float | None = None) -> None:
+        """Manually update the texture from the current source.
+
+        This happens automatically, so you shouldn't need to call this method.
+
+        Args:
+            dt:
+                The time elapsed since the last call to ``update_texture``.
+        """
+        source = self.source
+        _time = self.time
+
+        frame_rate = source.video_format.frame_rate
+        frame_duration = 1 / frame_rate
+        ts = source.get_next_video_timestamp()
+        # Allow up to frame_duration difference
+        while ts is not None and ts + frame_duration < _time:
+            source.get_next_video_frame()  # Discard frame
+            ts = source.get_next_video_timestamp()
+
+        if ts is None:
+            # No more video frames to show. End of video stream.
+            pyglet.clock.schedule_once(self._video_finished, 0)
+            return
+        if ts > _time:
+            # update_texture called too early (probably manually!)
+            pyglet.clock.schedule_once(self.update_texture, ts - _time)
+            return
+
+        image = source.get_next_video_frame()
+        if image is not None:
+            with self._context:
+                if self._texture is None:
+                    self._create_texture()
+                else:
+                    self._texture.bind()
+                self._texture.upload(image, 0, 0, 0)
+
+        ts = source.get_next_video_timestamp()
+        if ts is None:
+            delay = frame_duration
+        else:
+            delay = ts - _time
+
+        delay = max(0.0, delay)
+        pyglet.clock.schedule_once(self.update_texture, delay)
+
+    def _video_finished(self, _dt: float) -> None:
+        if self._audio_player is None:
+            self.dispatch_event("on_eos")
+
+    def _create_texture(self) -> pyglet.graphics.Texture:
+        video_format = self.source.video_format
+        self._texture = pyglet.graphics.Texture.create(video_format.width, video_format.height)
+
+        # Flip coordinates so output is correct orientation.
+        self._texture = self._texture.get_transform(flip_y=True)
+        # After flipping, the anchor_y is set to the top of the image. We want to keep it at the bottom.
+        self._texture.anchor_y = 0
+        return self._texture
+
+    @property
+    def texture(self) -> Texture | None:
+        """Get the texture for the current video frame, if any.
+
+        You should query this property every time you display a frame of video,
+        as multiple textures might be used. This property will be ``None`` if
+        the current Source does not contain video.
+        """
+        return self._texture
+
+    def seek_next_frame(self) -> None:
+        """Step forwards one video frame in the current source."""
+        time = self.source.get_next_video_timestamp()
+        if time is None:
+            return
+        self.seek(time)
+
+    def delete(self) -> None:
+        super().delete()
+        if self._texture is not None:
+            self._texture = None
 
 
 class PlayerGroup:
@@ -623,7 +633,7 @@ class PlayerGroup:
     All players in the group must currently not belong to any other group.
     """
 
-    def __init__(self, players: Iterable[Player]) -> None:
+    def __init__(self, players: Iterable[AudioPlayer]) -> None:
         """Initialize the PlayerGroup with the players."""
         self.players = list(players)
 

--- a/tests/integration/media/test_player.py
+++ b/tests/integration/media/test_player.py
@@ -7,18 +7,18 @@ import pyglet
 _debug = False
 pyglet.options.debug_media = _debug
 
-from pyglet.media import Player
+from pyglet.media import AudioPlayer
 from pyglet.media.synthesis import Silence
 from .mock_player import MockPlayer
 
 
-class PlayerTest(MockPlayer, Player):
+class AudioPlayerTest(MockPlayer, AudioPlayer):
     pass
 
 
 @pytest.fixture
 def player(event_loop):
-    return PlayerTest(event_loop)
+    return AudioPlayerTest(event_loop)
 
 
 class SilentTestSource(Silence):

--- a/tests/interactive/media/test_player.py
+++ b/tests/interactive/media/test_player.py
@@ -5,7 +5,7 @@ import pytest
 
 import pyglet
 pyglet.options.debug_media = False
-from pyglet.media.player import Player
+from pyglet.media.player import AudioPlayer
 from pyglet.media import synthesis
 from pyglet.media.codecs.base import StaticSource
 
@@ -13,7 +13,7 @@ from pyglet.media.codecs.base import StaticSource
 @pytest.mark.requires_user_validation
 def test_playback(event_loop, test_data):
     """Test playing back sound files."""
-    player = Player()
+    player = AudioPlayer()
     player.on_player_eos = event_loop.interrupt_event_loop
     player.play()
 
@@ -49,7 +49,7 @@ def test_playback_fire_and_forget(event_loop, test_data):
 def test_play_queue(event_loop):
     """Test playing a single sound on the queue."""
     source = synthesis.WhiteNoise(1.0)
-    player = Player()
+    player = AudioPlayer()
     player.on_player_eos = event_loop.interrupt_event_loop
     player.play()
     player.queue(source)
@@ -61,7 +61,7 @@ def test_play_queue(event_loop):
 def test_queue_play(event_loop):
     """Test putting a single sound on the queue and then starting the player."""
     source = synthesis.WhiteNoise(1.0)
-    player = Player()
+    player = AudioPlayer()
     player.on_player_eos = event_loop.interrupt_event_loop
     player.queue(source)
     player.play()
@@ -73,7 +73,7 @@ def test_queue_play(event_loop):
 def test_pause_queue(event_loop):
     """Test the queue is not played when player is paused."""
     source = synthesis.WhiteNoise(1.0)
-    player = Player()
+    player = AudioPlayer()
     player.pause()
     player.queue(source)
 
@@ -86,7 +86,7 @@ def test_pause_queue(event_loop):
 def test_pause_sound(event_loop):
     """Test that a playing sound can be paused."""
     source = synthesis.WhiteNoise(60.0)
-    player = Player()
+    player = AudioPlayer()
     player.queue(source)
     player.play()
 
@@ -106,7 +106,7 @@ def test_next_on_end_of_stream(event_loop):
     """Test that multiple items on the queue are played after each other."""
     source1 = synthesis.WhiteNoise(1.0)
     source2 = synthesis.Sine(1.0)
-    player = Player()
+    player = AudioPlayer()
     player.on_player_eos = event_loop.interrupt_event_loop
     player.queue(source1)
     player.queue(source2)
@@ -122,7 +122,7 @@ def test_static_source_wrapping(event_loop):
     source = synthesis.WhiteNoise(1.0)
     source = StaticSource(source)
     source = StaticSource(source)
-    player = Player()
+    player = AudioPlayer()
     player.on_player_eos = event_loop.interrupt_event_loop
     player.queue(source)
     player.play()

--- a/tests/unit/media/test_player.py
+++ b/tests/unit/media/test_player.py
@@ -2,7 +2,7 @@ from tests import mock
 import random
 import unittest
 
-from pyglet.media.player import Player, PlayerGroup
+from pyglet.media.player import AudioPlayer, PlayerGroup
 from pyglet.media.codecs.base import AudioFormat, VideoFormat, Source
 
 
@@ -16,7 +16,7 @@ class PlayerTestCase(unittest.TestCase):
     video_format_2.frame_rate = 25
 
     def setUp(self):
-        self.player = Player()
+        self.player = AudioPlayer()
 
         self._get_audio_driver_patcher = mock.patch('pyglet.media.player.get_audio_driver')
         self.mock_get_audio_driver = self._get_audio_driver_patcher.start()

--- a/tests/unit/media/test_player.py
+++ b/tests/unit/media/test_player.py
@@ -2,8 +2,12 @@ from tests import mock
 import random
 import unittest
 
-from pyglet.media.player import AudioPlayer, PlayerGroup
+from pyglet.media.player import AudioPlayer, VideoPlayer, PlayerGroup
 from pyglet.media.codecs.base import AudioFormat, VideoFormat, Source
+
+class TestVideoPlayer(VideoPlayer):
+    def _create_sprite(self) -> None:
+        pass
 
 
 class PlayerTestCase(unittest.TestCase):
@@ -16,7 +20,8 @@ class PlayerTestCase(unittest.TestCase):
     video_format_2.frame_rate = 25
 
     def setUp(self):
-        self.player = AudioPlayer()
+        self.audio_player = AudioPlayer()
+        self.video_player = TestVideoPlayer()
 
         self._get_audio_driver_patcher = mock.patch('pyglet.media.player.get_audio_driver')
         self.mock_get_audio_driver = self._get_audio_driver_patcher.start()
@@ -69,37 +74,37 @@ class PlayerTestCase(unittest.TestCase):
         queue_source.get_next_video_timestamp.side_effect = _get_timestamp
         queue_source.get_next_video_frame.side_effect = _get_frame
 
-    def assert_not_playing_yet(self, current_source=None):
+    def assert_not_playing_yet(self, player, current_source=None):
         """Assert the the player did not start playing yet."""
         self.assertFalse(self.mock_get_audio_driver.called, msg='No audio driver required yet')
-        self.assertAlmostEqual(self.player.time, 0.)
-        self.assert_not_playing(current_source)
+        self.assertAlmostEqual(player.time, 0.)
+        self.assert_not_playing(player, current_source)
 
-    def assert_not_playing(self, current_source=None):
-        self._assert_playing(False, current_source)
+    def assert_not_playing(self, player, current_source=None):
+        self._assert_playing(player, False, current_source)
 
-    def assert_now_playing(self, current_source):
-        self._assert_playing(True, current_source)
+    def assert_now_playing(self, player, current_source):
+        self._assert_playing(player, True, current_source)
 
-    def _assert_playing(self, playing, current_source=None):
-        self.assertEqual(self.player.playing, playing)
+    def _assert_playing(self, player, playing, current_source=None):
+        self.assertEqual(player.playing, playing)
         queued_source = (current_source.get_queue_source.return_value
                          if current_source is not None
                          else None)
-        self.assertIs(self.player.source, queued_source)
+        self.assertIs(player.source, queued_source)
 
-    def assert_driver_player_created_for(self, source):
+    def assert_driver_player_created_for(self, player, source):
         """Assert that a driver specific audio player is created to play back given source"""
-        self._assert_player_created_for(self.mock_get_audio_driver, self.mock_audio_driver, source)
+        self._assert_player_created_for(player, self.mock_get_audio_driver, self.mock_audio_driver, source)
 
-    def _assert_player_created_for(self, mock_get_audio_driver, mock_audio_driver, source):
+    def _assert_player_created_for(self, player, mock_get_audio_driver, mock_audio_driver, source):
         mock_get_audio_driver.assert_called_once_with()
         self.assertEqual(mock_audio_driver.create_audio_player.call_count, 1)
         call_args = mock_audio_driver.create_audio_player.call_args
         args, kwargs = call_args
         arg_source, arg_player = args
         self.assertIs(arg_source, source.get_queue_source.return_value)
-        self.assertIs(arg_player, self.player)
+        self.assertIs(arg_player, player)
 
     def assert_no_new_driver_player_created(self):
         """Assert that no new driver specific audio player is created."""
@@ -145,13 +150,13 @@ class PlayerTestCase(unittest.TestCase):
         self.assertFalse(self.mock_texture.upload.called)
 
     def assert_update_texture_scheduled(self):
-        self.mock_clock.schedule_once.assert_called_once_with(self.player.update_texture, 0)
+        self.mock_clock.schedule_once.assert_called_once_with(self.video_player.update_texture, 0)
 
     def assert_update_texture_unscheduled(self):
-        self.mock_clock.unschedule.assert_called_with(self.player.update_texture)
+        self.mock_clock.unschedule.assert_called_with(self.video_player.update_texture)
 
-    def pretend_player_at_time(self, t):
-        self.player._timer.set_time(t)
+    def pretend_player_at_time(self, player, t):
+        player._timer.set_time(t)
 
     def pretend_silent_driver_player_at_time(self, t):
         self.mock_silent_audio_driver_player.get_time.return_value = t
@@ -160,13 +165,13 @@ class PlayerTestCase(unittest.TestCase):
         """Queue a single audio source and start playing it."""
 
         mock_source = self.create_mock_source(self.audio_format_1, None)
-        self.player.queue(mock_source)
-        self.assert_not_playing_yet(mock_source)
+        self.audio_player.queue(mock_source)
+        self.assert_not_playing_yet(self.audio_player, mock_source)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source)
+        self.assert_now_playing(self.audio_player, mock_source)
 
     def test_queue_multiple_audio_sources_same_format_and_play(self):
         """Queue multiple audio sources using the same audio format and start playing."""
@@ -174,19 +179,19 @@ class PlayerTestCase(unittest.TestCase):
         mock_source2 = self.create_mock_source(self.audio_format_1, None)
         mock_source3 = self.create_mock_source(self.audio_format_1, None)
 
-        self.player.queue(mock_source1)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source1)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.queue(mock_source2)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.queue(mock_source3)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source3)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source1)
+        self.assert_now_playing(self.audio_player, mock_source1)
 
     def test_queue_multiple_audio_sources_different_format_and_play_and_skip(self):
         """Queue multiple audio sources having different formats and start playing. Different
@@ -195,33 +200,33 @@ class PlayerTestCase(unittest.TestCase):
         mock_source2 = self.create_mock_source(self.audio_format_2, None)
         mock_source3 = self.create_mock_source(self.audio_format_3, None)
 
-        self.player.queue(mock_source1)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source1)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.queue(mock_source2)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.queue(mock_source3)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source3)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source1)
+        self.assert_now_playing(self.audio_player, mock_source1)
 
         self.reset_mocks()
-        self.player.next_source()
+        self.audio_player.next_source()
         self.assert_driver_player_destroyed()
-        self.assert_driver_player_created_for(mock_source2)
+        self.assert_driver_player_created_for(self.audio_player, mock_source2)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source2)
+        self.assert_now_playing(self.audio_player, mock_source2)
 
         self.reset_mocks()
-        self.player.next_source()
+        self.audio_player.next_source()
         self.assert_driver_player_destroyed()
-        self.assert_driver_player_created_for(mock_source3)
+        self.assert_driver_player_created_for(self.audio_player, mock_source3)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source3)
+        self.assert_now_playing(self.audio_player, mock_source3)
 
     def test_queue_multiple_audio_sources_same_format_and_play_and_skip(self):
         """When multiple audio sources with the same format are queued, they are played
@@ -232,26 +237,26 @@ class PlayerTestCase(unittest.TestCase):
         mock_source2 = self.create_mock_source(self.audio_format_1, None)
         mock_source3 = self.create_mock_source(self.audio_format_1, None)
 
-        self.player.queue(mock_source1)
-        self.player.queue(mock_source2)
-        self.player.queue(mock_source3)
+        self.audio_player.queue(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.audio_player.queue(mock_source3)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source1)
+        self.assert_now_playing(self.audio_player, mock_source1)
 
         self.reset_mocks()
-        self.player.next_source()
+        self.audio_player.next_source()
         self.assert_driver_player_not_destroyed()
         self.assert_no_new_driver_player_created()
-        self.assert_now_playing(mock_source2)
+        self.assert_now_playing(self.audio_player, mock_source2)
 
         self.reset_mocks()
-        self.player.next_source()
+        self.audio_player.next_source()
         self.assert_driver_player_not_destroyed()
         self.assert_no_new_driver_player_created()
-        self.assert_now_playing(mock_source3)
+        self.assert_now_playing(self.audio_player, mock_source3)
 
     def test_on_eos(self):
         """The player receives on_eos for every source, but does not need to do anything.
@@ -260,44 +265,44 @@ class PlayerTestCase(unittest.TestCase):
         mock_source2 = self.create_mock_source(self.audio_format_1, None)
         mock_source3 = self.create_mock_source(self.audio_format_1, None)
 
-        self.player.queue(mock_source1)
-        self.player.queue(mock_source2)
-        self.player.queue(mock_source3)
+        self.audio_player.queue(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.audio_player.queue(mock_source3)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
         self.assert_driver_player_started()
 
         self.reset_mocks()
-        self.player.dispatch_event('on_eos')
+        self.audio_player.dispatch_event('on_eos')
         self.assert_driver_player_not_destroyed()
 
     def test_player_stops_after_last_eos(self):
         """If the last playlist source is eos, the player stops."""
         mock_source = self.create_mock_source(self.audio_format_1, None)
-        self.player.queue(mock_source)
-        self.assert_not_playing_yet(mock_source)
+        self.audio_player.queue(mock_source)
+        self.assert_not_playing_yet(self.audio_player, mock_source)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source)
+        self.assert_now_playing(self.audio_player, mock_source)
 
         self.reset_mocks()
-        self.player.dispatch_event('on_eos')
+        self.audio_player.dispatch_event('on_eos')
         self.assert_driver_player_destroyed()
-        self.assert_not_playing(None)
+        self.assert_not_playing(self.audio_player, None)
 
     def test_eos_events(self):
         """Test receiving various eos events: on source eos,
         on playlist exhausted and on player eos and on player next source.
         """
         on_eos_mock = mock.MagicMock(return_value=None)
-        self.player.event('on_eos')(on_eos_mock)
+        self.audio_player.event('on_eos')(on_eos_mock)
         on_player_eos_mock = mock.MagicMock(return_value=None)
-        self.player.event('on_player_eos')(on_player_eos_mock)
+        self.audio_player.event('on_player_eos')(on_player_eos_mock)
         on_player_next_source_mock = mock.MagicMock(return_value=None)
-        self.player.event('on_player_next_source')(on_player_next_source_mock)
+        self.audio_player.event('on_player_next_source')(on_player_next_source_mock)
 
         def reset_eos_mocks():
             on_eos_mock.reset_mock()
@@ -314,55 +319,55 @@ class PlayerTestCase(unittest.TestCase):
         mock_source2 = self.create_mock_source(self.audio_format_1, None)
         mock_source3 = self.create_mock_source(self.audio_format_2, None)
 
-        self.player.queue(mock_source1)
-        self.player.queue(mock_source2)
-        self.player.queue(mock_source3)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.audio_player.queue(mock_source3)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
 
         self.reset_mocks()
         reset_eos_mocks()
         # Pretend the current source in the group was eos and next source started
-        self.player.dispatch_event('on_eos')
+        self.audio_player.dispatch_event('on_eos')
         self.assert_driver_player_not_destroyed()
         assert_eos_events_received(on_eos=True, on_player_next_source=True)
-        self.assertEqual(len(self.player._playlists), 2)
+        self.assertEqual(len(self.audio_player._playlists), 2)
 
         # Pretend playlist is exhausted. Should be no more sources to play.
-        self.player.dispatch_event('on_eos')
+        self.audio_player.dispatch_event('on_eos')
         self.reset_mocks()
         reset_eos_mocks()
-        self.player.dispatch_event('on_eos')
-        self.assert_not_playing(None)
+        self.audio_player.dispatch_event('on_eos')
+        self.assert_not_playing(self.audio_player, None)
         assert_eos_events_received(on_eos=True, on_player_eos=True)
 
     def test_pause_resume(self):
         """A stream can be paused. After that play will resume where paused."""
         mock_source = self.create_mock_source(self.audio_format_1, None)
-        self.player.queue(mock_source)
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source)
+        self.audio_player.queue(mock_source)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source)
+        self.assert_now_playing(self.audio_player, mock_source)
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.5)
-        self.player.pause()
+        self.pretend_player_at_time(self.audio_player, 0.5)
+        self.audio_player.pause()
         self.assert_driver_player_stopped()
         self.assert_driver_player_not_destroyed()
 
         self.reset_mocks()
-        self.player.play()
-        self.assertGreaterEqual(self.player.time, 0.5)
+        self.audio_player.play()
+        self.assertGreaterEqual(self.audio_player.time, 0.5)
         self.assertAlmostEqual(
-            self.player.time, 0.5, delta=0.01,
+            self.audio_player.time, 0.5, delta=0.01,
             msg='Player time should have advanced during pause'
         )
         self.assert_driver_player_started()
         self.assert_no_new_driver_player_created()
-        self.assert_now_playing(mock_source)
+        self.assert_now_playing(self.audio_player, mock_source)
 
     def test_delete(self):
         """Test clean up of the player when delete() is called."""
@@ -370,45 +375,45 @@ class PlayerTestCase(unittest.TestCase):
         mock_source2 = self.create_mock_source(self.audio_format_2, None)
         mock_source3 = self.create_mock_source(self.audio_format_3, None)
 
-        self.player.queue(mock_source1)
-        self.player.queue(mock_source2)
-        self.player.queue(mock_source3)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.audio_player.queue(mock_source3)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
         self.assert_driver_player_started()
 
         self.reset_mocks()
-        self.pretend_player_at_time(1.)
-        self.player.delete()
+        self.pretend_player_at_time(self.audio_player, 1.)
+        self.audio_player.delete()
         self.assert_driver_player_destroyed()
 
     def test_empty_player(self):
         """A player without queued sources should not start a driver player and should not raise
         exceptions"""
-        self.assert_not_playing_yet(None)
+        self.assert_not_playing_yet(self.audio_player, None)
 
         self.reset_mocks()
-        self.player.play()
+        self.audio_player.play()
         self.assert_no_new_driver_player_created()
 
         self.reset_mocks()
-        self.player.pause()
-        self.assert_no_new_driver_player_created()
-        self.assert_driver_player_not_destroyed()
-
-        self.reset_mocks()
-        self.player.next_source()
+        self.audio_player.pause()
         self.assert_no_new_driver_player_created()
         self.assert_driver_player_not_destroyed()
 
         self.reset_mocks()
-        self.player.seek(0.8)
+        self.audio_player.next_source()
         self.assert_no_new_driver_player_created()
         self.assert_driver_player_not_destroyed()
 
-        self.player.delete()
+        self.reset_mocks()
+        self.audio_player.seek(0.8)
+        self.assert_no_new_driver_player_created()
+        self.assert_driver_player_not_destroyed()
+
+        self.audio_player.delete()
 
     def test_set_player_properties_before_playing(self):
         """When setting player properties before a driver specific player is
@@ -417,20 +422,20 @@ class PlayerTestCase(unittest.TestCase):
         """
         mock_source1 = self.create_mock_source(self.audio_format_1, None)
         mock_source2 = self.create_mock_source(self.audio_format_2, None)
-        self.player.queue(mock_source1)
-        self.player.queue(mock_source2)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
         self.reset_mocks()
-        self.player.volume = 10.
-        self.player.min_distance = 2.
-        self.player.max_distance = 3.
-        self.player.position = (4, 4, 4)
-        self.player.pitch = 5.0
-        self.player.cone_orientation = (6, 6, 6)
-        self.player.cone_inner_angle = 7.
-        self.player.cone_outer_angle = 8.
-        self.player.cone_outer_gain = 9.
+        self.audio_player.volume = 10.
+        self.audio_player.min_distance = 2.
+        self.audio_player.max_distance = 3.
+        self.audio_player.position = (4, 4, 4)
+        self.audio_player.pitch = 5.0
+        self.audio_player.cone_orientation = (6, 6, 6)
+        self.audio_player.cone_inner_angle = 7.
+        self.audio_player.cone_outer_angle = 8.
+        self.audio_player.cone_outer_gain = 9.
 
         def assert_properties_set():
             self.mock_audio_driver_player.set_volume.assert_called_once_with(10.)
@@ -444,15 +449,15 @@ class PlayerTestCase(unittest.TestCase):
             self.mock_audio_driver_player.set_cone_outer_gain.assert_called_once_with(9.)
 
         self.reset_mocks()
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
-        self.assert_now_playing(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
+        self.assert_now_playing(self.audio_player, mock_source1)
         assert_properties_set()
 
         self.reset_mocks()
-        self.player.next_source()
+        self.audio_player.next_source()
         self.assert_driver_player_destroyed()
-        self.assert_driver_player_created_for(mock_source2)
+        self.assert_driver_player_created_for(self.audio_player, mock_source2)
         assert_properties_set()
 
     def test_set_player_properties_while_playing(self):
@@ -460,55 +465,55 @@ class PlayerTestCase(unittest.TestCase):
         be propagated to the driver specific player right away."""
         mock_source1 = self.create_mock_source(self.audio_format_1, None)
         mock_source2 = self.create_mock_source(self.audio_format_2, None)
-        self.player.queue(mock_source1)
-        self.player.queue(mock_source2)
-        self.assert_not_playing_yet(mock_source1)
+        self.audio_player.queue(mock_source1)
+        self.audio_player.queue(mock_source2)
+        self.assert_not_playing_yet(self.audio_player, mock_source1)
 
         self.reset_mocks()
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source1)
-        self.assert_now_playing(mock_source1)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source1)
+        self.assert_now_playing(self.audio_player, mock_source1)
 
         self.reset_mocks()
-        self.player.volume = 10.
+        self.audio_player.volume = 10.
         self.mock_audio_driver_player.set_volume.assert_called_once_with(10.)
 
         self.reset_mocks()
-        self.player.min_distance = 2.
+        self.audio_player.min_distance = 2.
         self.mock_audio_driver_player.set_min_distance.assert_called_once_with(2.)
 
         self.reset_mocks()
-        self.player.max_distance = 3.
+        self.audio_player.max_distance = 3.
         self.mock_audio_driver_player.set_max_distance.assert_called_once_with(3.)
 
         self.reset_mocks()
-        self.player.position = (4, 4, 4)
+        self.audio_player.position = (4, 4, 4)
         self.mock_audio_driver_player.set_position.assert_called_once_with((4, 4, 4))
 
         self.reset_mocks()
-        self.player.pitch = 5.0
+        self.audio_player.pitch = 5.0
         self.mock_audio_driver_player.set_pitch.assert_called_once_with(5.)
 
         self.reset_mocks()
-        self.player.cone_orientation = (6, 6, 6)
+        self.audio_player.cone_orientation = (6, 6, 6)
         self.mock_audio_driver_player.set_cone_orientation.assert_called_once_with((6, 6, 6))
 
         self.reset_mocks()
-        self.player.cone_inner_angle = 7.
+        self.audio_player.cone_inner_angle = 7.
         self.mock_audio_driver_player.set_cone_inner_angle.assert_called_once_with(7.)
 
         self.reset_mocks()
-        self.player.cone_outer_angle = 8.
+        self.audio_player.cone_outer_angle = 8.
         self.mock_audio_driver_player.set_cone_outer_angle.assert_called_once_with(8.)
 
         self.reset_mocks()
-        self.player.cone_outer_gain = 9.
+        self.audio_player.cone_outer_gain = 9.
         self.mock_audio_driver_player.set_cone_outer_gain.assert_called_once_with(9.)
 
         self.reset_mocks()
-        self.player.next_source()
+        self.audio_player.next_source()
         self.assert_driver_player_destroyed()
-        self.assert_driver_player_created_for(mock_source2)
+        self.assert_driver_player_created_for(self.audio_player, mock_source2)
         self.mock_audio_driver_player.set_volume.assert_called_once_with(10.)
         self.mock_audio_driver_player.set_min_distance.assert_called_once_with(2.)
         self.mock_audio_driver_player.set_max_distance.assert_called_once_with(3.)
@@ -522,23 +527,23 @@ class PlayerTestCase(unittest.TestCase):
     def test_seek(self):
         """Test seeking to a specific time in the current source."""
         mock_source = self.create_mock_source(self.audio_format_1, None)
-        self.player.queue(mock_source)
-        self.assert_not_playing_yet(mock_source)
+        self.audio_player.queue(mock_source)
+        self.assert_not_playing_yet(self.audio_player, mock_source)
 
         self.reset_mocks()
         mock_source.reset_mock()
-        self.player.seek(0.7)
+        self.audio_player.seek(0.7)
         self.assert_source_seek(mock_source, 0.7)
 
         self.reset_mocks()
         mock_source.reset_mock()
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source)
-        self.assert_now_playing(mock_source)
+        self.audio_player.play()
+        self.assert_driver_player_created_for(self.audio_player, mock_source)
+        self.assert_now_playing(self.audio_player, mock_source)
 
         self.reset_mocks()
         mock_source.reset_mock()
-        self.player.seek(0.2)
+        self.audio_player.seek(0.2)
         self.assert_source_seek(mock_source, 0.2)
         # Clear buffers for immediate result
         self.assert_driver_player_cleared()
@@ -549,22 +554,22 @@ class PlayerTestCase(unittest.TestCase):
         video packet timestamp."""
         mock_source = self.create_mock_source(self.audio_format_1, self.video_format_1)
         self.set_video_data_for_mock_source(mock_source, [(0.2, 'a')])
-        self.player.queue(mock_source)
-        self.assert_not_playing_yet(mock_source)
+        self.video_player.queue(mock_source)
+        self.assert_not_playing_yet(self.video_player, mock_source)
 
         self.reset_mocks()
-        self.player.play()
-        self.assert_driver_player_created_for(mock_source)
+        self.video_player.play()
+        self.assert_driver_player_created_for(self.video_player, mock_source)
         self.assert_driver_player_started()
-        self.assert_now_playing(mock_source)
+        self.assert_now_playing(self.video_player, mock_source)
         self.assert_new_texture_created(self.video_format_1)
         self.assert_update_texture_scheduled()
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.2)
-        self.player.update_texture()
+        self.pretend_player_at_time(self.video_player, 0.2)
+        self.video_player.update_texture()
         self.assert_texture_updated('a')
-        self.assertIs(self.player.texture, self.mock_texture)
+        self.assertIs(self.video_player.texture, self.mock_texture)
 
     def test_video_seek(self):
         """Sources with video can also be seeked. It's the Source
@@ -573,25 +578,25 @@ class PlayerTestCase(unittest.TestCase):
         mock_source = self.create_mock_source(self.audio_format_1, self.video_format_1)
         self.set_video_data_for_mock_source(mock_source, [(0.0, 'a'), (0.1, 'b'), (0.2, 'c'),
                                                           (0.3, 'd'), (0.4, 'e'), (0.5, 'f')])
-        self.player.queue(mock_source)
-        self.player.play()
+        self.video_player.queue(mock_source)
+        self.video_player.play()
         self.assert_new_texture_created(self.video_format_1)
         self.assert_update_texture_scheduled()
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.0)
-        self.player.update_texture()
+        self.pretend_player_at_time(self.video_player, 0.0)
+        self.video_player.update_texture()
         self.assert_texture_updated('a')
 
         self.reset_mocks()
-        self.player.seek(0.3)
+        self.video_player.seek(0.3)
         self.assert_source_seek(mock_source, 0.3)
         self.assert_no_new_texture_created()
         self.assert_texture_updated('d')
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.4)
-        self.player.update_texture()
+        self.pretend_player_at_time(self.video_player, 0.4)
+        self.video_player.update_texture()
         self.assert_texture_updated('e')
 
     def test_video_frame_rate(self):
@@ -606,40 +611,40 @@ class PlayerTestCase(unittest.TestCase):
                  (0.3, 'd'), (0.4, 'e'), (0.5, 'f')]
             )
 
-        self.player.queue(mock_source1)
-        self.player.queue(mock_source2)
+        self.video_player.queue(mock_source1)
+        self.video_player.queue(mock_source2)
 
-        self.player.play()
+        self.video_player.play()
         self.assert_new_texture_created(self.video_format_1)
         self.assert_update_texture_scheduled()
 
         self.reset_mocks()
-        self.player.next_source()
+        self.video_player.next_source()
         self.assert_new_texture_created(self.video_format_2)
         self.assert_update_texture_unscheduled()
         # schedule_once called twice:
         #   - Once for seeking back to 0 the previous source in next_source()
         #   - Once for scheduling the next source update_texture
         assert self.mock_clock.schedule_once.call_count == 2
-        self.mock_clock.schedule_once.assert_called_with(self.player.update_texture, 0)
+        self.mock_clock.schedule_once.assert_called_with(self.video_player.update_texture, 0)
 
     def test_video_seek_next_frame(self):
         """It is possible to jump directly to the next frame of video and adjust the audio player
         accordingly."""
         mock_source = self.create_mock_source(self.audio_format_1, self.video_format_1)
         self.set_video_data_for_mock_source(mock_source, [(0.0, 'a'), (0.2, 'b')])
-        self.player.queue(mock_source)
-        self.player.play()
+        self.video_player.queue(mock_source)
+        self.video_player.play()
         self.assert_new_texture_created(self.video_format_1)
         self.assert_update_texture_scheduled()
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.0)
-        self.player.update_texture()
+        self.pretend_player_at_time(self.video_player, 0.0)
+        self.video_player.update_texture()
         self.assert_texture_updated('a')
 
         self.reset_mocks()
-        self.player.seek_next_frame()
+        self.video_player.seek_next_frame()
         self.assert_source_seek(mock_source, 0.2)
         self.assert_texture_updated('b')
 
@@ -648,35 +653,35 @@ class PlayerTestCase(unittest.TestCase):
         responsible for triggering eos."""
         mock_source = self.create_mock_source(self.audio_format_1, self.video_format_1)
         self.set_video_data_for_mock_source(mock_source, [(0.0, 'a'), (0.1, 'b')])
-        self.player.queue(mock_source)
-        self.player.play()
+        self.video_player.queue(mock_source)
+        self.video_player.play()
         self.assert_new_texture_created(self.video_format_1)
         self.assert_update_texture_scheduled()
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.0)
-        self.player.update_texture()
+        self.pretend_player_at_time(self.video_player, 0.0)
+        self.video_player.update_texture()
         self.assert_texture_updated('a')
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.1)
-        self.player.update_texture()
+        self.pretend_player_at_time(self.video_player, 0.1)
+        self.video_player.update_texture()
         self.assert_texture_updated('b')
 
         self.reset_mocks()
-        self.pretend_player_at_time(0.2)
-        self.player.update_texture()
+        self.pretend_player_at_time(self.video_player, 0.2)
+        self.video_player.update_texture()
         self.assert_texture_not_updated()
 
         self.reset_mocks()
-        self.player.seek_next_frame()
+        self.video_player.seek_next_frame()
         self.assert_texture_not_updated()
 
     def test_video_without_audio(self):
         """It is possible to have videos without audio streams."""
         mock_source = self.create_mock_source(None, self.video_format_1)
-        self.player.queue(mock_source)
-        self.player.play()
+        self.video_player.queue(mock_source)
+        self.video_player.play()
         self.assert_new_texture_created(self.video_format_1)
         self.assert_update_texture_scheduled()
         self.assert_no_new_driver_player_created()
@@ -685,8 +690,8 @@ class PlayerTestCase(unittest.TestCase):
         """An audio source with a silent driver."""
         mock_source = self.create_mock_source(self.audio_format_3, None)
         self.mock_get_audio_driver.return_value = None
-        self.player.queue(mock_source)
-        self.player.play()
+        self.audio_player.queue(mock_source)
+        self.audio_player.play()
 
 
 class PlayerGroupTestCase(unittest.TestCase):

--- a/tests/unit/media/test_player.py
+++ b/tests/unit/media/test_player.py
@@ -9,6 +9,10 @@ class TestVideoPlayer(VideoPlayer):
     def _create_sprite(self) -> None:
         pass
 
+    @staticmethod
+    def _check_ffmpeg_availability() -> None:
+        pass
+
 
 class PlayerTestCase(unittest.TestCase):
     # Default values to use

--- a/tests/unit/media/test_sources.py
+++ b/tests/unit/media/test_sources.py
@@ -93,7 +93,7 @@ class AudioDataTestCase(unittest.TestCase):
 
 
 class SourceTestCase(unittest.TestCase):
-    @mock.patch('pyglet.media.player.Player')
+    @mock.patch('pyglet.media.player.AudioPlayer')
     def test_play(self, player_mock):
         source = Source()
         returned_player = source.play()


### PR DESCRIPTION
* Split `Player` into `AudioPlayer` and `VideoPlayer`. 
* Update `media_player.py` to be more GUI instead of command line.
* Update tests.

I also have added a check to ensure FFMpeg is detected for `VideoPlayer` to work. 

Docs may need better adjusting later, but did a small pass. However there is a little ambiguity with the "driver" level `AudioPlayer` and the new `AudioPlayer` player. Perhaps a better name can be chosen for either? Open to feedback.