### PR TITLE
Update default dpi_scaling option to "platform".

### DIFF
--- a/examples/dpi_scaled_window.py
+++ b/examples/dpi_scaled_window.py
@@ -1,7 +1,5 @@
 import pyglet
-
-pyglet.options["debug_gl"] = False
-pyglet.options.dpi_scaling = "scaled"
+pyglet.options.debug_gl = False
 
 window = pyglet.window.Window(800, 600, caption="DPI Test", resizable=True)
 batch = pyglet.graphics.Batch()
@@ -31,8 +29,7 @@ labels = [hello_label, mouse_enter_label, mouse_leave_label, mouse_motion_label,
 dinosaur = pyglet.resource.animation("programming_guide/dinosaur.gif")
 
 sprite = pyglet.sprite.Sprite(dinosaur, x=100, y=140, batch=batch)
-if pyglet.options.dpi_scaling != "real":
-    sprite.scale = window.scale
+sprite.scale = window.scale
 
 
 @window.event
@@ -99,10 +96,9 @@ def on_scale(scale, dpi):
     print("Window Size:", window.get_size())
     print("Window Scale Ratio:", window.scale)
     print("Window Frame Buffer Size:", window.get_framebuffer_size())
-    if pyglet.options.dpi_scaling != "real":
-        for label in labels:
-            label.dpi = dpi
-        sprite.scale = window.scale
+    for label in labels:
+        label.dpi = dpi
+    sprite.scale = window.scale
 
 
 pyglet.app.run()

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -255,8 +255,8 @@ class Options:
 
     .. versionadded:: 2.0.5"""
 
-    dpi_scaling: Literal["real", "scaled", "stretch", "platform"] = "real"
-    """For 'HiDPI' displays, Window behavior can differ between operating systems. Defaults to `'real'`.
+    dpi_scaling: Literal["real", "scaled", "stretch", "platform"] = "platform"
+    """For 'HiDPI' displays, Window behavior can differ between operating systems. Defaults to `'platform'`.
 
     The current options are an attempt to create consistent behavior across all of the operating systems.
 


### PR DESCRIPTION
Update default dpi_scaling option to "platform", as this makes more sense for current usages and will be the default DPI scaling for 3.0.

This should really only impact MacOSX to ensure the windows aren't tiny on Retina displays.