### PR TITLE
Add support for FFmpeg 8.0

### DIFF
--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import ctypes
 import io
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, BinaryIO, List, Optional, Union
 
-from pyglet.media.exceptions import MediaException, CannotSeekException
-from pyglet.util import next_or_equal_power_of_two
+from pyglet.media.exceptions import CannotSeekException, MediaException
 
 if TYPE_CHECKING:
     from pyglet.image import AbstractImage
@@ -77,7 +79,7 @@ class AudioFormat:
             self.__class__.__name__, self.channels, self.sample_size,
             self.sample_rate)
 
-
+@dataclass
 class VideoFormat:
     """Video details.
 
@@ -98,20 +100,10 @@ class VideoFormat:
 
             .. versionadded:: 1.2
     """
-
-    def __init__(self, width: int, height: int, sample_aspect: float = 1.0) -> None:
-        self.width = width
-        self.height = height
-        self.sample_aspect = sample_aspect
-        self.frame_rate = None
-
-    def __eq__(self, other) -> bool:
-        if isinstance(other, VideoFormat):
-            return (self.width == other.width and
-                    self.height == other.height and
-                    self.sample_aspect == other.sample_aspect and
-                    self.frame_rate == other.frame_rate)
-        return False
+    width: int
+    height: int
+    sample_aspect: float = 0.0
+    frame_rate: float | None = None
 
 
 class AudioData:
@@ -132,14 +124,14 @@ class AudioData:
             `timestamp` and `duration` are unused and will be removed eventually.
     """
 
-    __slots__ = 'data', 'length', 'timestamp', 'duration', 'events', 'pointer'
+    __slots__ = 'data', 'duration', 'events', 'length', 'pointer', 'timestamp'
 
     def __init__(self,
-                 data: Union[bytes, ctypes.Array],
+                 data: bytes | ctypes.Array,
                  length: int,
                  timestamp: float = 0.0,
                  duration: float = 0.0,
-                 events: Optional[List['MediaEvent']] = None) -> None:
+                 events: list[MediaEvent] | None = None) -> None:
 
         if isinstance(data, bytes):
             # bytes are treated specially by ctypes and can be cast to a void pointer, get
@@ -163,6 +155,7 @@ class AudioData:
         self.events = [] if events is None else events
 
 
+@dataclass
 class SourceInfo:
     """Source metadata information.
 
@@ -180,15 +173,14 @@ class SourceInfo:
 
     .. versionadded:: 1.2
     """
-
-    title = ''
-    author = ''
-    copyright = ''
-    comment = ''
-    album = ''
-    year = 0
-    track = 0
-    genre = ''
+    title: str = ''
+    author: str = ''
+    copyright: str = ''
+    comment: str = ''
+    album: str = ''
+    year: int = 0
+    track: int = 0
+    genre: str = ''
 
 
 class Source:
@@ -255,9 +247,8 @@ class Source:
         player.on_player_eos = _on_player_eos
         return player
 
-    def get_animation(self) -> 'Animation':
-        """
-        Import all video frames into memory.
+    def get_animation(self) -> Animation:
+        """Import all video frames into memory.
 
         An empty animation will be returned if the source has no video.
         Otherwise, the animation will contain all unplayed video frames (the

--- a/pyglet/media/codecs/ffmpeg_lib/compat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/compat.py
@@ -18,6 +18,7 @@ release_versions = {
     5: {'avcodec': 59, 'avformat': 59, 'avutil': 57, 'swresample': 4, 'swscale': 6},  # 5.x
     6: {'avcodec': 60, 'avformat': 60, 'avutil': 58, 'swresample': 4, 'swscale': 7},  # 6.x
     7: {'avcodec': 61, 'avformat': 61, 'avutil': 59, 'swresample': 5, 'swscale': 8},  # 7.x
+    8: {'avcodec': 62, 'avformat': 62, 'avutil': 60, 'swresample': 6, 'swscale': 9},  # 8.x
 }
 
 # Removals done per library and version.

--- a/pyglet/media/codecs/ffmpeg_lib/libavformat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavformat.py
@@ -14,8 +14,8 @@ _debug = debug_print('debug_media')
 
 avformat = pyglet.lib.load_library(
     'avformat',
-    win32=('avformat-61', 'avformat-60', 'avformat-59', 'avformat-58'),
-    darwin=('avformat.61', 'avformat.60', 'avformat.59', 'avformat.58')
+    win32=('avformat-62', 'avformat-61', 'avformat-60', 'avformat-59', 'avformat-58'),
+    darwin=('avformat.62', 'avformat.61', 'avformat.60', 'avformat.59', 'avformat.58')
 )
 
 avformat.avformat_version.restype = c_int
@@ -147,7 +147,7 @@ compat.add_version_changes('avformat', 58, AVStream, AVStream_Fields, removals=(
 compat.add_version_changes('avformat', 59, AVStream, AVStream_Fields,
                            removals=('av_class', 'codec', 'recommended_encoder_configuration', 'info'))
 
-for compat_ver in (60, 61):
+for compat_ver in (60, 61, 62):
     compat.add_version_changes('avformat', compat_ver, AVStream, AVStream_Fields,
                                removals=('codec', 'recommended_encoder_configuration', 'info'),
                                repositions=(compat.Reposition("codecpar", "id"),))
@@ -318,8 +318,8 @@ if avformat_version >= 61:
         ('io_close2', CFUNCTYPE(c_int, POINTER(AVFormatContext), POINTER(AVIOContext)))  # Added in 59.
     ]
 
-    compat.add_version_changes('avformat', 61, AVFormatContext, AVFormatContext_Fields, removals=None)
-
+    for compat_ver in (61, 62):
+        compat.add_version_changes('avformat', compat_ver, AVFormatContext, AVFormatContext_Fields, removals=None)
 
 else:
     AVFormatContext_Fields = [
@@ -410,7 +410,7 @@ else:
     compat.add_version_changes('avformat', 58, AVFormatContext, AVFormatContext_Fields,
                                removals=('skip_estimate_duration_from_pts', 'max_probe_packets', 'io_close2'))
 
-    for compat_ver in (59, 60):
+    for compat_ver in (59, 60, 61, 62):
         compat.add_version_changes('avformat', compat_ver, AVFormatContext, AVFormatContext_Fields,
                                    removals=('filename', 'internal'))
 

--- a/pyglet/media/codecs/ffmpeg_lib/libavutil.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libavutil.py
@@ -12,8 +12,8 @@ _debug = debug_print('debug_media')
 
 avutil = pyglet.lib.load_library(
     'avutil',
-    win32=('avutil-59', 'avutil-58', 'avutil-57', 'avutil-56'),
-    darwin=('avutil.59', 'avutil.58', 'avutil.57', 'avutil.56')
+    win32=('avutil-60', 'avutil-59', 'avutil-58', 'avutil-57', 'avutil-56'),
+    darwin=('avutil.60', 'avutil.59', 'avutil.58', 'avutil.57', 'avutil.56')
 )
 
 avutil.avutil_version.restype = c_int
@@ -148,9 +148,9 @@ AVFrame_Fields = [
     ('opaque', c_void_p),
     ('error', c_uint64 * AV_NUM_DATA_POINTERS),  # Deprecated. Removed in 57.
     ('repeat_pict', c_int),
-    ('interlaced_frame', c_int),  # deprecated in 59. Targeted for removal. Use AV_FRAME_FLAG_INTERLACED
-    ('top_field_first', c_int),  # deprecated in 59. Targeted for removal. Use AV_FRAME_FLAG_TOP_FIELD_FIRST
-    ('palette_has_changed', c_int),  # deprecated in 59. Targeted for removal.
+    ('interlaced_frame', c_int),  # deprecated in 59. Targeted for removal. Use AV_FRAME_FLAG_INTERLACED (removed in 60)
+    ('top_field_first', c_int),  # deprecated in 59. Targeted for removal. Use AV_FRAME_FLAG_TOP_FIELD_FIRST (removed in 60)
+    ('palette_has_changed', c_int),  # deprecated in 59. Targeted for removal. (removed in 60)
     ('reordered_opaque', c_int64),  # removed in 59.
     ('sample_rate', c_int),
     ('channel_layout', c_uint64),  # removed in 59.
@@ -170,7 +170,7 @@ AVFrame_Fields = [
     ('pkt_duration', c_int64),  # removed in 59?
     ('metadata', POINTER(AVDictionary)),
     ('decode_error_flags', c_int),
-    ('channels', c_int),
+    ('channels', c_int),  # removed in 59.
     ('pkt_size', c_int),  # deprecated in 59.  use AV_CODEC_FLAG_COPY_OPAQUE to pass through arbitrary user data from packets to frames
     ('qscale_table', POINTER(c_int8)),  # Deprecated. Removed in 57.
     ('qstride', c_int),  # Deprecated. Removed in 57.
@@ -198,9 +198,18 @@ for compat_ver in (57, 58):
 compat.add_version_changes('avutil', 59, AVFrame, AVFrame_Fields,
                            removals=('pkt_pts', 'error', 'qscale_table', 'qstride', 'qscale_type', 'qp_table_buf',
                                      'channels', 'channel_layout',
-                                     'coded_picture_number', 'display_picture_number', 'reordered_opaque', 'pkt_duration'
+                                     'coded_picture_number', 'display_picture_number', 'reordered_opaque',
+                                     'pkt_duration',
                                      ))
 
+compat.add_version_changes('avutil', 60, AVFrame, AVFrame_Fields,
+                           removals=('pkt_pts', 'error', 'qscale_table', 'qstride', 'qscale_type', 'qp_table_buf',
+                                     'channels', 'channel_layout',
+                                     'coded_picture_number', 'display_picture_number', 'reordered_opaque',
+                                     'pkt_duration',
+                                     'interlaced_frame', 'top_field_first', 'palette_has_changed', 'pkt_pos',
+                                     'pkt_size',
+                                     ))
 
 AV_NOPTS_VALUE = -0x8000000000000000
 AV_TIME_BASE = 1000000
@@ -249,6 +258,12 @@ avutil.av_get_bytes_per_sample.restype = c_int
 avutil.av_get_bytes_per_sample.argtypes = [c_int]
 avutil.av_strerror.restype = c_int
 avutil.av_strerror.argtypes = [c_int, c_char_p, c_size_t]
+
+avutil.av_get_pix_fmt_name.restype = c_char_p
+avutil.av_get_pix_fmt_name.argtypes = [c_int]
+
+avutil.av_image_get_buffer_size.restype = c_int
+avutil.av_image_get_buffer_size.argtypes = [c_int, c_int, c_int, c_int]
 
 avutil.av_image_fill_arrays.restype = c_int
 avutil.av_image_fill_arrays.argtypes = [POINTER(c_uint8) * 4, c_int * 4,

--- a/pyglet/media/codecs/ffmpeg_lib/libswresample.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libswresample.py
@@ -13,8 +13,8 @@ _debug = debug_print('debug_media')
 
 swresample = pyglet.lib.load_library(
     'swresample',
-    win32=('swresample-5', 'swresample-4', 'swresample-3'),
-    darwin=('swresample.5', 'swresample.4', 'swresample.3')
+    win32=('swresample-6', 'swresample-5', 'swresample-4', 'swresample-3'),
+    darwin=('swresample.6', 'swresample.5', 'swresample.4', 'swresample.3')
 )
 
 swresample.swresample_version.restype = c_int

--- a/pyglet/media/codecs/ffmpeg_lib/libswscale.py
+++ b/pyglet/media/codecs/ffmpeg_lib/libswscale.py
@@ -13,8 +13,8 @@ _debug = debug_print('debug_media')
 
 swscale = pyglet.lib.load_library(
     'swscale',
-    win32=('swscale-8', 'swscale-7', 'swscale-6', 'swscale-5'),
-    darwin=('swscale.8', 'swscale.7', 'swscale.6', 'swscale.5')
+    win32=('swscale-9', 'swscale-8', 'swscale-7', 'swscale-6', 'swscale-5'),
+    darwin=('swscale.9', 'swscale.8', 'swscale.7', 'swscale.6', 'swscale.5')
 )
 
 swscale.swscale_version.restype = c_int


### PR DESCRIPTION
Adds support for FFmpeg 8.0.

Tested on Windows 11 with video and audio.

Tested and working on FFmpeg versions 8.0, 7.1, 6.0, 5.1, and 4.4.