### PR TITLE
Fix type hints and types to get unit tests to pass successfully on Python 3.8.20 on MacOS.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     name: Python ${{ matrix.python-version }} macOS
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,7 @@ __pycache__
 # Virtualenvs (from project root)
 /env
 /.env
-/.venv
-/.venv2
-/.venv3
+/.venv*
 
 # Pyenv
 .python-version

--- a/pyglet/graphics/buffer.py
+++ b/pyglet/graphics/buffer.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 ByteSource = Union[bytes, bytearray, memoryview]
-DataSource = Union[Sequence[Union[float, int]], Array[Any]]
+DataSource = Union[Sequence[Union[float, int]], Array]
 
 _DATA_TYPE_TO_CTYPE: dict[str, type[Any]] = {
     "?": ctypes.c_bool,

--- a/pyglet/libs/darwin/cocoapy/cocoatypes.py
+++ b/pyglet/libs/darwin/cocoapy/cocoatypes.py
@@ -23,7 +23,6 @@ from ctypes import (
 )
 import platform
 import struct
-from typing import Union
 
 __LP64__ = (8*struct.calcsize("P") == 64)
 __i386__ = (platform.machine() == 'i386')
@@ -40,9 +39,9 @@ def encoding_for_ctype(vartype):
 # Note CGBase.h located at
 # /System/Library/Frameworks/ApplicationServices.framework/Frameworks/CoreGraphics.framework/Headers/CGBase.h
 # defines CGFloat as double if __LP64__, otherwise it's a float.
-NSInteger: Union[type[c_long],  type[c_int]]
-NSUInteger: Union[type[c_ulong], type[c_uint]]
-CGFloat: Union[type[c_double], type[c_float]]
+NSInteger: type[c_long] | type[c_int]
+NSUInteger: type[c_ulong] | type[c_uint]
+CGFloat: type[c_double] | type[c_float]
 if __LP64__:
     NSInteger = c_long
     NSUInteger = c_ulong

--- a/pyglet/libs/darwin/cocoapy/cocoatypes.py
+++ b/pyglet/libs/darwin/cocoapy/cocoatypes.py
@@ -22,6 +22,7 @@ from ctypes import (
 )
 import platform
 import struct
+from typing import Type, Union
 
 __LP64__ = (8*struct.calcsize("P") == 64)
 __i386__ = (platform.machine() == 'i386')
@@ -38,9 +39,9 @@ def encoding_for_ctype(vartype):
 # Note CGBase.h located at
 # /System/Library/Frameworks/ApplicationServices.framework/Frameworks/CoreGraphics.framework/Headers/CGBase.h
 # defines CGFloat as double if __LP64__, otherwise it's a float.
-NSInteger: type[c_long] | type[c_int]
-NSUInteger: type[c_ulong] | type[c_uint]
-CGFloat: type[c_double] | type[c_float]
+NSInteger: Union[Type[c_long],  Type[c_int]]
+NSUInteger: Union[Type[c_ulong], Type[c_uint]]
+CGFloat: Union[Type[c_double], Type[c_float]]
 if __LP64__:
     NSInteger = c_long
     NSUInteger = c_ulong

--- a/pyglet/libs/darwin/cocoapy/cocoatypes.py
+++ b/pyglet/libs/darwin/cocoapy/cocoatypes.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from ctypes import (
     CFUNCTYPE,
     Structure,
@@ -22,7 +23,7 @@ from ctypes import (
 )
 import platform
 import struct
-from typing import Type, Union
+from typing import Union
 
 __LP64__ = (8*struct.calcsize("P") == 64)
 __i386__ = (platform.machine() == 'i386')
@@ -39,9 +40,9 @@ def encoding_for_ctype(vartype):
 # Note CGBase.h located at
 # /System/Library/Frameworks/ApplicationServices.framework/Frameworks/CoreGraphics.framework/Headers/CGBase.h
 # defines CGFloat as double if __LP64__, otherwise it's a float.
-NSInteger: Union[Type[c_long],  Type[c_int]]
-NSUInteger: Union[Type[c_ulong], Type[c_uint]]
-CGFloat: Union[Type[c_double], Type[c_float]]
+NSInteger: Union[type[c_long],  type[c_int]]
+NSUInteger: Union[type[c_ulong], type[c_uint]]
+CGFloat: Union[type[c_double], type[c_float]]
 if __LP64__:
     NSInteger = c_long
     NSUInteger = c_ulong

--- a/pyglet/libs/darwin/coreaudio.py
+++ b/pyglet/libs/darwin/coreaudio.py
@@ -171,7 +171,7 @@ kAudio_MemFullError = -108
 # All error constants below correspond to identically named errors in
 # Apple's audiotoolbox. The doc for each is at URLs ending with the same
 # names. For example, kAudioFileUnspecifiedError's documentation is at:
-# https://developer.apple.com/documentation/audiotoolbox/
+# https://developer.apple.com/documentation/audiotoolbox/kAudioFileUnspecifiedError
 
 # General file read errors
 kAudioFileNotOpenError = -38

--- a/pyglet/libs/darwin/coreaudio.py
+++ b/pyglet/libs/darwin/coreaudio.py
@@ -15,7 +15,8 @@ This module includes:
 from __future__ import annotations
 from ctypes import c_void_p, c_int, c_bool, Structure, c_uint32, util, cdll, c_uint, c_double, POINTER, c_int64, \
     CFUNCTYPE
-from typing import Final
+from types import MappingProxyType
+from typing import Final, Mapping
 
 from pyglet.libs.darwin import CFURLRef
 
@@ -194,9 +195,9 @@ kAudioFileInvalidPacketOffsetError = c_literal('pck?')  # 0x70636B3F, 1885563711
 kAudioFileInvalidFileError = c_literal('dta?')  # 0x6474613F, 1685348671
 kAudioFileOperationNotSupportedError = c_literal('op?')  # 0x6F703F3F, 1869627199
 
-
 # Maps kAudio errors -> error text
-err_str_db: Final[dict[int, str]] = {
+# MappingProxyType ensures that `err_str_db` keys and values are immutable
+err_str_db: Final[Mapping[int, str]] = MappingProxyType({
     kAudioFileNotOpenError: "The file is closed.",
     kAudioFileEndOfFileError: "End of file.",
     kAudioFilePositionError: "Invalid file position.",
@@ -213,7 +214,7 @@ err_str_db: Final[dict[int, str]] = {
     kAudioFileInvalidPacketOffsetError: "A packet offset was past the end of the file, or not at the end of the file when a VBR format was written, or a corrupt packet size was read when the packet table was built.",
     kAudioFileInvalidFileError: "The file is malformed, or otherwise not a valid instance of an audio file of its type.",
     kAudioFileOperationNotSupportedError: "The operation cannot be performed.",
-}
+})
 
 
 class CoreAudioException(Exception):

--- a/pyglet/media/codecs/ffmpeg_lib/compat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/compat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, NamedTuple, Protocol, Sequence, TYPE_CHECKING
+from typing import Any, NamedTuple, Protocol, Sequence, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ctypes import Structure
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 LibraryName = str
 Version = int
-FieldDef = tuple[str, Any]
+FieldDef = Tuple[str, Any]
 
 class Reposition(NamedTuple):
     field: str

--- a/pyglet/media/codecs/ffmpeg_lib/compat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/compat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, NamedTuple, Protocol, Sequence, TYPE_CHECKING
+from typing import Any, NamedTuple, Protocol, Sequence, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ctypes import Structure
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 LibraryName = str
 Version = int
-FieldDef = "tuple[str, Any]"
+FieldDef = Tuple[str, Any]
 
 class Reposition(NamedTuple):
     field: str

--- a/pyglet/media/codecs/ffmpeg_lib/compat.py
+++ b/pyglet/media/codecs/ffmpeg_lib/compat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, NamedTuple, Protocol, Sequence, Tuple, TYPE_CHECKING
+from typing import Any, NamedTuple, Protocol, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ctypes import Structure
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 LibraryName = str
 Version = int
-FieldDef = Tuple[str, Any]
+FieldDef = "tuple[str, Any]"
 
 class Reposition(NamedTuple):
     field: str

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -170,7 +170,11 @@ def _get_segment(p0: tuple[float, float] | list[float], p1: tuple[float, float] 
         v_normal_p0p1 = Vec2(-v_np0p1.y, v_np0p1.x)
         # Add the 2 normal vectors and normalize to get miter vector
         v_miter1 = Vec2(v_normal_p0p1.x + v_normal.x, v_normal_p0p1.y + v_normal.y).normalize()
-        scale1 = scale1 / math.sin(math.acos(v_np1p2.dot(v_miter1)))
+        try:
+            dot = max(-1.0, min(1.0, v_np1p2.dot(v_miter1)))
+            scale1 = scale1 / math.sin(math.acos(dot))
+        except ZeroDivisionError:
+            scale1 = thickness / 2.0
 
     if p3:
         # Compute the miter joint vector for the end of the segment
@@ -178,7 +182,11 @@ def _get_segment(p0: tuple[float, float] | list[float], p1: tuple[float, float] 
         v_normal_p2p3 = Vec2(-v_np2p3.y, v_np2p3.x)
         # Add the 2 normal vectors and normalize to get miter vector
         v_miter2 = Vec2(v_normal_p2p3.x + v_normal.x, v_normal_p2p3.y + v_normal.y).normalize()
-        scale2 = scale2 / math.sin(math.acos(v_np2p3.dot(v_miter2)))
+        try:
+            dot = max(-1.0, min(1.0, v_np2p3.dot(v_miter2)))
+            scale2 = scale2 / math.sin(math.acos(dot))
+        except ZeroDivisionError:
+            scale2 = thickness / 2.0
 
     # Quick fix for preventing the scaling factors from getting out of hand
     # with extreme angles.

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -170,11 +170,7 @@ def _get_segment(p0: tuple[float, float] | list[float], p1: tuple[float, float] 
         v_normal_p0p1 = Vec2(-v_np0p1.y, v_np0p1.x)
         # Add the 2 normal vectors and normalize to get miter vector
         v_miter1 = Vec2(v_normal_p0p1.x + v_normal.x, v_normal_p0p1.y + v_normal.y).normalize()
-        try:
-            dot = max(-1.0, min(1.0, v_np1p2.dot(v_miter1)))
-            scale1 = scale1 / math.sin(math.acos(dot))
-        except ZeroDivisionError:
-            scale1 = thickness / 2.0
+        scale1 = scale1 / math.sin(math.acos(v_np1p2.dot(v_miter1)))
 
     if p3:
         # Compute the miter joint vector for the end of the segment
@@ -182,11 +178,7 @@ def _get_segment(p0: tuple[float, float] | list[float], p1: tuple[float, float] 
         v_normal_p2p3 = Vec2(-v_np2p3.y, v_np2p3.x)
         # Add the 2 normal vectors and normalize to get miter vector
         v_miter2 = Vec2(v_normal_p2p3.x + v_normal.x, v_normal_p2p3.y + v_normal.y).normalize()
-        try:
-            dot = max(-1.0, min(1.0, v_np2p3.dot(v_miter2)))
-            scale2 = scale2 / math.sin(math.acos(dot))
-        except ZeroDivisionError:
-            scale2 = thickness / 2.0
+        scale2 = scale2 / math.sin(math.acos(v_np2p3.dot(v_miter2)))
 
     # Quick fix for preventing the scaling factors from getting out of hand
     # with extreme angles.

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -172,7 +172,7 @@ class PygletView_Implementation:
         self.associate("_tracking_area", tracking_area)
 
         self.addTrackingArea_(self._tracking_area)
-        cocoapy.send_super(self, 'updateTrackingAreas', superclass_name='NSView')
+        cocoapy.send_super(self, 'updateTrackingAreas')
 
     @PygletView.method('B')
     def canBecomeKeyView(self) -> bool:

--- a/pyglet/window/cocoa/pyglet_view.py
+++ b/pyglet/window/cocoa/pyglet_view.py
@@ -172,7 +172,7 @@ class PygletView_Implementation:
         self.associate("_tracking_area", tracking_area)
 
         self.addTrackingArea_(self._tracking_area)
-        cocoapy.send_super(self, 'updateTrackingAreas')
+        cocoapy.send_super(self, 'updateTrackingAreas', superclass_name='NSView')
 
     @PygletView.method('B')
     def canBecomeKeyView(self) -> bool:

--- a/tests/unit/libs/darwin/test_coreaudio.py
+++ b/tests/unit/libs/darwin/test_coreaudio.py
@@ -10,6 +10,6 @@ def test_coreaudio__try_to_add_key_and_value_to_err_str_db__type_error_raised():
 
 
 @require_platform(Platform.OSX)
-def test_coreaudio__try_to_change_key_and_value_in_err_str_db__type_error_raised():
+def test_coreaudio__try_to_change_value_of_key_in_err_str_db__type_error_raised():
     with pytest.raises(TypeError):
         err_str_db[kAudioFileFileNotFoundError] = "some_value"

--- a/tests/unit/libs/darwin/test_coreaudio.py
+++ b/tests/unit/libs/darwin/test_coreaudio.py
@@ -1,0 +1,15 @@
+import pytest
+from pyglet.libs.darwin.coreaudio import err_str_db, kAudioFileFileNotFoundError
+from tests.annotations import require_platform, Platform
+
+
+@require_platform(Platform.OSX)
+def test_coreaudio__try_to_add_key_and_value_to_err_str_db__type_error_raised():
+    with pytest.raises(TypeError):
+        err_str_db["some_key"] = "some_value"
+
+
+@require_platform(Platform.OSX)
+def test_coreaudio__try_to_change_key_and_value_in_err_str_db__type_error_raised():
+    with pytest.raises(TypeError):
+        err_str_db[kAudioFileFileNotFoundError] = "some_value"

--- a/tests/unit/libs/darwin/test_coreaudio.py
+++ b/tests/unit/libs/darwin/test_coreaudio.py
@@ -4,12 +4,7 @@ from tests.annotations import require_platform, Platform
 
 
 @require_platform(Platform.OSX)
-def test_coreaudio__try_to_add_key_and_value_to_err_str_db__type_error_raised():
+@pytest.mark.parametrize("key", ["some_key", kAudioFileFileNotFoundError])
+def test_coreaudio__try_to_change_key_and_value_of_err_str_db__type_error_raised(key: str):
     with pytest.raises(TypeError):
-        err_str_db["some_key"] = "some_value"
-
-
-@require_platform(Platform.OSX)
-def test_coreaudio__try_to_change_value_of_key_in_err_str_db__type_error_raised():
-    with pytest.raises(TypeError):
-        err_str_db[kAudioFileFileNotFoundError] = "some_value"
+        err_str_db[key] = "some_value"


### PR DESCRIPTION
### Description

I fixed the type hints and types of various objects to get the command `pytest tests/unit` to run successfully with Python 3.8.20 on a MacOS.

Changes:
- I added `from __future__ import annotations` where missing.
- I fixed the type hints and type of [pyglet.libs.darwin.coreaudio.err_str_db](https://github.com/pyglet/pyglet/blob/development/pyglet/libs/darwin/coreaudio.py#L199) so that `err_str_db` is now actually immutable, as I imagine was intended.
- I added a unit test to cover the immutability of `err_str_db`. 
- I fixed a link in a comment also in `coreaudio.py`.
- I updated gitignore to ignore any dir starting with `.venv` to support virtualenv names like `.venv-3.8.20`.
- I added Python 3.8 and 3.9 to the `python-version` matrix of the unit tests GitHub Action runner for `macos-latest`. 
  - Note: I have not fixed the **integration** tests for MacOS Python 3.8, but since the `unittests.yaml` has it ignored I felt it safe to add back in those Python versions. I will work on fixing the integration tests next.

### Running

*Ensure you are running with Python 3.8.20 on MacOS.*

Run:

```bash
pytest tests/unit
```

And all tests should run successfully.

### Discussion

Although the changes I made got the unit tests to run for Python 3.8.20, there are a lot of areas in the code that may not be covered by unit tests that use language constructs not available to Python 3.8 (such as using the `|` operator as a replacement for `Union` in type hints, which was introduced in Python 3.10). 

Both [Python 3.8 and Python 3.9 are end-of-life and no longer supported](https://devguide.python.org/versions/). Current [pyglet development documentation references using Python3.8+](https://pyglet.readthedocs.io/en/latest/internal/virtualenv.html#development-environment) for development. It may be worthwhile to develop a roadmap for no longer supporting Python 3.8 / 3.9 and update all development and user documentation to reflect that coming change.

There is [a discussion thread for this PR in the Discord at this link](https://discord.com/channels/438622377094414346/1490438039909040248) as well.