### PR TITLE
Fix transparent framebuffer for Xlib

### DIFF
--- a/pyglet/graphics/api/gl/base.py
+++ b/pyglet/graphics/api/gl/base.py
@@ -62,6 +62,8 @@ class OpenGLConfig(GraphicsConfig):
     opengl_api: str = "gl"
     #: Debug mode.
     debug: bool
+    #: If the framebuffer should be transparent.
+    transparent_framebuffer: bool
 
     @property
     def finalized_config(self) -> OpenGLWindowConfig | None:

--- a/pyglet/info.py
+++ b/pyglet/info.py
@@ -102,6 +102,7 @@ def dump_glx():
         return
     import pyglet
     window = pyglet.window.Window(visible=False)
+    glx_info = window.context._info.platform_info
     print('context.is_direct():', window.context.is_direct())
     window.close()
 
@@ -119,7 +120,7 @@ def dump_glx():
         for name in glx_info.get_client_extensions():
             print('  ', name)
         print('glx_info.get_extensions():')
-        for name in glx_info.get_extensions():
+        for name in glx_info.get_extensions(window.context):
             print('  ', name)
 
 

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -542,16 +542,16 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
 
             if not config:
                 for template_config in pyglet.graphics.api.get_default_configs():
+                    if self._style in ('transparent', 'overlay'):
+                        template_config.alpha_size = 8
+                        template_config.transparent_framebuffer = True
+
                     if config := template_config.match(self):
                         break
 
                 if not config:
                     msg = 'No standard config is available.'
                     raise NoSuchConfigException(msg)
-
-            # Necessary on Windows. More investigation needed:
-            if self._style in ('transparent', 'overlay'):
-                config.alpha = 8
 
             if not config.is_finalized:
                 config = config.match(self)


### PR DESCRIPTION
This corrects an issue with an insufficient config being chosen for visual info to allow transparent framebuffers.
Also remove left over code of window frame opacity setting.