### PR TITLE
Update CI matrix Python versions (add 3.13 and 3.14, remove 3.8)

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.10' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.10' ]
     name: Python ${{ matrix.python-version }} ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     name: Python ${{ matrix.python-version }} Windows
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**TL;DR:** Add 3.13 and 3.14 to the CI matrix in the GitHub action for pytest.

Unlike Arcade, we don't need to [bump the pillow version](https://github.com/pythonarcade/arcade/pull/2777) because:
1. pyglet treats it as [an optional dependency without a pinned version](https://github.com/pyglet/pyglet/blob/master/tests/requirements.txt)
2. The version with [beta 3.14 support](https://pillow.readthedocs.io/en/stable/releasenotes/11.3.0.html#python-3-14-beta) gets automatically pulled in
3. Future Pillow releases will automatically pull in improved 3.14 support