### PR TITLE
fix(shapes): fix ZeroDivisionError on Multiline creation

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -213,7 +213,11 @@ def _get_segment(p0: tuple[float, float] | list[float], p1: tuple[float, float] 
         v_normal_p0p1 = Vec2(-v_np0p1.y, v_np0p1.x)
         # Add the 2 normal vectors and normalize to get miter vector
         v_miter1 = Vec2(v_normal_p0p1.x + v_normal.x, v_normal_p0p1.y + v_normal.y).normalize()
-        scale1 = scale1 / math.sin(math.acos(v_np1p2.dot(v_miter1)))
+        try:
+            dot = max(-1.0, min(1.0, v_np1p2.dot(v_miter1)))
+            scale1 = scale1 / math.sin(math.acos(dot))
+        except ZeroDivisionError:
+            scale1 = thickness / 2.0
 
     if p3:
         # Compute the miter joint vector for the end of the segment
@@ -221,7 +225,11 @@ def _get_segment(p0: tuple[float, float] | list[float], p1: tuple[float, float] 
         v_normal_p2p3 = Vec2(-v_np2p3.y, v_np2p3.x)
         # Add the 2 normal vectors and normalize to get miter vector
         v_miter2 = Vec2(v_normal_p2p3.x + v_normal.x, v_normal_p2p3.y + v_normal.y).normalize()
-        scale2 = scale2 / math.sin(math.acos(v_np2p3.dot(v_miter2)))
+        try:
+            dot = max(-1.0, min(1.0, v_np2p3.dot(v_miter2)))
+            scale2 = scale2 / math.sin(math.acos(dot))
+        except ZeroDivisionError:
+            scale2 = thickness / 2.0
 
     # Quick fix for preventing the scaling factors from getting out of hand
     # with extreme angles.


### PR DESCRIPTION
## Problem
When creating a `MultiLine` with points that are extremely close or collinear, floating point precision can cause the dot product between `v_np1p2` and `v_miter1` (or `v_np2p3` and `v_miter2`) to evaluate to exactly `1.0` or `-1.0`. 
This results in `math.acos(1.0)` returning `0.0`, and `math.sin(0.0)` evaluating to `0.0`, which then causes a `ZeroDivisionError` when computing the scale factor. Floating point precision could also potentially push the dot product outside of the `[-1.0, 1.0]` domain, causing `math.acos` to raise a `ValueError`.

## Solution  
- Clamped the dot product between `-1.0` and `1.0` using `max(-1.0, min(1.0, ...))` to prevent domain `ValueError`s from `math.acos`.
- Wrapped the scale calculation in a `try...except ZeroDivisionError` block. If division by zero occurs (meaning the angle is `0` or `180` degrees), it falls back to the default `thickness / 2.0`.

## Testing
Created a test case reproducing the original issue where the first and last point lists are very close, resulting in parallel lines. Validated that the `ZeroDivisionError` is caught and `_get_segment` successfully returns the clamped/fallback scales instead of raising.

Closes #1403