### PR TITLE
Add parameters to `Quaternion.from_mat*` methods

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1398,11 +1398,11 @@ class Quaternion(_typing.NamedTuple):
     z: float = 0.0
 
     @classmethod
-    def from_mat3(cls) -> Quaternion:
+    def from_mat3(cls, mat: Mat3) -> Quaternion:
         raise NotImplementedError
 
     @classmethod
-    def from_mat4(cls) -> Quaternion:
+    def from_mat4(cls, mat: Mat4) -> Quaternion:
         raise NotImplementedError
 
     def to_mat4(self) -> Mat4:


### PR DESCRIPTION
This change matches what the most-likely future interface would be, and it allows users to implement their own extension methods without upsetting type checkers.

I think in principle it is a BC break, but if anyone was calling this without arguments before they were getting an error anyway.