### PR TITLE
replacing the list implementation of window's event queue by a double ended queue

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -91,6 +91,7 @@ from __future__ import annotations
 
 import sys
 from abc import abstractmethod
+from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import pyglet
@@ -502,7 +503,7 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
 
         """
         EventDispatcher.__init__(self)
-        self._event_queue = []
+        self._event_queue = deque()
 
         if not display:
             display = pyglet.display.get_display()
@@ -677,7 +678,7 @@ class BaseWindow(EventDispatcher, metaclass=_WindowMetaclass):
         self._context = None
         if app.event_loop:
             app.event_loop.dispatch_event('on_window_close', self)
-        self._event_queue = []
+        self._event_queue = deque()
 
     def dispatch_event(self, *args: Any) -> None:
         if not self._enable_event_queue or self._allow_dispatch_event:

--- a/pyglet/window/cocoa/__init__.py
+++ b/pyglet/window/cocoa/__init__.py
@@ -362,7 +362,7 @@ class CocoaWindow(BaseWindow):
 
     def dispatch_pending_events(self) -> None:
         while self._event_queue:
-            event = self._event_queue.pop(0)
+            event = self._event_queue.popleft()
             EventDispatcher.dispatch_event(self, *event)
 
     def set_caption(self, caption: str) -> None:

--- a/pyglet/window/headless/__init__.py
+++ b/pyglet/window/headless/__init__.py
@@ -90,7 +90,7 @@ class HeadlessWindow(BaseWindow):
 
     def dispatch_events(self) -> None:
         while self._event_queue:
-            EventDispatcher.dispatch_event(self, *self._event_queue.pop(0))
+            EventDispatcher.dispatch_event(self, *self._event_queue.popleft())
 
     def dispatch_pending_events(self) -> None:
         pass

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -846,7 +846,7 @@ class Win32Window(BaseWindow):
     def dispatch_pending_events(self) -> None:
         """Legacy or manual dispatch."""
         while self._event_queue:
-            event = self._event_queue.pop(0)
+            event = self._event_queue.popleft()
             if isinstance(event[0], str):
                 # pyglet event
                 EventDispatcher.dispatch_event(self, *event)

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -1036,7 +1036,7 @@ class XlibWindow(BaseWindow):
 
     def dispatch_pending_events(self) -> None:
         while self._event_queue:
-            EventDispatcher.dispatch_event(self, *self._event_queue.pop(0))
+            EventDispatcher.dispatch_event(self, *self._event_queue.popleft())
 
         # Dispatch any context-related events
         if self._lost_context:


### PR DESCRIPTION
I mentioned this a few days ago on discord, didn't get too much echo.
If there's any good reason to decline this PR, please feel free to do so.

In my case, this change does fix a frozen application. In case the event queue grows too large, list.pop(0) is very inefficient, leading to performance problems.
One can argue that the event queue growing too large is the result of a poor architecture on my side (I'm mixing a pyglet main window with a tkinter dialog, this happens when the tkinter dialog is open), and that the problem can be worked around (I currently do it with setting the pyglet window's visibility temporarily to False), or even properly solved (on discord I got detailed instructions about using a pyglet-based dialog window), so maybe this update is not needed. I can't see why it would hurt though.
But I don't know what other consequences the change can cause.

Thanks for taking this into consideration!