### PR TITLE
bugfix: fixing rotation behaviour of Sector

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1417,7 +1417,7 @@ class Sector(ShapeBase):
         if math.dist((self._x - self._anchor_x, self._y - self._anchor_y), point) > self._radius:
             return False
         angle = math.degrees(math.atan2(point[1] - self._y + self._anchor_y, point[0] - self._x + self._anchor_x))
-        angle = (angle + 360) % 360
+        angle = angle % 360
         start_angle = self._start_angle % 360
         end_angle = (start_angle + self._angle) % 360
         if self._angle >= 0:


### PR DESCRIPTION
The rotation of Sector is used when creating vertices in _get_vertices method. This has the effect of doubling the drawn rotation when e.g. setting radius, angle, etc. 

__contains__ method mixes deg and rad when comparing angles, and does not account for negative start_angle and/or negative angle.