### PR TITLE
Properly use existing canvas element for pyodide

### DIFF
--- a/pyglet/window/emscripten/__init__.py
+++ b/pyglet/window/emscripten/__init__.py
@@ -742,7 +742,7 @@ class EmscriptenWindow(BaseWindow):
         assert self._canvas is None
         canvas_name = pyglet.options.pyodide.canvas_id
         canvas = js.document.getElementById(canvas_name)
-        if not self._canvas:
+        if not canvas:
             self._canvas = js.document.createElement("canvas")
             self._canvas.id = canvas_name
             js.document.body.appendChild(self._canvas)


### PR DESCRIPTION
Currently pyglet ignores an existing canvas element, because the check changed here is looking at the wrong field for determining if one already exists.