### PR TITLE
Add missing export for imported mouse module.

### DIFF
--- a/pyglet/window/__init__.py
+++ b/pyglet/window/__init__.py
@@ -1798,6 +1798,7 @@ __all__ = (
     # imported  # noqa: ERA001
     "event",
     "key",
+    "mouse",
     # classes  # noqa: ERA001
     "BaseWindow",
     "Window",


### PR DESCRIPTION
Needed so that we can write:

```
import pyglet
pyglet.window.mouse.foo
```