### PR TITLE
Fix multi-draw array call by adding mode parameter

### DIFF
--- a/pyglet/graphics/api/webgl/vertexdomain.py
+++ b/pyglet/graphics/api/webgl/vertexdomain.py
@@ -228,7 +228,7 @@ class VertexDomain(VertexDomainBase):
         if self._supports_multi_draw:
             starts = (GLint * primcount)(*start_list)
             sizes = (GLsizei * primcount)(*size_list)
-            self._multi_draw_array(starts[:], 0, sizes[:], 0, primcount)
+            self._multi_draw_array(mode, starts[:], 0, sizes[:], 0, primcount)
         else:
             for start, size in zip(start_list, size_list):
                 self._gl.drawArrays(mode, start, size)


### PR DESCRIPTION
Following the docs, the mode parameter was missing:
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawArraysWEBGL

Caused error when used:

<img width="1068" height="95" alt="image" src="https://github.com/user-attachments/assets/dbb79f46-5551-443f-bbc1-3db456fed525" />
