### PR TITLE
Linux evdev controller backend:  Add support for SYN_DROPPED events

### DIFF
--- a/pyglet/input/linux/evdev_constants.py
+++ b/pyglet/input/linux/evdev_constants.py
@@ -1,4 +1,4 @@
-"""Event constants from /usr/include/linux/input.h """
+"""Event constants from /usr/include/linux/input-event-codes.h"""
 
 EV_SYN = 0x00
 EV_KEY = 0x01
@@ -17,6 +17,7 @@ EV_MAX = 0x1f
 
 SYN_REPORT = 0
 SYN_CONFIG = 1
+SYN_DROPPED = 3
 
 # Keys and buttons
 

--- a/pyglet/libs/ioctl.py
+++ b/pyglet/libs/ioctl.py
@@ -64,7 +64,7 @@ _IOC_READ = 2
 # 'code' instead of 'type' to indicate the ioctl "magic number" ('H', 'E', etc.).
 
 
-def _IOC(io_dir: _IOC_NONE | _IOC_READ | _IOC_WRITE, code: int, nr: int, size: int) -> int:
+def _IOC(io_dir: Union[_IOC_NONE, _IOC_READ, _IOC_WRITE], code: int, nr: int, size: int) -> int:
     return (io_dir << _IOC_DIRSHIFT) | (code << _IOC_TYPESHIFT) | (nr << _IOC_NRSHIFT) | (size << _IOC_SIZESHIFT)
 
 


### PR DESCRIPTION
This adds two improvements to the Linux evdev backend.
* First, support queuing events until the SYN_REPORT comes in. This is not super critical for controller/joystick events, but it is aligned with the evdev spec.
* Second, add support for the SYN_DROPPED event. Some devices, such as the Steam Virtual Gamepad, are prone to dropping events. This can cause the pyglet Controls to get "stuck". This PR takes this into account, and will perform a manual sync whenever such event comes in. 