### PR TITLE
Better 32-bit audio support

### DIFF
--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -127,17 +127,17 @@ def load(filename: str, file: BinaryIO | None = None,
         audio_sample_format:
             A specific audio sample format you wish the decoder to ouput,
             rather than relying on automatic detection. For possible values see
-            the AUDIO_SAMPLE_FORMAT_* constants.
+            ``pyglet.media.AUDIO_SAMPLE_FORMAT_*`` constants.
             NOTE: currently only supported by FFmpegDecoder!
         audio_sample_rate:
             A specific audio sample rate (in Hz) you wish the decoder to
             output, rather than relying on automatic detection. For possible
-            values see the AUDIO_SAMPLE_RATE_* constants.
+            values see ``pyglet.media.AUDIO_SAMPLE_RATE_*`` constants.
             NOTE: currently only supported by FFmpegDecoder!
         audio_channels:
             A specific number of channels you wish the decoder to output,
             rather than relying on autimatic detection. For possible values see
-            the AUDIO_CHANNELS_* constants.
+            ``pyglet.media.AUDIO_CHANNELS_*`` constants.
             Note: currently only supported by FFmpegDecoder!
         audio_resample_hq:
             Whether to use high-quality resampling when resamplig is required

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -72,24 +72,39 @@ AUDIO_SAMPLE_RATE_96000 = 96000
 AUDIO_SAMPLE_RATE_176400 = 176400
 AUDIO_SAMPLE_RATE_192000 = 192000
 
-_VALID_AUDIO_SAMPLE_FORMATS = (AUDIO_SAMPLE_FORMAT_U8,
-                               AUDIO_SAMPLE_FORMAT_S16,
-                               #AUDIO_SAMPLE_FORMAT_S24,  # Could be considered as well
-                               AUDIO_SAMPLE_FORMAT_S32,
-                               AUDIO_SAMPLE_FORMAT_F32)
+AUDIO_CHANNELS_MONO = 1
+AUDIO_CHANNELS_STEREO = 2
+AUDIO_CHANNELS_DUAL_MONO = -2
 
-_VALID_AUDIO_SAMPLE_RATES = (AUDIO_SAMPLE_RATE_22050,
-                             AUDIO_SAMPLE_RATE_44100,
-                             AUDIO_SAMPLE_RATE_48000,
-                             AUDIO_SAMPLE_RATE_88200,
-                             AUDIO_SAMPLE_RATE_96000,
-                             AUDIO_SAMPLE_RATE_176400,
-                             AUDIO_SAMPLE_RATE_192000)
+_VALID_AUDIO_SAMPLE_FORMATS = (
+    AUDIO_SAMPLE_FORMAT_U8,
+    AUDIO_SAMPLE_FORMAT_S16,
+    #AUDIO_SAMPLE_FORMAT_S24,  # Could be considered as well
+    AUDIO_SAMPLE_FORMAT_S32,
+    AUDIO_SAMPLE_FORMAT_F32,
+)
+
+_VALID_AUDIO_SAMPLE_RATES = (
+    AUDIO_SAMPLE_RATE_22050,
+    AUDIO_SAMPLE_RATE_44100,
+    AUDIO_SAMPLE_RATE_48000,
+    AUDIO_SAMPLE_RATE_88200,
+    AUDIO_SAMPLE_RATE_96000,
+    AUDIO_SAMPLE_RATE_176400,
+    AUDIO_SAMPLE_RATE_192000,
+)
+
+_VALID_AUDIO_CHANNELS = (
+    AUDIO_CHANNELS_MONO,
+    AUDIO_CHANNELS_STEREO,
+    AUDIO_CHANNELS_DUAL_MONO,
+)
 
 def load(filename: str, file: BinaryIO | None = None,
          streaming: bool = True, decoder: MediaDecoder | None = None,
          audio_sample_format: str | None = None,
-         audio_sample_rate: int | None = None) -> Source | StreamingSource:
+         audio_sample_rate: int | None = None,
+         audio_channels: int | None = None) -> Source | StreamingSource:
     """Load a Source from disk, or an opened file.
 
     All decoders that are registered for the filename extension are tried.
@@ -114,9 +129,15 @@ def load(filename: str, file: BinaryIO | None = None,
             the AUDIO_SAMPLE_FORMAT_* constants.
             NOTE: currently only supported by FFmpegDecoder!
         audio_sample_rate:
-            A specicif audio sample rate (in Hz) you wish the decoder to
-            output, rather than relying on automatic detection.
+            A specific audio sample rate (in Hz) you wish the decoder to
+            output, rather than relying on automatic detection. For possible
+            values see the AUDIO_SAMPLE_RATE_* constants.
             NOTE: currently only supported by FFmpegDecoder!
+        audio_channels:
+            A specific number of channels you wish the decoder to output,
+            rather than relying on autimatic detection. For possible values see
+            the AUDIO_CHANNELS_* constants.
+            Note: currently only supported by FFmpegDecoder!
     """
 
     audio_driver = get_audio_driver()
@@ -138,6 +159,12 @@ def load(filename: str, file: BinaryIO | None = None,
                 f"Expected one of: "
                 f"{', '.join([str(x) for x in _VALID_AUDIO_SAMPLE_RATES])}")
 
+    if audio_channels:
+        if audio_channels not in _VALID_AUDIO_CHANNELS:
+            raise ValueError(
+                f"Invalid audio_channels '{audio_channels}'. "
+                f"Expected one of: "
+                f"{', '.join([str(x) for x in _VALID_AUDIO_CHANNELS])}")
 
     if decoder:
         if type(decoder).__name__ == "FFmpegDecoder":
@@ -145,7 +172,8 @@ def load(filename: str, file: BinaryIO | None = None,
                 filename, file, streaming=streaming,
                 audio_sample_format=audio_sample_format,
                 audio_driver_sample_formats=audio_driver.sample_formats,
-                audio_sample_rate=audio_sample_rate)
+                audio_sample_rate=audio_sample_rate,
+                audio_channels=audio_channels)
         else:
             return decoder.decode(filename, file, streaming=streaming)
 

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -104,7 +104,8 @@ def load(filename: str, file: BinaryIO | None = None,
          streaming: bool = True, decoder: MediaDecoder | None = None,
          audio_sample_format: str | None = None,
          audio_sample_rate: int | None = None,
-         audio_channels: int | None = None) -> Source | StreamingSource:
+         audio_channels: int | None = None,
+         audio_resample_hq: bool=False) -> Source | StreamingSource:
     """Load a Source from disk, or an opened file.
 
     All decoders that are registered for the filename extension are tried.
@@ -138,10 +139,16 @@ def load(filename: str, file: BinaryIO | None = None,
             rather than relying on autimatic detection. For possible values see
             the AUDIO_CHANNELS_* constants.
             Note: currently only supported by FFmpegDecoder!
+        audio_resample_hq:
+            Whether to use high-quality resampling when resamplig is required
+            (e.g. when a specific sample rate is requested), at the cost of
+            increased CPU usage.
+            Note: currently only supported by FFmpegDecoder!
+
     """
 
     audio_driver = get_audio_driver()
-    if audio_sample_format:
+    if audio_sample_format is not None:
         if audio_sample_format not in _VALID_AUDIO_SAMPLE_FORMATS:
             raise ValueError(
                 f"Invalid audio_sample_format '{audio_sample_format}'. "
@@ -152,19 +159,24 @@ def load(filename: str, file: BinaryIO | None = None,
                 f"{type(audio_driver).__name__} is only compatible with: "
                 f"{', '.join(audio_driver.sample_formats)}")
 
-    if audio_sample_rate:
+    if audio_sample_rate is not None:
         if audio_sample_rate not in _VALID_AUDIO_SAMPLE_RATES:
             raise ValueError(
                 f"Invalid audio_sample_rate '{audio_sample_rate}'. "
                 f"Expected one of: "
                 f"{', '.join([str(x) for x in _VALID_AUDIO_SAMPLE_RATES])}")
 
-    if audio_channels:
+    if audio_channels is not None:
         if audio_channels not in _VALID_AUDIO_CHANNELS:
             raise ValueError(
                 f"Invalid audio_channels '{audio_channels}'. "
                 f"Expected one of: "
                 f"{', '.join([str(x) for x in _VALID_AUDIO_CHANNELS])}")
+
+    if not isinstance(audio_resample_hq, bool):
+        raise ValueError(
+                f"Invalid audio_resample_hq '{audio_resample_hq}'. "
+                f"Expected a boolean (True, False)")
 
     if decoder:
         if type(decoder).__name__ == "FFmpegDecoder":
@@ -173,7 +185,8 @@ def load(filename: str, file: BinaryIO | None = None,
                 audio_sample_format=audio_sample_format,
                 audio_driver_sample_formats=audio_driver.sample_formats,
                 audio_sample_rate=audio_sample_rate,
-                audio_channels=audio_channels)
+                audio_channels=audio_channels,
+                audio_resample_hq=audio_resample_hq)
         else:
             return decoder.decode(filename, file, streaming=streaming)
 

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -64,15 +64,32 @@ AUDIO_SAMPLE_FORMAT_S16 = "S16"
 AUDIO_SAMPLE_FORMAT_S32 = "S32"
 AUDIO_SAMPLE_FORMAT_F32 = "F32"
 
+AUDIO_SAMPLE_RATE_22050 = 22050
+AUDIO_SAMPLE_RATE_44100 = 44100
+AUDIO_SAMPLE_RATE_48000 = 48000
+AUDIO_SAMPLE_RATE_88200 = 88200
+AUDIO_SAMPLE_RATE_96000 = 96000
+AUDIO_SAMPLE_RATE_176400 = 176400
+AUDIO_SAMPLE_RATE_192000 = 192000
+
 _VALID_AUDIO_SAMPLE_FORMATS = (AUDIO_SAMPLE_FORMAT_U8,
                                AUDIO_SAMPLE_FORMAT_S16,
                                #AUDIO_SAMPLE_FORMAT_S24,  # Could be considered as well
                                AUDIO_SAMPLE_FORMAT_S32,
                                AUDIO_SAMPLE_FORMAT_F32)
 
+_VALID_AUDIO_SAMPLE_RATES = (AUDIO_SAMPLE_RATE_22050,
+                             AUDIO_SAMPLE_RATE_44100,
+                             AUDIO_SAMPLE_RATE_48000,
+                             AUDIO_SAMPLE_RATE_88200,
+                             AUDIO_SAMPLE_RATE_96000,
+                             AUDIO_SAMPLE_RATE_176400,
+                             AUDIO_SAMPLE_RATE_192000)
+
 def load(filename: str, file: BinaryIO | None = None,
          streaming: bool = True, decoder: MediaDecoder | None = None,
-         audio_sample_format: str | None = None) -> Source | StreamingSource:
+         audio_sample_format: str | None = None,
+         audio_sample_rate: int | None = None) -> Source | StreamingSource:
     """Load a Source from disk, or an opened file.
 
     All decoders that are registered for the filename extension are tried.
@@ -96,6 +113,10 @@ def load(filename: str, file: BinaryIO | None = None,
             rather than relying on automatic detection. For possible values see
             the AUDIO_SAMPLE_FORMAT_* constants.
             NOTE: currently only supported by FFmpegDecoder!
+        audio_sample_rate:
+            A specicif audio sample rate (in Hz) you wish the decoder to
+            output, rather than relying on automatic detection.
+            NOTE: currently only supported by FFmpegDecoder!
     """
 
     audio_driver = get_audio_driver()
@@ -110,12 +131,21 @@ def load(filename: str, file: BinaryIO | None = None,
                 f"{type(audio_driver).__name__} is only compatible with: "
                 f"{', '.join(audio_driver.sample_formats)}")
 
+    if audio_sample_rate:
+        if audio_sample_rate not in _VALID_AUDIO_SAMPLE_RATES:
+            raise ValueError(
+                f"Invalid audio_sample_rate '{audio_sample_rate}'. "
+                f"Expected one of: "
+                f"{', '.join([str(x) for x in _VALID_AUDIO_SAMPLE_RATES])}")
+
+
     if decoder:
         if type(decoder).__name__ == "FFmpegDecoder":
             return decoder.decode(
                 filename, file, streaming=streaming,
                 audio_sample_format=audio_sample_format,
-                audio_driver_sample_formats=audio_driver.sample_formats)
+                audio_driver_sample_formats=audio_driver.sample_formats,
+                audio_sample_rate=audio_sample_rate)
         else:
             return decoder.decode(filename, file, streaming=streaming)
 

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -179,18 +179,21 @@ def load(filename: str, file: BinaryIO | None = None,
                 f"Expected a boolean (True, False)")
 
     if decoder:
-        if type(decoder).__name__ == "FFmpegDecoder":
-            return decoder.decode(
-                filename, file, streaming=streaming,
-                audio_sample_format=audio_sample_format,
-                audio_driver_sample_formats=audio_driver.sample_formats,
-                audio_sample_rate=audio_sample_rate,
-                audio_channels=audio_channels,
-                audio_resample_hq=audio_resample_hq)
-        else:
-            return decoder.decode(filename, file, streaming=streaming)
+        return decoder.decode(
+            filename, file, streaming=streaming,
+            audio_sample_format=audio_sample_format,
+            audio_driver_sample_formats=audio_driver.sample_formats,
+            audio_sample_rate=audio_sample_rate,
+            audio_channels=audio_channels,
+            audio_resample_hq=audio_resample_hq)
 
-    return _codec_registry.decode(filename, file, streaming=streaming)
+    return _codec_registry.decode(
+        filename, file, streaming=streaming,
+        audio_sample_format=audio_sample_format,
+        audio_driver_sample_formats=audio_driver.sample_formats,
+        audio_sample_rate=audio_sample_rate,
+        audio_channels=audio_channels,
+        audio_resample_hq=audio_resample_hq)
 
 
 _add_default_codecs()

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -98,19 +98,26 @@ def load(filename: str, file: BinaryIO | None = None,
             NOTE: currently only supported by FFmpegDecoder!
     """
 
-    if audio_sample_format \
-            and audio_sample_format not in _VALID_AUDIO_SAMPLE_FORMATS:
-        raise ValueError(
-            f"Invalid audio_sample_format '{audio_sample_format}'. "
-            f"Expected one of: {', '.join(_VALID_AUDIO_SAMPLE_FORMATS)}")
+    audio_driver = get_audio_driver()
+    if audio_sample_format:
+        if audio_sample_format not in _VALID_AUDIO_SAMPLE_FORMATS:
+            raise ValueError(
+                f"Invalid audio_sample_format '{audio_sample_format}'. "
+                f"Expected one of: {', '.join(_VALID_AUDIO_SAMPLE_FORMATS)}")
+        if audio_sample_format not in audio_driver.sample_formats:
+            raise ValueError(
+                f"Unsupported audio_sample_format '{audio_sample_format}'. "
+                f"{type(audio_driver).__name__} is only compatible with: "
+                f"{', '.join(audio_driver.sample_formats)}")
 
     if decoder:
         if type(decoder).__name__ == "FFmpegDecoder":
-            return decoder.decode(filename, file, streaming=streaming,
-                                  audio_sample_format=audio_sample_format)
+            return decoder.decode(
+                filename, file, streaming=streaming,
+                audio_sample_format=audio_sample_format,
+                audio_driver_sample_formats=audio_driver.sample_formats)
         else:
             return decoder.decode(filename, file, streaming=streaming)
-
 
     return _codec_registry.decode(filename, file, streaming=streaming)
 

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -58,8 +58,21 @@ if TYPE_CHECKING:
 __all__ = 'load', 'get_audio_driver', 'Player', 'PlayerGroup', 'SourceGroup', 'StaticSource', 'StreamingSource'
 
 
+AUDIO_SAMPLE_FORMAT_U8 = "U8"
+AUDIO_SAMPLE_FORMAT_S16 = "S16"
+#AUDIO_SAMPLE_FORMAT_S24 = "S24"  # Could be considered as well
+AUDIO_SAMPLE_FORMAT_S32 = "S32"
+AUDIO_SAMPLE_FORMAT_F32 = "F32"
+
+_VALID_AUDIO_SAMPLE_FORMATS = (AUDIO_SAMPLE_FORMAT_U8,
+                               AUDIO_SAMPLE_FORMAT_S16,
+                               #AUDIO_SAMPLE_FORMAT_S24,  # Could be considered as well
+                               AUDIO_SAMPLE_FORMAT_S32,
+                               AUDIO_SAMPLE_FORMAT_F32)
+
 def load(filename: str, file: BinaryIO | None = None,
-         streaming: bool = True, decoder: MediaDecoder | None = None) -> Source | StreamingSource:
+         streaming: bool = True, decoder: MediaDecoder | None = None,
+         audio_sample_format: str | None = None) -> Source | StreamingSource:
     """Load a Source from disk, or an opened file.
 
     All decoders that are registered for the filename extension are tried.
@@ -78,9 +91,26 @@ def load(filename: str, file: BinaryIO | None = None,
         decoder:
             A specific decoder you wish to use, rather than relying on
             automatic detection. If specified, no other decoders are tried.
+        audio_sample_format:
+            A specific audio sample format you wish the decoder to ouput,
+            rather than relying on automatic detection. For possible values see
+            the AUDIO_SAMPLE_FORMAT_* constants.
+            NOTE: currently only supported by FFmpegDecoder!
     """
+
+    if audio_sample_format \
+            and audio_sample_format not in _VALID_AUDIO_SAMPLE_FORMATS:
+        raise ValueError(
+            f"Invalid audio_sample_format '{audio_sample_format}'. "
+            f"Expected one of: {', '.join(_VALID_AUDIO_SAMPLE_FORMATS)}")
+
     if decoder:
-        return decoder.decode(filename, file, streaming=streaming)
+        if type(decoder).__name__ == "FFmpegDecoder":
+            return decoder.decode(filename, file, streaming=streaming,
+                                  audio_sample_format=audio_sample_format)
+        else:
+            return decoder.decode(filename, file, streaming=streaming)
+
 
     return _codec_registry.decode(filename, file, streaming=streaming)
 
@@ -97,4 +127,9 @@ __all__ = [
     'load', 
     'synthesis', 
     'get_audio_driver',
+    'AUDIO_SAMPLE_FORMAT_U8',
+    'AUDIO_SAMPLE_FORMAT_S16'
+    #'AUDIO_SAMPLE_FORMAT_S24' # Could be considered as well
+    'AUDIO_SAMPLE_FORMAT_S32'
+    'AUDIO_SAMPLE_FORMAT_F32'
 ]

--- a/pyglet/media/__init__.py
+++ b/pyglet/media/__init__.py
@@ -128,8 +128,8 @@ __all__ = [
     'synthesis', 
     'get_audio_driver',
     'AUDIO_SAMPLE_FORMAT_U8',
-    'AUDIO_SAMPLE_FORMAT_S16'
+    'AUDIO_SAMPLE_FORMAT_S16',
     #'AUDIO_SAMPLE_FORMAT_S24' # Could be considered as well
-    'AUDIO_SAMPLE_FORMAT_S32'
-    'AUDIO_SAMPLE_FORMAT_F32'
+    'AUDIO_SAMPLE_FORMAT_S32',
+    'AUDIO_SAMPLE_FORMAT_F32',
 ]

--- a/pyglet/media/codecs/__init__.py
+++ b/pyglet/media/codecs/__init__.py
@@ -1,6 +1,8 @@
 import sys
 import warnings
 
+from typing import BinaryIO
+
 from pyglet.util import CodecRegistry, Decoder, Encoder
 from .base import *
 

--- a/pyglet/media/codecs/__init__.py
+++ b/pyglet/media/codecs/__init__.py
@@ -1,8 +1,6 @@
 import sys
 import warnings
 
-from typing import BinaryIO
-
 from pyglet.util import CodecRegistry, Decoder, Encoder
 from .base import *
 

--- a/pyglet/media/codecs/__init__.py
+++ b/pyglet/media/codecs/__init__.py
@@ -20,12 +20,52 @@ get_encoders = registry.get_encoders
 
 class MediaDecoder(Decoder):
 
-    def decode(self, filename, file, streaming):
+    def decode(self, filename: str, file: BinaryIO | None, streaming: bool,
+               audio_sample_format: str | None=None,
+               audio_driver_sample_formats: list[str] | None=None,
+               audio_sample_rate: int | None=None,
+               audio_channels: int | None=None,
+               audio_resample_hq: bool=False
+    ) -> Source | StreamingSource:
         """Read the given file object and return an instance of `Source`
-        or `StreamingSource`. 
-        Throws DecodeException if there is an error.  `filename`
-        can be a file type hint.
+        or `StreamingSource`. Throws DecodeException if there is an error.
+        `filename` can be a file type hint.
+
+        Args:
+        filename:
+            Used to guess the media format, and to load the file if ``file``
+            is unspecified.
+        file:
+            An optional file-like object containing the source data.
+        streaming:
+            If ``False``, a :class:`StaticSource` will be returned; otherwise
+            a :class:`~pyglet.media.StreamingSource` is created.
+        decoder:
+            A specific decoder you wish to use, rather than relying on
+            automatic detection. If specified, no other decoders are tried.
+        audio_sample_format:
+            A specific audio sample format you wish the decoder to ouput,
+            rather than relying on automatic detection. For possible values see
+            the AUDIO_SAMPLE_FORMAT_* constants.
+            NOTE: currently only supported by FFmpegDecoder!
+        audio_sample_rate:
+            A specific audio sample rate (in Hz) you wish the decoder to
+            output, rather than relying on automatic detection. For possible
+            values see the AUDIO_SAMPLE_RATE_* constants.
+            NOTE: currently only supported by FFmpegDecoder!
+        audio_channels:
+            A specific number of channels you wish the decoder to output,
+            rather than relying on autimatic detection. For possible values see
+            the AUDIO_CHANNELS_* constants.
+            Note: currently only supported by FFmpegDecoder!
+        audio_resample_hq:
+            Whether to use high-quality resampling when resamplig is required
+            (e.g. when a specific sample rate is requested), at the cost of
+            increased CPU usage.
+            Note: currently only supported by FFmpegDecoder!
+
         """
+
         raise NotImplementedError()
 
 

--- a/pyglet/media/codecs/__init__.py
+++ b/pyglet/media/codecs/__init__.py
@@ -22,49 +22,48 @@ get_encoders = registry.get_encoders
 
 class MediaDecoder(Decoder):
 
-    def decode(self, filename: str, file: BinaryIO | None, streaming: bool,
-               audio_sample_format: str | None=None,
-               audio_driver_sample_formats: list[str] | None=None,
-               audio_sample_rate: int | None=None,
-               audio_channels: int | None=None,
-               audio_resample_hq: bool=False
-    ) -> Source | StreamingSource:
+    def decode(self, filename, file, streaming, audio_sample_format,
+               audio_driver_sample_formats, audio_sample_rate, audio_channels,
+               audio_resample_hq):
         """Read the given file object and return an instance of `Source`
         or `StreamingSource`. Throws DecodeException if there is an error.
         `filename` can be a file type hint.
 
         Args:
-        filename:
-            Used to guess the media format, and to load the file if ``file``
-            is unspecified.
-        file:
-            An optional file-like object containing the source data.
-        streaming:
-            If ``False``, a :class:`StaticSource` will be returned; otherwise
-            a :class:`~pyglet.media.StreamingSource` is created.
-        decoder:
-            A specific decoder you wish to use, rather than relying on
-            automatic detection. If specified, no other decoders are tried.
-        audio_sample_format:
-            A specific audio sample format you wish the decoder to ouput,
-            rather than relying on automatic detection. For possible values see
-            the AUDIO_SAMPLE_FORMAT_* constants.
-            NOTE: currently only supported by FFmpegDecoder!
-        audio_sample_rate:
-            A specific audio sample rate (in Hz) you wish the decoder to
-            output, rather than relying on automatic detection. For possible
-            values see the AUDIO_SAMPLE_RATE_* constants.
-            NOTE: currently only supported by FFmpegDecoder!
-        audio_channels:
-            A specific number of channels you wish the decoder to output,
-            rather than relying on autimatic detection. For possible values see
-            the AUDIO_CHANNELS_* constants.
-            Note: currently only supported by FFmpegDecoder!
-        audio_resample_hq:
-            Whether to use high-quality resampling when resamplig is required
-            (e.g. when a specific sample rate is requested), at the cost of
-            increased CPU usage.
-            Note: currently only supported by FFmpegDecoder!
+            filename (str):
+                Used to guess the media format, and to load the file if
+                ``file`` is unspecified.
+            file (BinaryIO, optional):
+                A file-like object containing the source data.
+            streaming (bool):
+                If ``False``, a :class:`StaticSource` will be returned;
+                otherwise a :class:`~pyglet.media.StreamingSource` is created.
+            audio_sample_format (str, optional):
+                A specific audio sample format you wish the decoder to ouput,
+                rather than relying on automatic detection. For possible values
+                see ``pyglet.media.AUDIO_SAMPLE_FORMAT_*`` constants.
+                NOTE: currently only supported by FFmpegDecoder!
+            audio_driver_sample_formats (list[str], optional)
+                A list of sample formats supported by the current audio driver.
+                For possible values see ``pyglet.media.AUDIO_SAMPLE_FORMAT_*``
+                constants.
+                NOTE: currently only supported by FFmpegDecoder!
+            audio_sample_rate (int, optional):
+                A specific audio sample rate (in Hz) you wish the decoder to
+                output, rather than relying on automatic detection. For
+                possible values see ``pyglet.media.AUDIO_SAMPLE_RATE_*``
+                constants.
+                NOTE: currently only supported by FFmpegDecoder!
+            audio_channels (int, optional):
+                A specific number of channels you wish the decoder to output,
+                rather than relying on autimatic detection. For possible values
+                see ``pyglet.media.AUDIO_CHANNELS_*`` constants.
+                Note: currently only supported by FFmpegDecoder!
+            audio_resample_hq (bool, optional, default=False):
+                Whether to use high-quality resampling when resamplig is
+                required (e.g. when a specific sample rate is requested), at
+                the cost of increased CPU usage.
+                Note: currently only supported by FFmpegDecoder!
 
         """
 

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -51,9 +51,10 @@ class AudioFormat:
         self.sample_type = sample_type
 
         # Convenience
-
-        self.sample_format = \
-            f"{self.sample_type[0].capitalize()}{self.sample_size}"
+        prefixes = {self.SAMPLE_TYPE_INT: "S",
+                    self.SAMPLE_TYPE_UINT: "U",
+                    self.SAMPLE_TYPE_FLOAT: "F"}
+        self.sample_format = f"{prefixes[self.sample_type]}{self.sample_size}"
 
         self.bytes_per_frame = (sample_size // 8) * channels
         self.bytes_per_second = self.bytes_per_frame * sample_rate

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -37,10 +37,15 @@ class AudioFormat:
     _VALID_TYPES = (SAMPLE_TYPE_INT, SAMPLE_TYPE_UINT, SAMPLE_TYPE_FLOAT)
 
     def __init__(self, channels: int, sample_size: int, sample_rate: int,
-                 sample_type: str = SAMPLE_TYPE_INT) -> None:
+                 sample_type: str | None = None) -> None:
         self.channels = channels
         self.sample_size = sample_size
         self.sample_rate = sample_rate
+        if sample_type is None:
+            if self.sample_size == 8:
+                sample_type = SAMPLE_TYPE_UINT
+            else:
+                sample_type = SAMPLE_TYPE_INT
         if sample_type not in self._VALID_TYPES:
             raise ValueError(f"sample_type must be one of {self._VALID_TYPES}")
         self.sample_type = sample_type
@@ -92,13 +97,17 @@ class AudioFormat:
         if isinstance(other, AudioFormat):
             return (self.channels == other.channels and
                     self.sample_size == other.sample_size and
-                    self.sample_rate == other.sample_rate)
+                    self.sample_rate == other.sample_rate and
+                    self.sample_type == other.sample_type)
         return NotImplemented
 
     def __repr__(self) -> str:
-        return '%s(channels=%d, sample_size=%d, sample_rate=%d)' % (
-            self.__class__.__name__, self.channels, self.sample_size,
-            self.sample_rate)
+        return (
+            '%s(channels=%d, sample_size=%d, sample_rate=%d, sample_type=%s)'
+            % (self.__class__.__name__, self.channels, self.sample_size,
+               self.sample_rate, sample_type)
+        )
+
 
 @dataclass
 class VideoFormat:

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -52,6 +52,9 @@ class AudioFormat:
 
         # Convenience
 
+        self.sample_format = \
+            f"{self.sample_type[0].capitalize()}{self.sample_size}"
+
         self.bytes_per_frame = (sample_size // 8) * channels
         self.bytes_per_second = self.bytes_per_frame * sample_rate
 
@@ -63,16 +66,6 @@ class AudioFormat:
         For the actual amount of bytes per sample, divide `sample_size` by
         eight.
         """
-
-    @property
-    def sample_format(self) -> str:
-        mapping = {
-            self.SAMPLE_TYPE_FLOAT: 'F',
-            self.SAMPLE_TYPE_UINT:  'U',
-            self.SAMPLE_TYPE_INT:   'S'
-        }
-        prefix = mapping.get(self.sample_type, 'S')
-        return f"{prefix}{self.sample_size}"
 
     def align(self, num_bytes: int) -> int:
         """Align a given amount of bytes to the audio frame size of this

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -27,12 +27,23 @@ class AudioFormat:
             (pyglet does not yet support surround-sound sources).
         sample_size (int): Bits per sample; only 8 or 16 are supported.
         sample_rate (int): Samples per second (in Hertz).
+        sample_type (str): "int", "uint" or "float"
     """
 
-    def __init__(self, channels: int, sample_size: int, sample_rate: int) -> None:
+    SAMPLE_TYPE_INT = 'int'
+    SAMPLE_TYPE_UINT = 'uint'
+    SAMPLE_TYPE_FLOAT = 'float'
+
+    _VALID_TYPES = (SAMPLE_TYPE_INT, SAMPLE_TYPE_UINT, SAMPLE_TYPE_FLOAT)
+
+    def __init__(self, channels: int, sample_size: int, sample_rate: int,
+                 sample_type: str = SAMPLE_TYPE_INT) -> None:
         self.channels = channels
         self.sample_size = sample_size
         self.sample_rate = sample_rate
+        if sample_type not in self._VALID_TYPES:
+            raise ValueError(f"sample_type must be one of {self._VALID_TYPES}")
+        self.sample_type = sample_type
 
         # Convenience
 
@@ -47,6 +58,16 @@ class AudioFormat:
         For the actual amount of bytes per sample, divide `sample_size` by
         eight.
         """
+
+    @property
+    def sample_format(self) -> str:
+        mapping = {
+            self.SAMPLE_TYPE_FLOAT: 'F',
+            self.SAMPLE_TYPE_UINT:  'U',
+            self.SAMPLE_TYPE_INT:   'S'
+        }
+        prefix = mapping.get(self.sample_type, 'S')
+        return f"{prefix}{self.sample_size}"
 
     def align(self, num_bytes: int) -> int:
         """Align a given amount of bytes to the audio frame size of this

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -105,7 +105,7 @@ class AudioFormat:
         return (
             '%s(channels=%d, sample_size=%d, sample_rate=%d, sample_type=%s)'
             % (self.__class__.__name__, self.channels, self.sample_size,
-               self.sample_rate, sample_type)
+               self.sample_rate, self.sample_type)
         )
 
 

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -43,9 +43,9 @@ class AudioFormat:
         self.sample_rate = sample_rate
         if sample_type is None:
             if self.sample_size == 8:
-                sample_type = SAMPLE_TYPE_UINT
+                sample_type = self.SAMPLE_TYPE_UINT
             else:
-                sample_type = SAMPLE_TYPE_INT
+                sample_type = self.SAMPLE_TYPE_INT
         if sample_type not in self._VALID_TYPES:
             raise ValueError(f"sample_type must be one of {self._VALID_TYPES}")
         self.sample_type = sample_type

--- a/pyglet/media/codecs/coreaudio.py
+++ b/pyglet/media/codecs/coreaudio.py
@@ -171,7 +171,7 @@ class CoreAudioDecoder(MediaDecoder):
     def get_file_extensions(self):
         return '.aac', '.ac3', '.aif', '.aiff', '.aifc', '.caf', '.mp3', '.mp4', '.m4a', '.snd', '.au', '.sd2', '.wav'
 
-    def decode(self, filename, file, streaming=True):
+    def decode(self, filename, file, streaming=True, **kwargs):
         if streaming:
             return CoreAudioSource(filename, file)
         else:

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -585,7 +585,8 @@ class FFmpegSource(StreamingSource):
                  audio_sample_format: str | None=None,
                  audio_driver_sample_formats: list[str] | None=None,
                  audio_sample_rate: int | None=None,
-                 audio_channels: int | None=None):
+                 audio_channels: int | None=None,
+                 audio_resample_hq: bool=False):
         self._packet = None
         self._video_stream = None
         self._audio_stream = None
@@ -706,7 +707,7 @@ class FFmpegSource(StreamingSource):
                     raise FFmpegException(
                         'Cannot create sample rate converter.')
 
-                # Dither withnoise-shaping when reducing bit-depth
+                # Dither with noise-shaping when reducing bit-depth
                 if (self.AV_FORMAT_MAP[self.tgt_format][0] < sample_bits):
                     avutil.av_opt_set(self.audio_convert_ctx,
                                       asbytes("dither_method"),
@@ -722,6 +723,32 @@ class FFmpegSource(StreamingSource):
                     matrix = MatrixArrayType(*data)
                     swresample.swr_set_matrix(self.audio_convert_ctx, matrix,
                                               info.channels)
+
+                if audio_resample_hq:  # Replace with soxr in future?
+                    avutil.av_opt_set_int(self.audio_convert_ctx,
+                                          asbytes("filter_size"),
+                                          128,
+                                          0)
+                    avutil.av_opt_set_int(self.audio_convert_ctx,
+                                          asbytes("phase_shift"),
+                                          14,
+                                          0)
+                    avutil.av_opt_set_int(self.audio_convert_ctx,
+                                          asbytes("kaiser_beta"),
+                                          12,
+                                          0)
+                    avutil.av_opt_set_double(self.audio_convert_ctx,
+                                             asbytes("cutoff"),
+                                             0.98,
+                                             0)
+                    avutil.av_opt_set_int(self.audio_convert_ctx,
+                                          asbytes("exact_rational"),
+                                          1,
+                                          0)
+                    avutil.av_opt_set_int(self.audio_convert_ctx,
+                                          asbytes("linear_interp"),
+                                          0,
+                                          0)
 
                 result = swresample.swr_init(self.audio_convert_ctx)
                 if result < 0:
@@ -1295,7 +1322,8 @@ class FFmpegDecoder(MediaDecoder):
                streaming: bool=True, audio_sample_format: str | None=None,
                audio_driver_sample_formats: list[str] | None=None,
                audio_sample_rate: int | None=None,
-               audio_channels: int | None=None
+               audio_channels: int | None=None,
+               audio_resample_hq: bool=False
     ) -> FFmpegSource | StaticSource:
 
         if audio_sample_format \
@@ -1307,13 +1335,15 @@ class FFmpegDecoder(MediaDecoder):
             return FFmpegSource(filename, file, audio_sample_format,
                                 audio_driver_sample_formats,
                                 audio_sample_rate,
-                                audio_channels)
+                                audio_channels,
+                                audio_resample_hq)
         else:
             return StaticSource(FFmpegSource(filename, file,
                                              audio_sample_format,
                                              audio_driver_sample_formats,
                                              audio_sample_rate,
-                                             audio_channels))
+                                             audio_channels,
+                                             audio_resample_hq))
 
 
 def get_decoders() -> list[FFmpegDecoder]:

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -582,7 +582,8 @@ class FFmpegSource(StreamingSource):
 
     def __init__(self, filename: str, file: BinaryIO | None=None,
                  audio_sample_format: str | None=None,
-                 audio_driver_sample_formats: list[str] | None=None):
+                 audio_driver_sample_formats: list[str] | None=None,
+                 audio_sample_rate: int | None=None):
         self._packet = None
         self._video_stream = None
         self._audio_stream = None
@@ -680,11 +681,15 @@ class FFmpegSource(StreamingSource):
                 else:
                     raise FFmpegException('Audio format not supported.')
 
+                if not audio_sample_rate:
+                    audio_sample_rate = info.sample_rate
+                self.tgt_sample_rate = audio_sample_rate
+
                 self.audio_format = AudioFormat(
                     channels=channels_out,
                     sample_size=self.AV_FORMAT_MAP[self.tgt_format][0],
                     sample_type=self.AV_FORMAT_MAP[self.tgt_format][1],
-                    sample_rate=info.sample_rate)
+                    sample_rate=self.tgt_sample_rate)
                 self._audio_stream = stream
                 self._audio_stream_index = i
 
@@ -738,23 +743,27 @@ class FFmpegSource(StreamingSource):
         if self.start_time > 0:
             self.seek(0.0)
 
-    def get_formatted_swr_context(self, channel_output: AVChannelLayout | int, sample_rate: int,
-                                  channel_input: AVChannelLayout | int, sample_format: int) -> int | SwrContext:
+    def get_formatted_swr_context(self, channel_output: AVChannelLayout | int,
+                                  sample_rate: int,
+                                  channel_input: AVChannelLayout | int,
+                                  sample_format: int) -> int | SwrContext:
         # Newer FFmpeg versions use the AVChannelLayout
         if swresample_version < 5:
-            return swresample.swr_alloc_set_opts(None,
-                                          channel_output, self.tgt_format, sample_rate,
-                                          channel_input, sample_format, sample_rate,
-                                          0, None)
+            return swresample.swr_alloc_set_opts(
+                None,
+                channel_output, self.tgt_format, self.tgt_sample_rate,
+                channel_input, sample_format, sample_rate,
+                0, None)
         else:
             swr_ctx = swresample.swr_alloc()
             if not swr_ctx:
                 raise RuntimeError("Could not allocate SwrContext")
 
-            if swresample.swr_alloc_set_opts2(byref(swr_ctx),
-                                              channel_output, self.tgt_format, sample_rate,
-                                              channel_input, sample_format, sample_rate,
-                                              0, None) < 0:
+            if swresample.swr_alloc_set_opts2(
+                byref(swr_ctx),
+                channel_output, self.tgt_format, self.tgt_sample_rate,
+                channel_input, sample_format, sample_rate,
+                0, None) < 0:
                 raise Exception("Could not set sample rate context values.")
             return swr_ctx
 
@@ -1271,6 +1280,7 @@ class FFmpegDecoder(MediaDecoder):
     def decode(self, filename: str, file: BinaryIO | None,
                streaming: bool=True, audio_sample_format: str | None=None,
                audio_driver_sample_formats: list[str] | None=None,
+               audio_sample_rate: int | None=None,
     ) -> FFmpegSource | StaticSource:
 
         if audio_sample_format \
@@ -1280,11 +1290,13 @@ class FFmpegDecoder(MediaDecoder):
 
         if streaming:
             return FFmpegSource(filename, file, audio_sample_format,
-                                audio_driver_sample_formats)
+                                audio_driver_sample_formats,
+                                audio_sample_rate)
         else:
             return StaticSource(FFmpegSource(filename, file,
                                              audio_sample_format,
-                                             audio_driver_sample_formats))
+                                             audio_driver_sample_formats,
+                                             audio_sample_rate))
 
 
 def get_decoders() -> list[FFmpegDecoder]:

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sys
+import math
 from collections import deque
 from ctypes import (
     POINTER,
@@ -654,7 +655,16 @@ class FFmpegSource(StreamingSource):
                 if not audio_channels:
                     audio_channels = info.channels
                 channels_out = min(2, abs(audio_channels))
-                channel_input = self._get_default_channel_layout(info.channels)
+
+                channel_input = 0
+                if hasattr(stream.codec_context.contents, "ch_layout"):
+                    channel_input = stream.codec_context.contents.ch_layout
+                elif hasattr(stream.codec_context.contents, "channel_layout"):
+                    channel_input = stream.codec_context.contents.channel_layout
+                if not channel_input:
+                    channel_input = self._get_default_channel_layout(
+                        info.channels)
+
                 channel_output = self._get_default_channel_layout(channels_out)
 
                 sample_format = stream.codec_context.contents.sample_fmt
@@ -716,12 +726,29 @@ class FFmpegSource(StreamingSource):
 
                 # Set matrix for mixing down to dual-mono
                 if audio_channels == -2 and info.channels > 1:
-                    num_elements = info.channels * 2
-                    weight = 1.0 / info.channels
-                    MatrixArrayType = c_double * num_elements
-                    data = [weight] * num_elements
-                    matrix = MatrixArrayType(*data)
-                    swresample.swr_set_matrix(self.audio_convert_ctx, matrix,
+                    if isinstance(channel_input, int):
+                        in_layout = channel_input
+                    else:
+                        in_layout = channel_input.u.mask
+                    speakers = \
+                        [1 << i for i in range(64) if in_layout & (1 << i)]
+                    mono_row = []
+                    for i in range(info.channels):
+                        speaker = speakers[i] if i < len(speakers) else 0
+                        if speaker in (0x1, 0x2):
+                            w = 0.5                   # FL, FR (-6dB)
+                        elif speaker == 0x4:
+                            w = math.sqrt(0.5)        # Center (-3dB)
+                        elif speaker == 0x8:
+                            w = 0.0                   # LFE (Discarded)
+                        else:
+                            w = 0.5 * math.sqrt(0.5)  # Surrounds (-9dB)
+                        mono_row.append(w * 0.99)
+                    final_weights = mono_row + mono_row
+                    self._matrix_storage = \
+                        (c_double * len(final_weights))(*final_weights)
+                    swresample.swr_set_matrix(self.audio_convert_ctx,
+                                              self._matrix_storage,
                                               info.channels)
 
                 if audio_resample_hq:  # Replace with soxr in future?
@@ -739,7 +766,7 @@ class FFmpegSource(StreamingSource):
                                           0)
                     avutil.av_opt_set_double(self.audio_convert_ctx,
                                              asbytes("cutoff"),
-                                             0.98,
+                                             c_double(0.98),
                                              0)
                     avutil.av_opt_set_int(self.audio_convert_ctx,
                                           asbytes("exact_rational"),

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -14,6 +14,7 @@ from ctypes import (
     c_int,
     c_int32,
     c_uint8,
+    c_double,
     cast,
     create_string_buffer,
     memmove,
@@ -583,7 +584,8 @@ class FFmpegSource(StreamingSource):
     def __init__(self, filename: str, file: BinaryIO | None=None,
                  audio_sample_format: str | None=None,
                  audio_driver_sample_formats: list[str] | None=None,
-                 audio_sample_rate: int | None=None):
+                 audio_sample_rate: int | None=None,
+                 audio_channels: int | None=None):
         self._packet = None
         self._video_stream = None
         self._audio_stream = None
@@ -648,7 +650,9 @@ class FFmpegSource(StreamingSource):
                   and self._audio_stream is None):
                 stream = ffmpeg_open_stream(self._file, i)
 
-                channels_out = min(2, info.channels)
+                if not audio_channels:
+                    audio_channels = info.channels
+                channels_out = min(2, abs(audio_channels))
                 channel_input = self._get_default_channel_layout(info.channels)
                 channel_output = self._get_default_channel_layout(channels_out)
 
@@ -708,6 +712,16 @@ class FFmpegSource(StreamingSource):
                                       asbytes("dither_method"),
                                       asbytes("low_shibata"),
                                       0)
+
+                # Set matrix for mixing down to dual-mono
+                if audio_channels == -2 and info.channels > 1:
+                    num_elements = info.channels * 2
+                    weight = 1.0 / info.channels
+                    MatrixArrayType = c_double * num_elements
+                    data = [weight] * num_elements
+                    matrix = MatrixArrayType(*data)
+                    swresample.swr_set_matrix(self.audio_convert_ctx, matrix,
+                                              info.channels)
 
                 result = swresample.swr_init(self.audio_convert_ctx)
                 if result < 0:
@@ -1281,6 +1295,7 @@ class FFmpegDecoder(MediaDecoder):
                streaming: bool=True, audio_sample_format: str | None=None,
                audio_driver_sample_formats: list[str] | None=None,
                audio_sample_rate: int | None=None,
+               audio_channels: int | None=None
     ) -> FFmpegSource | StaticSource:
 
         if audio_sample_format \
@@ -1291,12 +1306,14 @@ class FFmpegDecoder(MediaDecoder):
         if streaming:
             return FFmpegSource(filename, file, audio_sample_format,
                                 audio_driver_sample_formats,
-                                audio_sample_rate)
+                                audio_sample_rate,
+                                audio_channels)
         else:
             return StaticSource(FFmpegSource(filename, file,
                                              audio_sample_format,
                                              audio_driver_sample_formats,
-                                             audio_sample_rate))
+                                             audio_sample_rate,
+                                             audio_channels))
 
 
 def get_decoders() -> list[FFmpegDecoder]:

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -69,6 +69,12 @@ if TYPE_CHECKING:
     from .ffmpeg_lib.libavformat import AVStream
 
 
+AUDIO_SAMPLE_FORMATS = {"U8": AV_SAMPLE_FMT_U8,
+                        "S16": AV_SAMPLE_FMT_S16,
+                        "S32": AV_SAMPLE_FMT_S32,
+                        "F32": AV_SAMPLE_FMT_FLT}
+
+
 class FileInfo:
     def __init__(self):
         self.n_streams = None
@@ -558,13 +564,24 @@ class AudioPacket(_Packet):
 
 
 class FFmpegSource(StreamingSource):
+
+    AV_FORMAT_MAP = {AV_SAMPLE_FMT_U8: (8, AudioFormat.SAMPLE_TYPE_UINT),
+                     AV_SAMPLE_FMT_U8P: (8, AudioFormat.SAMPLE_TYPE_UINT),
+                     AV_SAMPLE_FMT_S16: (16, AudioFormat.SAMPLE_TYPE_INT),
+                     AV_SAMPLE_FMT_S16P: (16, AudioFormat.SAMPLE_TYPE_INT),
+                     AV_SAMPLE_FMT_S32: (32, AudioFormat.SAMPLE_TYPE_INT),
+                     AV_SAMPLE_FMT_S32P: (32, AudioFormat.SAMPLE_TYPE_INT),
+                     AV_SAMPLE_FMT_FLT: (32, AudioFormat.SAMPLE_TYPE_FLOAT),
+                     AV_SAMPLE_FMT_FLTP: (32, AudioFormat.SAMPLE_TYPE_FLOAT)}
+
     # Max increase/decrease of original sample size
     SAMPLE_CORRECTION_PERCENT_MAX = 10
 
     # Maximum amount of packets to create for video and audio queues.
     MAX_QUEUE_SIZE = 100
 
-    def __init__(self, filename: str, file: BinaryIO | None=None):
+    def __init__(self, filename: str, file: BinaryIO | None=None,
+                 audio_sample_format: str | None=None):
         self._packet = None
         self._video_stream = None
         self._audio_stream = None
@@ -575,7 +592,8 @@ class FFmpegSource(StreamingSource):
         encoded_filename = filename.encode(sys.getfilesystemencoding())
 
         if file:
-            self._file, self._memory_file = ffmpeg_open_memory_file(encoded_filename, file)
+            self._file, self._memory_file = ffmpeg_open_memory_file(
+                encoded_filename, file)
         else:
             self._file = ffmpeg_open_filename(encoded_filename)
 
@@ -621,37 +639,73 @@ class FFmpegSource(StreamingSource):
                 self._video_stream = stream
                 self._video_stream_index = i
 
-            elif isinstance(info, StreamAudioInfo) and self._audio_stream is None:
+            elif (isinstance(info, StreamAudioInfo)
+                  and self._audio_stream is None):
                 stream = ffmpeg_open_stream(self._file, i)
 
                 channels_out = min(2, info.channels)
                 channel_input = self._get_default_channel_layout(info.channels)
                 channel_output = self._get_default_channel_layout(channels_out)
 
-                sample_bits = info.sample_bits
-                if info.sample_format in (AV_SAMPLE_FMT_U8, AV_SAMPLE_FMT_U8P):
-                    self.tgt_format = AV_SAMPLE_FMT_U8
+                sample_format = stream.codec_context.contents.sample_fmt
+                sample_bits = self.AV_FORMAT_MAP[sample_format][0]
+
+                if not audio_sample_format:
+                    audio_driver = pyglet.media.get_audio_driver()
+                    if info.sample_format in (AV_SAMPLE_FMT_FLT,
+                                              AV_SAMPLE_FMT_FLTP):
+                        if "F32" in audio_driver.sample_formats:
+                            self.tgt_format = AV_SAMPLE_FMT_FLT
+                        else:
+                            self.tgt_format = AV_SAMPLE_FMT_S16
+                    elif info.sample_format in (AV_SAMPLE_FMT_S32,
+                                                AV_SAMPLE_FMT_S32P):
+                        if "S32" in audio_driver.sample_formats:
+                            self.tgt_format = AV_SAMPLE_FMT_S32
+                        elif "F32" in audio_driver.sample_formats:
+                            self.tgt_format = AV_SAMPLE_FMT_FLT
+                        else:
+                            self.tgt_format = AV_SAMPLE_FMT_S16
+                    elif info.sample_format in (AV_SAMPLE_FMT_S16,
+                                                AV_SAMPLE_FMT_S16P):
+                        self.tgt_format = AV_SAMPLE_FMT_S16
+                    elif info.sample_format in (AV_SAMPLE_FMT_U8,
+                                                AV_SAMPLE_FMT_U8P):
+                        self.tgt_format = AV_SAMPLE_FMT_U8
+                elif audio_sample_format in AUDIO_SAMPLE_FORMATS:
+                    self.tgt_format = AUDIO_SAMPLE_FORMATS[audio_sample_format]
                 else:
-                    # No matter the input format, produce S16 samples.
-                    sample_bits = 16
-                    self.tgt_format = AV_SAMPLE_FMT_S16
+                    raise FFmpegException('Audio format not supported.')
 
                 self.audio_format = AudioFormat(
                     channels=channels_out,
-                    sample_size=sample_bits,
+                    sample_size=self.AV_FORMAT_MAP[self.tgt_format][0],
+                    sample_type=self.AV_FORMAT_MAP[self.tgt_format][1],
                     sample_rate=info.sample_rate)
                 self._audio_stream = stream
                 self._audio_stream_index = i
 
-                self.audio_convert_ctx = self.get_formatted_swr_context(channel_output, info.sample_rate, channel_input, info.sample_format)
+                self.audio_convert_ctx = self.get_formatted_swr_context(
+                    channel_output, info.sample_rate, channel_input,
+                    info.sample_format)
+
                 if not self.audio_convert_ctx:
                     swresample.swr_free(self.audio_convert_ctx)
-                    raise FFmpegException('Cannot create sample rate converter.')
+                    raise FFmpegException(
+                        'Cannot create sample rate converter.')
+
+                # Dither withnoise-shaping when reducing bit-depth
+                if (self.AV_FORMAT_MAP[self.tgt_format][0] < sample_bits):
+                        avutil.av_opt_set(self.audio_convert_ctx,
+                                          asbytes("dither_method"),
+                                          asbytes("low_shibata"),
+                                          0)
 
                 result = swresample.swr_init(self.audio_convert_ctx)
                 if result < 0:
                     swresample.swr_free(self.audio_convert_ctx)
-                    raise FFmpegException('Cannot create sample rate converter.', result)
+                    raise FFmpegException(
+                        'Cannot create sample rate converter.', result)
 
         self._packet = ffmpeg_init_packet()
         self._events = []  # They don't seem to be used!
@@ -1211,11 +1265,20 @@ class FFmpegDecoder(MediaDecoder):
     def get_file_extensions(self) -> Sequence[str]:
         return '.mp3', '.ogg'
 
-    def decode(self, filename: str, file: BinaryIO | None, streaming: bool=True) -> FFmpegSource | StaticSource:
+    def decode(self, filename: str, file: BinaryIO | None,
+               streaming: bool=True, audio_sample_format: str | None=None
+    ) -> FFmpegSource | StaticSource:
+
+        if audio_sample_format \
+                and audio_sample_format not in AUDIO_SAMPLE_FORMATS:
+            raise FFmpegException(
+                f"Audio format '{audio_sample_format}' not supported.")
+
         if streaming:
-            return FFmpegSource(filename, file)
+            return FFmpegSource(filename, file, audio_sample_format)
         else:
-            return StaticSource(FFmpegSource(filename, file))
+            return StaticSource(FFmpegSource(filename, file,
+                                             audio_sample_format))
 
 
 def get_decoders() -> list[FFmpegDecoder]:

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -652,9 +652,11 @@ class FFmpegSource(StreamingSource):
                   and self._audio_stream is None):
                 stream = ffmpeg_open_stream(self._file, i)
 
+                self._audio_stream = stream
+                self._audio_stream_index = i
+
                 if not audio_channels:
                     audio_channels = info.channels
-                channels_out = min(2, abs(audio_channels))
 
                 channel_input = 0
                 if hasattr(stream.codec_context.contents, "ch_layout"):
@@ -665,6 +667,7 @@ class FFmpegSource(StreamingSource):
                     channel_input = self._get_default_channel_layout(
                         info.channels)
 
+                channels_out = min(2, abs(audio_channels))
                 channel_output = self._get_default_channel_layout(channels_out)
 
                 sample_format = stream.codec_context.contents.sample_fmt
@@ -705,8 +708,6 @@ class FFmpegSource(StreamingSource):
                     sample_size=self.AV_FORMAT_MAP[self.tgt_format][0],
                     sample_type=self.AV_FORMAT_MAP[self.tgt_format][1],
                     sample_rate=self.tgt_sample_rate)
-                self._audio_stream = stream
-                self._audio_stream_index = i
 
                 self.audio_convert_ctx = self.get_formatted_swr_context(
                     channel_output, info.sample_rate, channel_input,

--- a/pyglet/media/codecs/ffmpeg.py
+++ b/pyglet/media/codecs/ffmpeg.py
@@ -581,13 +581,17 @@ class FFmpegSource(StreamingSource):
     MAX_QUEUE_SIZE = 100
 
     def __init__(self, filename: str, file: BinaryIO | None=None,
-                 audio_sample_format: str | None=None):
+                 audio_sample_format: str | None=None,
+                 audio_driver_sample_formats: list[str] | None=None):
         self._packet = None
         self._video_stream = None
         self._audio_stream = None
         self._stream_end = False
         self._file = None
         self._memory_file = None
+
+        if audio_driver_sample_formats is None:
+            audio_driver_sample_formats = ["U8", "S16"]
 
         encoded_filename = filename.encode(sys.getfilesystemencoding())
 
@@ -651,18 +655,17 @@ class FFmpegSource(StreamingSource):
                 sample_bits = self.AV_FORMAT_MAP[sample_format][0]
 
                 if not audio_sample_format:
-                    audio_driver = pyglet.media.get_audio_driver()
                     if info.sample_format in (AV_SAMPLE_FMT_FLT,
                                               AV_SAMPLE_FMT_FLTP):
-                        if "F32" in audio_driver.sample_formats:
+                        if "F32" in audio_driver_sample_formats:
                             self.tgt_format = AV_SAMPLE_FMT_FLT
                         else:
                             self.tgt_format = AV_SAMPLE_FMT_S16
                     elif info.sample_format in (AV_SAMPLE_FMT_S32,
                                                 AV_SAMPLE_FMT_S32P):
-                        if "S32" in audio_driver.sample_formats:
+                        if "S32" in audio_driver_sample_formats:
                             self.tgt_format = AV_SAMPLE_FMT_S32
-                        elif "F32" in audio_driver.sample_formats:
+                        elif "F32" in audio_driver_sample_formats:
                             self.tgt_format = AV_SAMPLE_FMT_FLT
                         else:
                             self.tgt_format = AV_SAMPLE_FMT_S16
@@ -696,10 +699,10 @@ class FFmpegSource(StreamingSource):
 
                 # Dither withnoise-shaping when reducing bit-depth
                 if (self.AV_FORMAT_MAP[self.tgt_format][0] < sample_bits):
-                        avutil.av_opt_set(self.audio_convert_ctx,
-                                          asbytes("dither_method"),
-                                          asbytes("low_shibata"),
-                                          0)
+                    avutil.av_opt_set(self.audio_convert_ctx,
+                                      asbytes("dither_method"),
+                                      asbytes("low_shibata"),
+                                      0)
 
                 result = swresample.swr_init(self.audio_convert_ctx)
                 if result < 0:
@@ -1266,7 +1269,8 @@ class FFmpegDecoder(MediaDecoder):
         return '.mp3', '.ogg'
 
     def decode(self, filename: str, file: BinaryIO | None,
-               streaming: bool=True, audio_sample_format: str | None=None
+               streaming: bool=True, audio_sample_format: str | None=None,
+               audio_driver_sample_formats: list[str] | None=None,
     ) -> FFmpegSource | StaticSource:
 
         if audio_sample_format \
@@ -1275,10 +1279,12 @@ class FFmpegDecoder(MediaDecoder):
                 f"Audio format '{audio_sample_format}' not supported.")
 
         if streaming:
-            return FFmpegSource(filename, file, audio_sample_format)
+            return FFmpegSource(filename, file, audio_sample_format,
+                                audio_driver_sample_formats)
         else:
             return StaticSource(FFmpegSource(filename, file,
-                                             audio_sample_format))
+                                             audio_sample_format,
+                                             audio_driver_sample_formats))
 
 
 def get_decoders() -> list[FFmpegDecoder]:

--- a/pyglet/media/codecs/gstreamer.py
+++ b/pyglet/media/codecs/gstreamer.py
@@ -246,7 +246,7 @@ class GStreamerDecoder(MediaDecoder):
     def get_file_extensions(self):
         return '.mp3', '.flac', '.ogg', '.m4a'
 
-    def decode(self, filename, file, streaming=True):
+    def decode(self, filename, file, streaming=True, **kwargs):
 
         if not any(filename.endswith(ext) for ext in self.get_file_extensions()):
             # Refuse to decode anything not specifically listed in the supported

--- a/pyglet/media/codecs/pyogg.py
+++ b/pyglet/media/codecs/pyogg.py
@@ -449,7 +449,7 @@ class PyOggDecoder(MediaDecoder):
     def get_file_extensions(self):
         return PyOggDecoder.exts
 
-    def decode(self, filename, file, streaming=True):
+    def decode(self, filename, file, streaming=True, **kwargs):
         name, ext = os.path.splitext(filename)
         if ext in PyOggDecoder.vorbis_exts:
             source = PyOggVorbisSource

--- a/pyglet/media/codecs/wave.py
+++ b/pyglet/media/codecs/wave.py
@@ -70,7 +70,7 @@ class WaveDecoder(MediaDecoder):
     def get_file_extensions(self):
         return '.wav', '.wave', '.riff'
 
-    def decode(self, filename, file, streaming=True):
+    def decode(self, filename, file, streaming=True, **kwargs):
         if streaming:
             return WaveSource(filename, file)
         else:

--- a/pyglet/media/codecs/wmf.py
+++ b/pyglet/media/codecs/wmf.py
@@ -875,7 +875,7 @@ class WMFDecoder(MediaDecoder):
     def get_file_extensions(self):
         return self.extensions
 
-    def decode(self, filename, file, streaming=True):
+    def decode(self, filename, file, streaming=True, **kwargs):
         if streaming:
             return WMFSource(filename, file)
         return StaticSource(WMFSource(filename, file))

--- a/pyglet/media/drivers/base.py
+++ b/pyglet/media/drivers/base.py
@@ -450,6 +450,12 @@ class AbstractAudioDriver(metaclass=ABCMeta):
     def get_listener(self):
         pass
 
+    @property
+    @abstractmethod
+    def sample_formats(self):
+        """Get list of supported sample formats ("U8", "S16", "S32", "F32")."""
+        pass
+
     @abstractmethod
     def delete(self):
         pass

--- a/pyglet/media/drivers/directsound/adaptation.py
+++ b/pyglet/media/drivers/directsound/adaptation.py
@@ -45,6 +45,10 @@ class DirectSoundDriver(AbstractAudioDriver):
         self.worker = PlayerWorkerThread()
         self.worker.start()
 
+    @property
+    def sample_formats(self):
+        return tuple(interface.SAMPLE_FORMATS.keys())
+
     def create_audio_player(self, source, player):
         assert self._ds_driver is not None
         return DirectSoundAudioPlayer(self, source, player)

--- a/pyglet/media/drivers/directsound/interface.py
+++ b/pyglet/media/drivers/directsound/interface.py
@@ -14,6 +14,11 @@ from .exceptions import DirectSoundNativeError
 
 _debug = debug_print('debug_media')
 
+SAMPLE_FORMATS = {"U8": lib.WAVE_FORMAT_PCM,
+                  "S16": lib.WAVE_FORMAT_PCM,
+                  "S24": lib.WAVE_FORMAT_PCM,
+                  "S32": lib.WAVE_FORMAT_PCM,
+                  "F32": 3)}
 
 def _check(hresult):
     if hresult != lib.DS_OK:
@@ -21,11 +26,15 @@ def _check(hresult):
 
 
 def _create_wave_format(audio_format):
-    if audio_format.channels > 2 or audio_format.sample_size not in (8, 16):
-        raise MediaException(f'Unsupported audio format: {audio_format}')
+    if audio_format.channels > 2 \
+            or audio_format.sample_format not in SAMPLE_FORMATS:
+        raise MediaException(
+            f"DirectSound does not support '{audio_format.channels}-channel, "
+            f"{audio_format.sample_size}-bit "
+            f"{audio_format.sample_type}' audio.")
 
     wfx = lib.WAVEFORMATEX()
-    wfx.wFormatTag = lib.WAVE_FORMAT_PCM
+    wfx.wFormatTag = SAMPLE_FORMATS[audio_format.sample_format]
     wfx.nChannels = audio_format.channels
     wfx.nSamplesPerSec = audio_format.sample_rate
     wfx.wBitsPerSample = audio_format.sample_size

--- a/pyglet/media/drivers/directsound/interface.py
+++ b/pyglet/media/drivers/directsound/interface.py
@@ -18,7 +18,7 @@ SAMPLE_FORMATS = {"U8": lib.WAVE_FORMAT_PCM,
                   "S16": lib.WAVE_FORMAT_PCM,
                   "S24": lib.WAVE_FORMAT_PCM,
                   "S32": lib.WAVE_FORMAT_PCM,
-                  "F32": 3)}
+                  "F32": 3}
 
 def _check(hresult):
     if hresult != lib.DS_OK:

--- a/pyglet/media/drivers/openal/adaptation.py
+++ b/pyglet/media/drivers/openal/adaptation.py
@@ -28,6 +28,10 @@ class OpenALDriver(AbstractAudioDriver):
         self.worker = PlayerWorkerThread()
         self.worker.start()
 
+    @property
+    def sample_formats(self):
+        return tuple(interface.SAMPLE_FORMATS.keys())
+
     def create_audio_player(self, source: 'Source', player: 'Player') -> 'OpenALAudioPlayer':
         assert self.device is not None, 'Device was closed'
         return OpenALAudioPlayer(self, source, player)

--- a/pyglet/media/drivers/openal/adaptation.py
+++ b/pyglet/media/drivers/openal/adaptation.py
@@ -30,7 +30,7 @@ class OpenALDriver(AbstractAudioDriver):
 
     @property
     def sample_formats(self):
-        return tuple(interface.SAMPLE_FORMATS.keys())
+       return self.context._supported_formats
 
     def create_audio_player(self, source: 'Source', player: 'Player') -> 'OpenALAudioPlayer':
         assert self.device is not None, 'Device was closed'
@@ -222,7 +222,8 @@ class OpenALAudioPlayer(AbstractAudioPlayer):
 
         # Get, fill and queue OpenAL buffer using the entire AudioData
         buf = self.alsource.get_buffer()
-        buf.data(audio_data, self.source.audio_format)
+        buf.data(audio_data, self.source.audio_format,
+                 self.driver.sample_formats)
         self.alsource.queue_buffer(buf)
 
         # Adjust the write cursor and memorize buffer length

--- a/pyglet/media/drivers/openal/interface.py
+++ b/pyglet/media/drivers/openal/interface.py
@@ -11,7 +11,18 @@ from pyglet.media.exceptions import MediaException
 _debug = debug_print('debug_media')
 
 
-SAMPLE_FORMATS = {}  # Gets set dynamically by OpenALContext on driver creation
+SAMPLE_FORMATS = {
+	"U8":  (None, {1: al.AL_FORMAT_MONO8, 2: al.AL_FORMAT_STEREO8}),
+	"S16": (None, {1: al.AL_FORMAT_MONO16, 2: al.AL_FORMAT_STEREO16}),
+	"S32": (b"AL_EXT_32bit_formats",
+            {1: al.alGetEnumValue(b"AL_FORMAT_MONO_I32"),
+             2: al.alGetEnumValue(b"AL_FORMAT_STEREO_I32")}),
+	"F32": (b"AL_EXT_float32",
+            {1: al.alGetEnumValue(b"AL_FORMAT_MONO_FLOAT32"),
+             2: al.alGetEnumValue(b"AL_FORMAT_STEREO_FLOAT32")}),
+}
+
+al.alGetError()  # Clear error from possibly unknown enum values
 
 
 class OpenALException(MediaException):
@@ -109,7 +120,12 @@ class OpenALContext(OpenALObject):
         self._al_context = al_context
         self._sources = set()
         self.make_current()
-        self.initialize_sample_formats()
+
+        self._supported_formats = []
+        for fmt, (required_extension, _) in SAMPLE_FORMATS.items():
+            if (required_extension is None
+                    or al.alIsExtensionPresent(required_extension)):
+                self._supported_formats.append(fmt)
 
     def delete_sources(self):
         for s in tuple(self._sources):
@@ -138,20 +154,6 @@ class OpenALContext(OpenALObject):
         new_source = OpenALSource(self)
         self._sources.add(new_source)
         return new_source
-
-    def initialize_sample_formats(self):
-        global SAMPLE_FORMATS
-        SAMPLE_FORMATS = {
-            "U8": {1: al.AL_FORMAT_MONO8, 2: al.AL_FORMAT_STEREO8},
-            "S16": {1: al.AL_FORMAT_MONO16, 2: al.AL_FORMAT_STEREO16}}
-        if bool(al.alIsExtensionPresent(b"AL_EXT_32bit_formats")):
-                SAMPLE_FORMATS["S32"] = {
-                    1: al.alGetEnumValue(b"AL_FORMAT_MONO_I32"),
-                    2: al.alGetEnumValue(b"AL_FORMAT_STEREO_I32")}
-        if bool(al.alIsExtensionPresent(b"AL_EXT_float32")):
-                SAMPLE_FORMATS["F32"] = {
-                    1: al.alGetEnumValue(b"AL_FORMAT_MONO_FLOAT32"),
-                    2: al.alGetEnumValue(b"AL_FORMAT_STEREO_FLOAT32")}
 
     def source_deleted(self, source):
         self._sources.remove(source)
@@ -426,14 +428,16 @@ class OpenALBuffer(OpenALObject):
             self._check_error('Error deleting buffer.')
             self.al_name = None
 
-    def data(self, audio_data, audio_format):
+    def data(self, audio_data, audio_format, supported_formats):
         assert self.is_valid
 
         try:
             sample_format = audio_format.sample_format
             channels = audio_format.channels
-            al_format = SAMPLE_FORMATS[sample_format][channels]
-        except KeyError:
+            assert sample_format in SAMPLE_FORMATS
+            assert sample_format in supported_formats
+            al_format = SAMPLE_FORMATS[sample_format][1][channels]
+        except AssertionError:
             raise MediaException(
                 f"OpenAL does not support '{audio_format.channels}-channel, "
                 f"{audio_format.sample_size}-bit "

--- a/pyglet/media/drivers/openal/interface.py
+++ b/pyglet/media/drivers/openal/interface.py
@@ -10,15 +10,8 @@ from pyglet.media.exceptions import MediaException
 
 _debug = debug_print('debug_media')
 
-SAMPLE_FORMATS = {"U8": {1: al.AL_FORMAT_MONO8, 2: al.AL_FORMAT_STEREO8},
-                 "S16": {1: al.AL_FORMAT_MONO16, 2: al.AL_FORMAT_STEREO16}}
 
-if bool(al.alIsExtensionPresent(b"AL_EXT_32bit_formats")):
-    SAMPLE_FORMATS["S32"] = {1: al.alGetEnumValue(b"AL_FORMAT_MONO_I32"),
-                            2: al.alGetEnumValue(b"AL_FORMAT_STEREO_I32")}
-if bool(al.alIsExtensionPresent(b"AL_EXT_float32")):
-    SAMPLE_FORMATS["F32"] = {1: al.alGetEnumValue(b"AL_FORMAT_MONO_FLOAT32"),
-                            2: al.alGetEnumValue(b"AL_FORMAT_STEREO_FLOAT32")}
+SAMPLE_FORMATS = {}  # Gets set dynamically by OpenALContext on driver creation
 
 
 class OpenALException(MediaException):
@@ -116,6 +109,7 @@ class OpenALContext(OpenALObject):
         self._al_context = al_context
         self._sources = set()
         self.make_current()
+        self.initialize_sample_formats()
 
     def delete_sources(self):
         for s in tuple(self._sources):
@@ -144,6 +138,20 @@ class OpenALContext(OpenALObject):
         new_source = OpenALSource(self)
         self._sources.add(new_source)
         return new_source
+
+    def initialize_sample_formats(self):
+        global SAMPLE_FORMATS
+        SAMPLE_FORMATS = {
+            "U8": {1: al.AL_FORMAT_MONO8, 2: al.AL_FORMAT_STEREO8},
+            "S16": {1: al.AL_FORMAT_MONO16, 2: al.AL_FORMAT_STEREO16}}
+        if bool(al.alIsExtensionPresent(b"AL_EXT_32bit_formats")):
+                SAMPLE_FORMATS["S32"] = {
+                    1: al.alGetEnumValue(b"AL_FORMAT_MONO_I32"),
+                    2: al.alGetEnumValue(b"AL_FORMAT_STEREO_I32")}
+        if bool(al.alIsExtensionPresent(b"AL_EXT_float32")):
+                SAMPLE_FORMATS["F32"] = {
+                    1: al.alGetEnumValue(b"AL_FORMAT_MONO_FLOAT32"),
+                    2: al.alGetEnumValue(b"AL_FORMAT_STEREO_FLOAT32")}
 
     def source_deleted(self, source):
         self._sources.remove(source)

--- a/pyglet/media/drivers/openal/interface.py
+++ b/pyglet/media/drivers/openal/interface.py
@@ -10,6 +10,16 @@ from pyglet.media.exceptions import MediaException
 
 _debug = debug_print('debug_media')
 
+SAMPLE_FORMATS = {"U8": {1: al.AL_FORMAT_MONO8, 2: al.AL_FORMAT_STEREO8},
+                 "S16": {1: al.AL_FORMAT_MONO16, 2: al.AL_FORMAT_STEREO16}}
+
+if bool(al.alIsExtensionPresent(b"AL_EXT_32bit_formats")):
+    SAMPLE_FORMATS["S32"] = {1: al.alGetEnumValue(b"AL_FORMAT_MONO_I32"),
+                            2: al.alGetEnumValue(b"AL_FORMAT_STEREO_I32")}
+if bool(al.alIsExtensionPresent(b"AL_EXT_float32")):
+    SAMPLE_FORMATS["F32"] = {1: al.alGetEnumValue(b"AL_FORMAT_MONO_FLOAT32"),
+                            2: al.alGetEnumValue(b"AL_FORMAT_STEREO_FLOAT32")}
+
 
 class OpenALException(MediaException):
     def __init__(self, message=None, error_code=None, error_string=None):
@@ -384,12 +394,6 @@ class OpenALListener(OpenALObject):
 
 
 class OpenALBuffer(OpenALObject):
-    _format_map = {
-        (1,  8): al.AL_FORMAT_MONO8,
-        (1, 16): al.AL_FORMAT_MONO16,
-        (2,  8): al.AL_FORMAT_STEREO8,
-        (2, 16): al.AL_FORMAT_STEREO16,
-    }
 
     def __init__(self, al_name):
         self.al_name = al_name
@@ -418,9 +422,14 @@ class OpenALBuffer(OpenALObject):
         assert self.is_valid
 
         try:
-            al_format = self._format_map[(audio_format.channels, audio_format.sample_size)]
+            sample_format = audio_format.sample_format
+            channels = audio_format.channels
+            al_format = SAMPLE_FORMATS[sample_format][channels]
         except KeyError:
-            raise MediaException(f"OpenAL does not support '{audio_format.sample_size}bit' audio.")
+            raise MediaException(
+                f"OpenAL does not support '{audio_format.channels}-channel, "
+                f"{audio_format.sample_size}-bit "
+                f"{audio_format.sample_type}' audio.")
 
         al.alBufferData(self.al_name,
                         al_format,

--- a/pyglet/media/drivers/pulse/adaptation.py
+++ b/pyglet/media/drivers/pulse/adaptation.py
@@ -1,5 +1,4 @@
-from collections import deque
-import ctypes
+from collections import deSAMPLEmport ctypes
 import threading
 from typing import Deque, Optional, TYPE_CHECKING
 import weakref
@@ -10,7 +9,7 @@ from pyglet.media.player_worker_thread import PlayerWorkerThread
 from pyglet.util import debug_print
 
 from . import lib_pulseaudio as pa
-from .interface import PulseAudioMainloop
+from .interface import PulseAudioMainloop, SAMPLE_FORMATS
 
 if TYPE_CHECKING:
     from pyglet.media.codecs import AudioData, AudioFormat, Source
@@ -30,6 +29,10 @@ class PulseAudioDriver(AbstractAudioDriver):
         self.worker.start()
         self._players = weakref.WeakSet()
         self._listener = PulseAudioListener(self)
+
+    @property
+    def sample_formats(self):
+        return tuple(SAMPLE_FORMATS.keys())
 
     def create_audio_player(self, source: 'Source', player: 'Player') -> 'PulseAudioPlayer':
         assert self.context is not None

--- a/pyglet/media/drivers/pulse/adaptation.py
+++ b/pyglet/media/drivers/pulse/adaptation.py
@@ -1,4 +1,5 @@
-from collections import deSAMPLEmport ctypes
+from collections import deque
+import ctypes
 import threading
 from typing import Deque, Optional, TYPE_CHECKING
 import weakref

--- a/pyglet/media/drivers/pulse/interface.py
+++ b/pyglet/media/drivers/pulse/interface.py
@@ -25,6 +25,16 @@ _SIZE_T_MAX = sys.maxsize*2 + 1
 PA_INVALID_INDEX = _UINT32_MAX
 PA_INVALID_WRITABLE_SIZE = _SIZE_T_MAX
 
+SAMPLE_FORMATS = {"U8": {"little": pa.PA_SAMPLE_U8,
+                         "big": pa.PA_SAMPLE_U8},
+                  "S16": {"little": pa.PA_SAMPLE_S16LE,
+                          "big": pa.PA_SAMPLE_S16BE},
+                  "S24": {"little": pa.PA_SAMPLE_S24LE,
+                          "big": pa.PA_SAMPLE_S24BE},
+                  "S32": {"little": pa.PA_SAMPLE_S32LE,
+                          "big": pa.PA_SAMPLE_S32BE},
+                  "F32": {"little": pa.PA_SAMPLE_FLOAT32LE,
+                          "big": pa.PA_SAMPLE_FLOAT32BE)}}
 
 def get_uint32_or_none(value: int) -> Optional[int]:
     if value == _UINT32_MAX:
@@ -373,20 +383,18 @@ class PulseAudioStream(PulseAudioMainloopChild):
         """
         Create a PulseAudio sample spec from pyglet audio format.
         """
-        _FORMATS = {
-            ('little', 8):  pa.PA_SAMPLE_U8,
-            ('big', 8):     pa.PA_SAMPLE_U8,
-            ('little', 16): pa.PA_SAMPLE_S16LE,
-            ('big', 16):    pa.PA_SAMPLE_S16BE,
-            ('little', 24): pa.PA_SAMPLE_S24LE,
-            ('big', 24):    pa.PA_SAMPLE_S24BE,
-        }
-        fmt = (sys.byteorder, audio_format.sample_size) 
-        if fmt not in _FORMATS:
-            raise MediaException(f'Unsupported sample size/format: {fmt}')
+
+        try:
+            fmt = SAMPLE_FORMATS[audio_format.sample_format][sys.byteorder]
+        except KeyError:
+            raise MediaException(
+                f"PulseAudio does not support "
+                f"'{audio_format.channels}-channel, "
+                f"{audio_format.sample_size}-bit "
+                f"{audio_format.sample_type}' audio.")
 
         sample_spec = pa.pa_sample_spec()
-        sample_spec.format = _FORMATS[fmt]
+        sample_spec.format = fmt
         sample_spec.rate = audio_format.sample_rate
         sample_spec.channels = audio_format.channels
         return sample_spec

--- a/pyglet/media/drivers/pulse/interface.py
+++ b/pyglet/media/drivers/pulse/interface.py
@@ -34,7 +34,7 @@ SAMPLE_FORMATS = {"U8": {"little": pa.PA_SAMPLE_U8,
                   "S32": {"little": pa.PA_SAMPLE_S32LE,
                           "big": pa.PA_SAMPLE_S32BE},
                   "F32": {"little": pa.PA_SAMPLE_FLOAT32LE,
-                          "big": pa.PA_SAMPLE_FLOAT32BE)}}
+                          "big": pa.PA_SAMPLE_FLOAT32BE}}
 
 def get_uint32_or_none(value: int) -> Optional[int]:
     if value == _UINT32_MAX:

--- a/pyglet/media/drivers/silent/adaptation.py
+++ b/pyglet/media/drivers/silent/adaptation.py
@@ -1,3 +1,4 @@
+#from pyglet.media import _VALID_AUDIO_SAMPLE_FORMATS
 from pyglet.media.drivers.base import AbstractAudioDriver, AbstractAudioPlayer, MediaEvent
 from pyglet.media.drivers.listener import AbstractListener
 from pyglet.media.player_worker_thread import PlayerWorkerThread
@@ -8,6 +9,14 @@ class SilentDriver(AbstractAudioDriver):
         super().__init__()
         self.worker = PlayerWorkerThread()
         self.worker.start()
+
+    @property
+    def sample_formats(self):
+        return ("U8",
+                "S16",
+                "S24",
+                "S32"
+                "F32")
 
     def create_audio_player(self, source, player):
         return SilentAudioPlayer(self, source, player)

--- a/pyglet/media/drivers/silent/adaptation.py
+++ b/pyglet/media/drivers/silent/adaptation.py
@@ -15,7 +15,7 @@ class SilentDriver(AbstractAudioDriver):
         return ("U8",
                 "S16",
                 "S24",
-                "S32"
+                "S32",
                 "F32")
 
     def create_audio_player(self, source, player):

--- a/pyglet/media/drivers/xaudio2/adaptation.py
+++ b/pyglet/media/drivers/xaudio2/adaptation.py
@@ -31,6 +31,10 @@ class XAudio2Driver(AbstractAudioDriver):
         self.worker = PlayerWorkerThread()
         self.worker.start()
 
+    @property
+    def sample_formats(self):
+        return tuple(interface.SAMPLE_FORMATS.keys())
+
     def get_performance(self) -> interface.lib.XAUDIO2_PERFORMANCE_DATA:
         assert self._xa2_driver is not None
         return self._xa2_driver.get_performance()

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -19,7 +19,7 @@ SAMPLE_FORMATS = {"U8": lib.WAVE_FORMAT_PCM,
                   "S16": lib.WAVE_FORMAT_PCM,
                   "S24": lib.WAVE_FORMAT_PCM,
                   "S32": lib.WAVE_FORMAT_PCM,
-                  "F32": 3)}
+                  "F32": 3}
 
 
 def create_xa2_buffer(audio_data):

--- a/pyglet/media/drivers/xaudio2/interface.py
+++ b/pyglet/media/drivers/xaudio2/interface.py
@@ -15,6 +15,12 @@ from . import lib_xaudio2 as lib
 
 _debug = debug_print('debug_media')
 
+SAMPLE_FORMATS = {"U8": lib.WAVE_FORMAT_PCM,
+                  "S16": lib.WAVE_FORMAT_PCM,
+                  "S24": lib.WAVE_FORMAT_PCM,
+                  "S32": lib.WAVE_FORMAT_PCM,
+                  "F32": 3)}
+
 
 def create_xa2_buffer(audio_data):
     """Creates a XAUDIO2_BUFFER to be used with a source voice.
@@ -28,11 +34,16 @@ def create_xa2_buffer(audio_data):
 
 
 def create_xa2_waveformat(audio_format):
-    if audio_format.channels > 2 or audio_format.sample_size not in (8, 16):
-        raise MediaException(f'Unsupported audio format: {audio_format}')
+    if audio_format.channels > 2 \
+            or audio_format.sample_format not in SAMPLE_FORMATS:
+        raise MediaException(
+            f"XAudio2 does not support '{audio_format.channels}-channel, "
+            f"{audio_format.sample_size}-bit "
+            f"{audio_format.sample_type}' audio.")
+
 
     wfx = lib.WAVEFORMATEX()
-    wfx.wFormatTag = lib.WAVE_FORMAT_PCM
+    wfx.wFormatTag = SAMPLE_FORMATS[audio_format.sample_format]
     wfx.nChannels = audio_format.channels
     wfx.nSamplesPerSec = audio_format.sample_rate
     wfx.wBitsPerSample = audio_format.sample_size

--- a/tests/unit/media/test_sources.py
+++ b/tests/unit/media/test_sources.py
@@ -57,10 +57,10 @@ class AudioFormatTestCase(unittest.TestCase):
 
     def test_repr(self):
         af1 = AudioFormat(1, 8, 22050)
-        self.assertEqual(repr(af1), 'AudioFormat(channels=1, sample_size=8, sample_rate=22050)')
+        self.assertEqual(repr(af1), 'AudioFormat(channels=1, sample_size=8, sample_rate=22050, sample_type=uint)')
 
         af2 = AudioFormat(2, 16, 44100)
-        self.assertEqual(repr(af2), 'AudioFormat(channels=2, sample_size=16, sample_rate=44100)')
+        self.assertEqual(repr(af2), 'AudioFormat(channels=2, sample_size=16, sample_rate=44100, sample_type=int)')
 
 
 class AudioDataTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR implements more robust 32-bit audio support as suggested in #1316. Most importantly, it introduces unified audio sample format definitions and enables audio drivers to explicitly distinguish between 32-bit integer and floating-point formats.

**Note**: For now, the FFmpeg decoder is the primary implementation utilizing these new capabilities. It serves as a reference for adapting other decoders in the future and is designed not to break the current behavior of other drivers.

### Changes
- **`pyglet.media`**: Added `AUDIO_SAMPLE_FORMAT_U8`, `AUDIO_SAMPLE_FORMAT_S16`, `AUDIO_SAMPLE_FORMAT_S32`, `AUDIO_SAMPLE_FORMAT_F32` string constants
- **`media.load`**: Added argument `audio_sample_format` (defaults to `None`) to set a fixed target format (currently only supported by `FFmpegDecoder`)
- **`media.base.AudioFormat`**: Added `SAMPLE_TYPE_INT`, `SAMPLE_TYPE_UINT`, `SAMPLE_TYPE_FLOAT` string constants
- **`media.base.AudioFormat`**: Added argument `sample_type` (defaults to `SAMPLE_TYPE_INT`)
- **`media.base.AudioFormat`**: Added property `sample_format` which returns a `media.AUDIO_SAMPLE_FORMAT_*` string
- **`media.ffmpeg`**: Added `AUDIO_SAMPLE_FORMATS` dict that maps supported `media.AUDIO_SAMPLE_FORMAT_*` values to FFmpeg-specific `AV_SAMPLE_FMT_*` values
- **`FFmpeg decoder`**: Added `audio_sample_format` argument to `FFmpegDecoder.decode`, and `FFmpegSource.__init__`
- **`FFmpegSource`**: Added new default behaviour (`audio_sample_format=None`) to automatically set the target format based on the input format
- **`FFmpegSource`**: Added fallback mechanisms if automatic target format is not supported by current audio driver
- **`FFmpegSource`**: Added noise-shaping dither when target format bit-depth is lower than source format
- **`OpenAL` audio driver**: added support for playing 32-bit int and/or float formats, depending on available extensions (`AL_EXT_FLOAT32`, etc.)
- **All other audio drivers**: added support for playing 32-bit int and float formats (and also 24-bit)
- **All audio drivers**: added mappings from `media.AUDIO_SAMPLE_FORMAT_*` formats to driver-specific formats, and  added property `sample_formats` which returns the `media.AUDIO_SAMPLE_FORMAT_*` formats they support