### PR TITLE
Update super class call for MacOS

### DIFF
--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -171,7 +171,7 @@ class PygletView_Implementation:
         self.associate("_tracking_area", tracking_area)
 
         self.addTrackingArea_(self._tracking_area)
-        cocoapy.send_super(self, 'updateTrackingAreas')
+        cocoapy.send_super(self, 'updateTrackingAreas', superclass_name='NSView')
 
     @PygletView.method('B')
     def canBecomeKeyView(self) -> bool:


### PR DESCRIPTION
Use proper super class call when updating the base tracking areas: Fixes #1410