### PR TITLE
Add Python Version Support section to Installation docs.

### DIFF
--- a/doc/programming_guide/installation.rst
+++ b/doc/programming_guide/installation.rst
@@ -26,6 +26,19 @@ To play video, or a wide selection of compressed audio, pyglet can optionally
 use `FFmpeg <https://www.ffmpeg.org/download.html>`_.
 
 
+Python Version Support
+----------------------
+
+pyglet aims to support all non-End-Of-Life (non-EOL) Python versions.
+Support isn't necessarily dropped as soon as a Python version enters EOL,
+but support might be dropped, so it is best practice to use a non-EOL Python
+version when developing with pyglet.
+
+To find out which versions of Python are currently supported and which are
+EOL you can reference
+`the Status of Python Versions in the Python Developer's Guide <https://devguide.python.org/versions/>`_.
+
+
 Running the examples
 --------------------
 


### PR DESCRIPTION
### Description

Added a Python Version Support section to the Installation user docs.

Partially addresses issue #1430. 

### Running

Pull and checkout this branch and run the following:

```bash
./make.py docs --open
```

Then navigate to the Installation portion of the Python docs in the static docs web page that opens in your brower. You should see a new heading underneath Installation titled "Python Version Support" with content that looks like the following:

<img width="1152" height="956" alt="image" src="https://github.com/user-attachments/assets/52c19fc0-4c6d-4d1e-8751-76a42997cd07" />