### PR TITLE
Update gitignore to ignore all .venv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,7 @@ __pycache__
 # Virtualenvs (from project root)
 /env
 /.env
-/.venv
-/.venv2
-/.venv3
+/.venv*
 
 # Pyenv
 .python-version


### PR DESCRIPTION
### Description

Updated the `.gitignore` to ignore *all* `.venv` directories.

### Running

Create a virtual environment with anything appended to the `.venv` portion, such as the current Python version or current task, like so:

```bash
python -m venv .venv-working-on-ignoring-all-venv-dirs
```

With the changes in this PR, the newly created `.venv` directory should not show up as changes waiting to be staged for commit.