### PR TITLE
Check Windows version before importing `shcore`.

### DIFF
--- a/pyglet/display/win32.py
+++ b/pyglet/display/win32.py
@@ -4,7 +4,7 @@ import ctypes
 from ctypes import byref, sizeof
 from typing import TYPE_CHECKING
 
-from pyglet.libs.win32 import _gdi32, _shcore, _user32
+from pyglet.libs.win32 import _gdi32, _user32
 from pyglet.libs.win32.constants import (
     CDS_FULLSCREEN,
     DISP_CHANGE_SUCCESSFUL,
@@ -36,6 +36,9 @@ from pyglet.libs.win32.types import (
 )
 
 from .base import Canvas, Display, Screen, ScreenMode
+
+if WINDOWS_8_1_OR_GREATER:
+    from pyglet.libs.win32 import _shcore
 
 if TYPE_CHECKING:
     from ctypes.wintypes import HDC, HMONITOR, LPARAM, LPRECT

--- a/pyglet/libs/win32/__init__.py
+++ b/pyglet/libs/win32/__init__.py
@@ -22,7 +22,9 @@ _dwmapi = DebugLibrary('dwmapi')
 _shell32 = DebugLibrary('shell32')
 _ole32 = DebugLibrary('ole32')
 _oleaut32 = DebugLibrary('oleaut32')
-_shcore = DebugLibrary('shcore')
+
+if constants.WINDOWS_8_1_OR_GREATER:
+    _shcore = DebugLibrary('shcore')
 
 # _gdi32
 _gdi32.AddFontMemResourceEx.restype = HANDLE


### PR DESCRIPTION
fix bug of issue #1401.

add check windows version on shcore library load and import.

fix exception on windows 7
> FileNotFoundError: Could not find module 'shcore' (or one of its dependencies). Try using the full path with constructor syntax.