### PR TITLE
Fix issue #1298. 

### DIFF
--- a/pyglet/text/document.py
+++ b/pyglet/text/document.py
@@ -678,13 +678,13 @@ class _FontStyleRunsRangeIterator(runlist.RunIterator):
         from pyglet import font
         for start_, end_, styles in self.zip_iter.ranges(start, end):
             font_name, font_size, weight, italic, stretch = styles
-            ft = font.load(font_name, font_size, weight=weight, italic=bool(italic), stretch=stretch, dpi=self.dpi)
+            ft = font.load(font_name, font_size, weight=weight or "normal", italic=bool(italic), stretch=stretch or False, dpi=self.dpi)
             yield start_, end_, ft
 
     def __getitem__(self, index: int) -> Font:
         from pyglet import font
         font_name, font_size, weight, italic, stretch = self.zip_iter[index]
-        return font.load(font_name, font_size, weight=weight, italic=bool(italic), stretch=stretch, dpi=self.dpi)
+        return font.load(font_name, font_size, weight=weight or "normal", italic=bool(italic), stretch=stretch or False, dpi=self.dpi)
 
 
 class _NoStyleRangeIterator(runlist.RunIterator):


### PR DESCRIPTION
Font objects should no longer accept None for some of it's parameters. So this ensures attribute text styles pass the correct types.

Seems to have affected the Linux FreeType font loader the most as it prevented attributed font names being loaded. Tested using WSL.