### PR TITLE
Transparency and overlay fixes

### DIFF
--- a/pyglet/gl/base.py
+++ b/pyglet/gl/base.py
@@ -89,6 +89,7 @@ class Config:
         'forward_compatible',
         'opengl_api',
         'debug',
+        'transparent_framebuffer',
     )
 
     #: The OpenGL major version.
@@ -101,6 +102,8 @@ class Config:
     opengl_api: str
     #: Debug mode.
     debug: bool
+    #: If the framebuffer should be transparent.
+    transparent_framebuffer: bool
 
     def __init__(self, **kwargs: float) -> None:
         """Create a template config with the given attributes.
@@ -180,6 +183,7 @@ class DisplayConfig(Config, abc.ABC):
         self.forward_compatible = base_config.forward_compatible
         self.opengl_api = base_config.opengl_api or self.opengl_api
         self.debug = base_config.debug
+        self.transparent_framebuffer = base_config.transparent_framebuffer
 
     @abc.abstractmethod
     def compatible(self, canvas: Canvas) -> bool:

--- a/pyglet/libs/x11/xrender.py
+++ b/pyglet/libs/x11/xrender.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import warnings
+from ctypes import Structure, c_ushort, c_ulong, c_int, c_void_p, POINTER
+import pyglet.lib
+from pyglet.libs.x11.xlib import Visual
+
+lib = None
+try:
+    lib = pyglet.lib.load_library("Xrender")
+except ImportError:
+    if pyglet.options.debug_lib:
+        warnings.warn("XRender could not be loaded.")
+
+
+class XRenderDirectFormat(Structure):
+    _fields_ = [
+        ('red', c_ushort),
+        ('redMask', c_ushort),
+        ('green', c_ushort),
+        ('greenMask', c_ushort),
+        ('blue', c_ushort),
+        ('blueMask', c_ushort),
+        ('alpha', c_ushort),
+        ('alphaMask', c_ushort),
+    ]
+
+class XRenderPictFormat(Structure):
+    _fields_ = [
+        ('id', c_ulong),
+        ('type', c_int),
+        ('depth', c_int),
+        ('direct', XRenderDirectFormat),
+        ('colormap', c_ulong),
+    ]
+
+# XRenderFindVisualFormat(Display *dpy, Visual *visual)
+try:
+    XRenderFindVisualFormat = lib.XRenderFindVisualFormat
+    XRenderFindVisualFormat.argtypes = [c_void_p, POINTER(Visual)]
+    XRenderFindVisualFormat.restype = POINTER(XRenderPictFormat)
+except ValueError:
+    XRenderFindVisualFormat = None

--- a/pyglet/libs/x11/xsync.py
+++ b/pyglet/libs/x11/xsync.py
@@ -406,6 +406,49 @@ XSyncGetPriority = _lib.XSyncGetPriority
 XSyncGetPriority.restype = c_int
 XSyncGetPriority.argtypes = [POINTER(Display), XID, POINTER(c_int)]
 
+# Shape kind
+ShapeBounding = 0
+ShapeClip = 1
+ShapeInput = 2
+
+# Shape operation
+ShapeSet = 0
+ShapeUnion = 1
+ShapeIntersect = 2
+ShapeSubtract = 3
+ShapeInvert = 4
+
+XShapeCombineRegion = _lib.XShapeCombineRegion
+XShapeCombineRegion.argtypes = [
+    POINTER(Display),
+    c_void_p,
+    ctypes.c_int,  # shape kind
+    ctypes.c_int, ctypes.c_int,  # x, y offset
+    c_void_p,
+    ctypes.c_int   # ShapeOp
+]
+
+XShapeCombineMask = _lib.XShapeCombineMask
+XShapeCombineMask.argtypes = [
+    Display,       # *display
+    c_void_p,        # dest window
+    ctypes.c_int,  # shape_kind (e.g., ShapeInput)
+    ctypes.c_int,  # x offset
+    ctypes.c_int,  # y offset
+    ctypes.c_ulong,  # Pixmap (can be 0 for None)
+    ctypes.c_int   # ShapeOp (e.g., ShapeSet)
+]
+XShapeCombineMask.restype = None
+
+XShapeQueryExtension = _lib.XShapeQueryExtension
+XShapeQueryExtension.argtypes = [Display, ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int)]
+XShapeQueryExtension.restype = Bool
+
+def has_shape_support(display: Display) -> bool:
+    event_base = ctypes.c_int()
+    error_base = ctypes.c_int()
+    return XShapeQueryExtension(display, ctypes.byref(event_base), ctypes.byref(error_base))
+
 
 __all__ = ['SYNC_MAJOR_VERSION', 'SYNC_MINOR_VERSION', 'X_SyncInitialize',
 'X_SyncListSystemCounters', 'X_SyncCreateCounter', 'X_SyncSetCounter',

--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -510,13 +510,20 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
         if not screen:
             screen = display.get_default_screen()
 
-        # Ensure the framebuffer is large enough to support transparency.
-        alpha_size = 8 if style in ('transparent', 'overlay') else None
-
         if not config:
+            alpha_size = None
+            transparent_fb = False
+            # Override config settings if intention is transparency.
+            if style in ('transparent', 'overlay'):
+                # Ensure the framebuffer is large enough to support transparency.
+                alpha_size = 8
+                transparent_fb = True
+
             for template_config in [
-                gl.Config(double_buffer=True, depth_size=24, major_version=3, minor_version=3, alpha_size=alpha_size),
-                gl.Config(double_buffer=True, depth_size=16, major_version=3, minor_version=3, alpha_size=alpha_size),
+                gl.Config(double_buffer=True, depth_size=24, major_version=3, minor_version=3,
+                          alpha_size=alpha_size, transparent_framebuffer=transparent_fb),
+                gl.Config(double_buffer=True, depth_size=16, major_version=3, minor_version=3,
+                          alpha_size=alpha_size, transparent_framebuffer=transparent_fb),
                 None,
             ]:
                 try:
@@ -528,8 +535,9 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
                 msg = 'No standard config is available.'
                 raise NoSuchConfigException(msg)
         else:
-            # Override config setting if they are requesting transparency.
-            config.alpha_size = alpha_size
+            if style in ('transparent', 'overlay'):
+                config.alpha_size = 8
+                config.transparent_framebuffer = True
 
         if not config.is_complete():
             config = screen.get_best_config(config)

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -166,13 +166,17 @@ class Win32Window(BaseWindow):
         else:
             styles = {
                 self.WINDOW_STYLE_DEFAULT: (constants.WS_OVERLAPPEDWINDOW, 0),
-                self.WINDOW_STYLE_DIALOG: (constants.WS_OVERLAPPED | constants.WS_CAPTION | constants.WS_SYSMENU,
-                                           constants.WS_EX_DLGMODALFRAME),
-                self.WINDOW_STYLE_TOOL: (constants.WS_OVERLAPPED | constants.WS_CAPTION | constants.WS_SYSMENU,
-                                         constants.WS_EX_TOOLWINDOW),
+                self.WINDOW_STYLE_DIALOG: (
+                    constants.WS_OVERLAPPED | constants.WS_CAPTION | constants.WS_SYSMENU,
+                    constants.WS_EX_DLGMODALFRAME,
+                ),
+                self.WINDOW_STYLE_TOOL: (
+                    constants.WS_OVERLAPPED | constants.WS_CAPTION | constants.WS_SYSMENU,
+                    constants.WS_EX_TOOLWINDOW,
+                ),
                 self.WINDOW_STYLE_BORDERLESS: (constants.WS_POPUP, 0),
-                self.WINDOW_STYLE_TRANSPARENT: (constants.WS_OVERLAPPEDWINDOW, 0),
-                self.WINDOW_STYLE_OVERLAY: (constants.WS_POPUP, constants.WS_EX_TRANSPARENT),
+                self.WINDOW_STYLE_TRANSPARENT: (constants.WS_OVERLAPPEDWINDOW, constants.WS_EX_LAYERED),
+                self.WINDOW_STYLE_OVERLAY: (constants.WS_POPUP, constants.WS_EX_LAYERED | constants.WS_EX_TRANSPARENT),
             }
             self._ws_style, self._ex_ws_style = styles[self._style]
 
@@ -389,6 +393,8 @@ class Win32Window(BaseWindow):
 
         _dwmapi.DwmEnableBlurBehindWindow(self._hwnd, byref(bb))
         _gdi32.DeleteObject(region)
+
+        _user32.SetLayeredWindowAttributes(self._hwnd, 0, 255, constants.LWA_ALPHA)
 
     def flip(self) -> None:
         self.draw_mouse_cursor()

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -301,6 +301,11 @@ class XlibWindow(BaseWindow):
             protocols = (c_ulong * len(protocols))(*protocols)
             xlib.XSetWMProtocols(self._x_display, self._window, protocols, len(protocols))
 
+            # Overlay should allow mouse to pass through and stay on top.
+            if self._style == "overlay":
+                self._set_mouse_passthrough(True)
+                self._set_wm_state("_NET_WM_STATE_ABOVE")
+
             # Create window resize sync counter
             if self._enable_xsync:
                 value = xsync.XSyncValue()
@@ -433,6 +438,16 @@ class XlibWindow(BaseWindow):
         self.set_mouse_platform_visible()
         self._applied_mouse_exclusive = None
         self._update_exclusivity()
+
+    def _set_mouse_passthrough(self, state: bool) -> None:
+        """Sets the clickable area in the application to an empty region if enabled."""
+        if state:
+            region = xlib.XCreateRegion()
+            xsync.XShapeCombineRegion(self._x_display, self._window, xsync.ShapeInput, 0, 0, region, xsync.ShapeSet)
+            xlib.XDestroyRegion(region)
+        else:
+            # Reset input shape to default
+            xsync.XShapeCombineMask(self._x_display, self._window, xsync.ShapeInput, 0, 0, 0, xsync.ShapeSet)
 
     def _map(self) -> None:
         if self._mapped:

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -229,8 +229,6 @@ class XlibWindow(BaseWindow):
             root = xlib.XRootWindow(self._x_display, self._x_screen_id)
 
             visual_info = self.config.get_visual_info()
-            if self.style in ('transparent', 'overlay'):
-                xlib.XMatchVisualInfo(self._x_display, self._x_screen_id, 32, xlib.TrueColor, visual_info)
 
             visual = visual_info.visual
             visual_id = xlib.XVisualIDFromVisual(visual)


### PR DESCRIPTION
This fixes issues with transparency:
Win32 and Xlib: Overlay should allow click throughs.
Xlib: Overlay should be kept on top.

This corrects an issue with an insufficient config being chosen for visual info to allow transparent framebuffers.

Tested on Ubuntu and Windows 11, both seem to work. Ubuntu was tested on a VM, needs testing to see if it will work on non-VM's.