### PR TITLE
Add `dpi_scaling = "none"` option for pixel-perfect windows

### DIFF
--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -253,7 +253,7 @@ class Options:
 
     .. versionadded:: 2.0.5"""
 
-    dpi_scaling: Literal["platform", "stretch"] = "platform"
+    dpi_scaling: Literal["platform", "stretch", "none"] = "platform"
     """For 'HiDPI' displays, Window behavior can differ between operating systems. Defaults to `'platform'`.
 
     The current options are an attempt to create consistent behavior across all of the operating systems.
@@ -270,6 +270,10 @@ class Options:
     No rescaling and repositioning of content will be necessary, but at the cost of blurry content depending on the
     extent of the stretch. For example, 800x600 at 150% DPI will be 800x600 for `window.get_size()` and 1200x900 for
     `window.get_framebuffer_size()`.
+
+    `'none'`: DPI scaling is completely ignored. The window and framebuffer are created at exactly the requested pixel
+    size, with a 1:1 mapping between logical pixels and physical pixels. The window may appear smaller on HiDPI
+    displays, but rendering will be pixel-perfect with no interpolation or scaling artifacts.
     """
 
     shader_bind_management: bool = True

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -197,7 +197,10 @@ class Win32Window(BaseWindow):
         else:
             self._ws_style &= ~(constants.WS_THICKFRAME | constants.WS_MAXIMIZEBOX)
 
-        self._dpi = self._screen.get_dpi()
+        if pyglet.options.dpi_scaling == "none":
+            self._dpi = 96
+        else:
+            self._dpi = self._screen.get_dpi()
 
         if self._fullscreen:
             width = self.screen.width
@@ -1420,7 +1423,7 @@ class Win32Window(BaseWindow):
 
     @Win32EventHandler(constants.WM_GETDPISCALEDSIZE)
     def _event_dpi_scaled_size(self, msg: int, wParam: int, lParam: int) -> int | None:
-        if pyglet.options.dpi_scaling == "stretch":
+        if pyglet.options.dpi_scaling in ("stretch", "none"):
             return None
 
         size = cast(lParam, POINTER(SIZE)).contents
@@ -1448,6 +1451,9 @@ class Win32Window(BaseWindow):
     @Win32EventHandler(constants.WM_DPICHANGED)
     def _event_dpi_change(self, msg: int, wParam: int, lParam: int) -> int:
         y_dpi, x_dpi = self._get_location(wParam)
+
+        if pyglet.options.dpi_scaling == "none":
+            return 1
 
         scale = x_dpi / constants.USER_DEFAULT_SCREEN_DPI
 


### PR DESCRIPTION
## Summary

- Add a third `dpi_scaling` mode (`"none"`) that forces `_dpi = 96` regardless of the OS
  display scaling, producing a window and framebuffer at exactly the requested pixel size
- This gives applications a way to opt out of DPI scaling entirely when they need
  pixel-perfect, unscaled rendering

## Motivation

When Windows display scaling is set above 100% (e.g., 125%), pyglet creates a framebuffer
larger than the requested window size. A 400x300 window at 125% scaling gets a 500x375
framebuffer. The existing `"stretch"` mode still creates the oversized framebuffer and
stretches content into it, which introduces interpolation blur.

Some applications (pixel art games, retro emulators, diagnostic tools) need an exact 1:1
mapping between requested pixels and framebuffer pixels. There is currently no way to
achieve this.

## Changes

### 1. `pyglet/__init__.py` — Add `"none"` to the `dpi_scaling` option

```python
# Before
dpi_scaling: Literal["platform", "stretch"] = "platform"

# After
dpi_scaling: Literal["platform", "stretch", "none"] = "platform"
```

Added documentation:

> `'none'`: DPI scaling is completely ignored. The window and framebuffer are created at
> exactly the requested pixel size, with a 1:1 mapping between logical pixels and physical
> pixels. The window may appear smaller on HiDPI displays, but rendering will be
> pixel-perfect with no interpolation or scaling artifacts.

### 2. `pyglet/window/win32/__init__.py` — Three changes in `_create()` and event handlers

**a) Force `_dpi = 96` during window creation (line ~200):**

```python
# Before
self._dpi = self._screen.get_dpi()

# After
if pyglet.options.dpi_scaling == "none":
    self._dpi = 96
else:
    self._dpi = self._screen.get_dpi()
```

This makes `Window.scale` return `1.0` (since `scale = _dpi / 96`), and
`_client_to_window_size` calculates window chrome at the base DPI, so the client area
matches the requested size exactly.

**b) Skip `WM_GETDPISCALEDSIZE` (line ~1424):**

```python
# Before
if pyglet.options.dpi_scaling == "stretch":
    return None

# After
if pyglet.options.dpi_scaling in ("stretch", "none"):
    return None
```

Prevents Windows from suggesting a scaled window size before a DPI change.

**c) Ignore `WM_DPICHANGED` (line ~1451):**

```python
# Added at the top of the handler, before any state mutation:
if pyglet.options.dpi_scaling == "none":
    return 1
```

Prevents the window from resizing or updating `_dpi` when dragged between monitors with
different DPI values. The window stays at its original pixel size.

## Behavior comparison

| | `"platform"` (default) | `"stretch"` | `"none"` |
|---|---|---|---|
| 400x300 window at 125% | | | |
| `get_size()` | (400, 300) | (400, 300) | (400, 300) |
| `get_framebuffer_size()` | (500, 375) | (500, 375) | **(400, 300)** |
| `scale` | 1.25 | 1.25 | **1.0** |
| `get_pixel_ratio()` | 1.25 | 1.25 | **1.0** |
| Rendering | Sharp but scaled | Blurry (stretched) | **Pixel-perfect** |
| Mouse coords | Logical (0-400) | Logical (0-400) | **Physical (0-400)** |
| Window on screen | 400 logical px | 400 logical px | **Physically smaller** |

