### PR TITLE
Add context_options for Pyodide rendering contexts

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -54,6 +54,12 @@ class PyodideOptions:
     page, and do not want to alter your code, then modify this option.
     """
 
+    context_options: dict[str, Any] = field(default_factory=lambda: {})  # noqa: PIE807
+    """Some applications may need to specify options to the getContext call for creating the WebGL2RenderingContext.
+
+    These can be passed in here as a dictionary. A common example of this would be to disable pre-multipled alpha.
+    """
+
 
 @dataclass
 class Options:

--- a/pyglet/graphics/api/webgl/context.py
+++ b/pyglet/graphics/api/webgl/context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import weakref
 from typing import TYPE_CHECKING, Any, Callable
 
+import pyglet
 import js
 from pyodide.ffi import create_proxy
 
@@ -68,7 +69,7 @@ class OpenGLSurfaceContext(SurfaceContext):
         self.is_current = False
 
         # The GL Context.
-        self.gl = self.window.canvas.getContext("webgl2")
+        self.gl = self.window.canvas.getContext("webgl2", pyglet.options.pyodide.context_options)
 
         self._info = GLInfo()
         self._info.query(self.gl)


### PR DESCRIPTION
This adds a new `context_options` field to the Pyodide options in pyglet, which allows an application to set values in a dictionary that will be passed to the `canvas.getContext` function when the webgl2 context is created.

This allows applications to do things like turn off pre-multiplied alpha, or turn off alpha on the back-buffer.

As a sidenote, Pyglet may want to explore setting `alpha` to False in these options, as it's much more in line with how desktop OpenGL handles the backbuffer. With default WebGL settings if you do any alpha blending as you normally would without pre-multiplied alpha you will get the color of the page behind the canvas leaking through the alpha blending which leads to things like edge artifacts.