### PR TITLE
Label Class's __init__ font_family type hinting update

### DIFF
--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -398,7 +398,7 @@ class Label(DocumentLabel):
             width: int | None = None, height: int | None = None,
             anchor_x: AnchorX = "left", anchor_y: AnchorY = "baseline", rotation: float = 0.0,
             multiline: bool = False, dpi: int | None = None,
-            font_name: str | None = None, font_size: float | None = None,
+            font_name: str | list[str] | None = None, font_size: float | None = None,
             weight: str = "normal", italic: bool | str = False, stretch: bool | str = False,
             color: tuple[int, int, int, int] | tuple[int, int, int] = (255, 255, 255, 255),
             align: HorizontalAlign = "left",
@@ -437,7 +437,8 @@ class Label(DocumentLabel):
                 Resolution of the fonts in this layout.  Defaults to 96.
             font_name:
                 Font family name(s).  If more than one name is given, the
-                first matching name is used.
+                first matching name is used. A list of names can optionally
+                be given: the first matching font will be used.
             font_size:
                 Font size, in points.
             weight:


### PR DESCRIPTION
Update Label.__init__'s font_family attribute type hint to indicate it can optionally take a font family in the form of a list.

It appears the underlying code supports receiving a font family as a list of strings, but the type hint does not allow it.

Thanks for maintaining pyglet!

~Brett