### PR TITLE
Implement platform text shaping for MacOS.

### DIFF
--- a/pyglet/libs/darwin/cocoapy/cocoalibs.py
+++ b/pyglet/libs/darwin/cocoapy/cocoalibs.py
@@ -660,6 +660,9 @@ ct.CTFontCreateUIFontForLanguage.argtypes = [c_uint32, c_double, c_void_p]
 ct.CTFontCreateCopyWithSymbolicTraits.restype = c_void_p
 ct.CTFontCreateCopyWithSymbolicTraits.argtypes = [c_void_p, CGFloat, c_void_p, c_uint32, c_uint32]
 
+ct.CTFontCreateCopyWithAttributes.restype = c_void_p
+ct.CTFontCreateCopyWithAttributes.argtypes = [c_void_p, c_double, c_void_p, c_void_p]
+
 ct.CTFontCreateWithFontDescriptor.restype = c_void_p
 ct.CTFontCreateWithFontDescriptor.argtypes = [c_void_p, CGFloat, c_void_p]
 


### PR DESCRIPTION
Adds text shaping for MacOS using CoreText.

This enables kerning and emoji combinations:

Old:
![image](https://github.com/user-attachments/assets/f20c02e4-9498-4c97-9498-a0ff693d9cb2)

New:
![image](https://github.com/user-attachments/assets/95a645e9-a560-4e20-b71b-00c2167e51f6)
