### PR TITLE
Restore old loop for everything but M1 processors

### DIFF
--- a/pyglet/app/__init__.py
+++ b/pyglet/app/__init__.py
@@ -47,8 +47,10 @@ if _is_pyglet_doc_run:
 else:
     if compat_platform == 'darwin':
         from pyglet.app.cocoa import CocoaPlatformEventLoop as PlatformEventLoop
+        from pyglet.libs.darwin.cocoapy.runtime import get_chip_model
 
-        if platform.machine() == 'arm64' or pyglet.options["osx_alt_loop"]:
+        # Use alternate loop only if forced, or using an M1 chip.
+        if (platform.machine() == 'arm64' and "M1" in get_chip_model()) or pyglet.options.osx_alt_loop:
             from pyglet.app.cocoa import CocoaAlternateEventLoop as EventLoop
     elif compat_platform in ('win32', 'cygwin'):
         from pyglet.app.win32 import Win32EventLoop as PlatformEventLoop


### PR DESCRIPTION
We have an old ticket about timing issues with the current loop alternate loop. The NSTimer is inherently much more inaccurate. 

This PR will restore the original loop to everything but M1 processors.

The reason for the loop was due to a bug we saw with M1 processors. I have a Mac M2 mini and have never experience the event degradation issue. The only reports we've seen stem from M1 processors (mainly Macbooks). 

If someone else who has an M2 or higher Macbook can test this loop and ensure there are no event issues with clicking or other areas, that would be great before this is merged.