### PR TITLE
typo in the docs

### DIFF
--- a/doc/programming_guide/rendering.rst
+++ b/doc/programming_guide/rendering.rst
@@ -26,7 +26,7 @@ in more detail in the following sections, but a rough overview is as follows:
   standard OpenGL Shader Programs. pyglet does full attribute and uniform
   introspection, and provides methods for automatically generating buffers
   that match the attribute formats.
-* VertexDomains at at the lowest level, and users will generally not need to
+* VertexDomains are at the lowest level, and users will generally not need to
   interact with them directly. They maintain ownership of raw OpenGL vertex
   array buffers, that match a specific collection of vertex attributes.
   Buffers are resized automatically as needed. Access to these buffers is


### PR DESCRIPTION
This is just a typo fix in `doc/programming_guide/rendering.rst`, in the overview of the first paragraph.

I did not open an issue because it would have felt like spam to report it.