### PR TITLE
Doc updates and minor refactors

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,6 +51,7 @@ If you are migrating from an older version of pyglet, please read through
    programming_guide/shapes
    programming_guide/models
    programming_guide/resources
+   programming_guide/texture
    programming_guide/rendering
    programming_guide/events
    programming_guide/gui

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,6 +65,7 @@ If you are migrating from an older version of pyglet, please read through
    programming_guide/options
    programming_guide/debug
    programming_guide/migration
+   programming_guide/migration2
    programming_guide/pyodide
 
 .. toctree::
@@ -86,6 +87,7 @@ If you are migrating from an older version of pyglet, please read through
    modules/input
    modules/math
    modules/media
+   modules/models
    modules/resource
    modules/sprite
    modules/shapes

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -76,6 +76,7 @@ If you are migrating from an older version of pyglet, please read through
    modules/pyglet
    modules/app
    modules/clock
+   modules/config/index
    modules/display
    modules/customtypes
    modules/enums

--- a/doc/internal/media_manual.rst
+++ b/doc/internal/media_manual.rst
@@ -75,7 +75,7 @@ A silent audio driver that consumes, but does not play back any audio is also
 available.
 
 If your source contains video, and you are using a :class:`~pyglet.media.VideoPlayer`
-then the player will contain a :meth:`~pyglet.media.VideoPlayer.texture`
+then the player will contain a :attr:`~pyglet.media.player.VideoPlayer.texture`
 property returning the current video frame.
 
 The player has an internal `master clock` which is used to synchronize the
@@ -83,11 +83,11 @@ video and the audio. The audio synchronization is delegated to the
 ``AudioPlayer``. More info found below. The video synchronization is made by
 asking the :class:`~pyglet.media.Source` for the next video timestamp.
 The player then schedules on pyglet event loop a
-call to its :meth:`~pyglet.media.AudioPlayer.update_texture` with a delay
+call to its :meth:`~pyglet.media.player.VideoPlayer.update_texture` with a delay
 equal to the difference between the next video timestamp and the master clock
 current time.
 
-When :meth:`~pyglet.media.AudioPlayer.update_texture` is called, we will
+When :meth:`~pyglet.media.player.VideoPlayer.update_texture` is called, we will
 check if the actual master clock time is not too late compared to the video
 timestamp. This could happen if the loop was very busy and the function could
 not be called on time. In this case, the frame would be skipped until we find
@@ -309,21 +309,21 @@ When the client code runs ``player.play()``:
 The :class:`~pyglet.media.player.AudioPlayer` will check if there is an audio track
 on the media. If so it will instantiate an ``AudioPlayer`` appropriate for the
 available sound driver on the platform. It will create an empty
-:class:`~pyglet.image.Texture` if the media contains video frames and will
-schedule its :meth:`~pyglet.media.AudioPlayer.update_texture` to be called
+:class:`~pyglet.graphics.texture.Texture` if the media contains video frames and will
+schedule its :meth:`~pyglet.media.player.VideoPlayer.update_texture` to be called
 immediately. Finally it will start the master clock.
 
 The ``AudioPlayer`` will start playing
 :ref:`as described above <audioplayer-play>`.
 
-When the :meth:`~pyglet.media.VideoPlayer.update_texture` method is called,
+When the :meth:`~pyglet.media.player.VideoPlayer.update_texture` method is called,
 the next video timestamp will be checked with the master clock. We allow a
 delay up to the frame duration. If the master clock is beyond that time, the
 frame will be skipped. We will check the following frames for its timestamp
 until we find the appropriate frame for the master clock time. We will set the
 :attr:`~pyglet.media.player.VideoPlayer.texture` to the new video frame. We will
 check for the next video frame timestamp and we will schedule a new call to
-:meth:`~pyglet.media.VideoPlayer.update_texture` with a delay equals to the
+:meth:`~pyglet.media.player.VideoPlayer.update_texture` with a delay equals to the
 difference between the next video timestamps and the master clock time.
 
 Helpful tools

--- a/doc/modules/config/base.rst
+++ b/doc/modules/config/base.rst
@@ -1,0 +1,6 @@
+pyglet.config.base
+==================
+
+.. automodule:: pyglet.config.base
+  :members:
+  :undoc-members:

--- a/doc/modules/config/gl.rst
+++ b/doc/modules/config/gl.rst
@@ -1,0 +1,6 @@
+pyglet.config.gl
+================
+
+.. automodule:: pyglet.config.gl
+  :members:
+  :undoc-members:

--- a/doc/modules/config/index.rst
+++ b/doc/modules/config/index.rst
@@ -1,0 +1,14 @@
+pyglet.config
+=============
+
+.. rubric:: Submodules
+
+.. toctree::
+   :maxdepth: 1
+
+   base
+   gl
+
+.. automodule:: pyglet.config
+  :members:
+  :undoc-members:

--- a/doc/modules/dialog.rst
+++ b/doc/modules/dialog.rst
@@ -12,6 +12,8 @@ Classes
 
   .. rubric:: Methods
 
+  .. automethod:: __init__
+
   .. automethod:: open
 
   .. rubric:: Events
@@ -22,6 +24,8 @@ Classes
   :show-inheritance:
 
   .. rubric:: Methods
+
+  .. automethod:: __init__
 
   .. automethod:: open
 

--- a/doc/modules/font/group.rst
+++ b/doc/modules/font/group.rst
@@ -1,0 +1,6 @@
+pyglet.font.group
+=================
+
+.. automodule:: pyglet.font.group
+  :members:
+  :undoc-members:

--- a/doc/modules/graphics/atlas.rst
+++ b/doc/modules/graphics/atlas.rst
@@ -1,5 +1,5 @@
 pyglet.graphics.atlas
-==================
+=====================
 
 .. automodule:: pyglet.graphics.atlas
   :members:

--- a/doc/modules/graphics/index.rst
+++ b/doc/modules/graphics/index.rst
@@ -7,6 +7,8 @@ pyglet.graphics
    :maxdepth: 1
 
    allocation
+   atlas
+   draw
    framebuffer
    shader
    vertexbuffer

--- a/doc/modules/graphics/index.rst
+++ b/doc/modules/graphics/index.rst
@@ -11,6 +11,7 @@ pyglet.graphics
    draw
    framebuffer
    shader
+   texture
    vertexbuffer
    vertexdomain
 

--- a/doc/modules/graphics/texture.rst
+++ b/doc/modules/graphics/texture.rst
@@ -1,18 +1,6 @@
 pyglet.graphics.texture
 =======================
 
-.. py:module:: pyglet.graphics.texture
-
-.. py:class:: Texture
-
-.. py:class:: TextureRegion
-
-.. py:class:: TextureArrayRegion
-
-.. py:class:: TextureArray
-
-.. py:class:: Texture3D
-
-.. py:class:: TextureGrid
-
-.. py:class:: CompressedTexture
+.. automodule:: pyglet.graphics.texture
+  :members:
+  :undoc-members:

--- a/doc/modules/graphics/texture.rst
+++ b/doc/modules/graphics/texture.rst
@@ -1,0 +1,18 @@
+pyglet.graphics.texture
+=======================
+
+.. py:module:: pyglet.graphics.texture
+
+.. py:class:: Texture
+
+.. py:class:: TextureRegion
+
+.. py:class:: TextureArrayRegion
+
+.. py:class:: TextureArray
+
+.. py:class:: Texture3D
+
+.. py:class:: TextureGrid
+
+.. py:class:: CompressedTexture

--- a/doc/modules/graphics/vertexbuffer.rst
+++ b/doc/modules/graphics/vertexbuffer.rst
@@ -1,6 +1,6 @@
 pyglet.graphics.vertexbuffer
 ============================
 
-.. automodule:: pyglet.graphics.vertexbuffer
+.. automodule:: pyglet.graphics.buffer
   :members:
   :undoc-members:

--- a/doc/modules/media.rst
+++ b/doc/modules/media.rst
@@ -128,7 +128,10 @@ Functions
 ---------
 
 .. autofunction:: get_audio_driver
-.. autofunction:: load
+.. autofunction:: load_audio
+.. autofunction:: load_video
+.. autofunction:: play_audio
+.. autofunction:: play_video
 .. autofunction:: have_ffmpeg
 
 Exceptions

--- a/doc/modules/media.rst
+++ b/doc/modules/media.rst
@@ -14,6 +14,12 @@ pyglet.media
 
 .. automodule:: pyglet.media
 
+.. py:class:: pyglet.media.AudioPlayer
+   :canonical: pyglet.media.player.AudioPlayer
+
+.. py:class:: pyglet.media.VideoPlayer
+   :canonical: pyglet.media.player.VideoPlayer
+
 Classes
 -------
 

--- a/doc/modules/resource.rst
+++ b/doc/modules/resource.rst
@@ -3,7 +3,6 @@ pyglet.resource
 
 .. automodule:: pyglet.resource
   :members:
-  :noindex:
   :undoc-members:
 
 
@@ -17,7 +16,8 @@ Functions
 .. autofunction:: image
 .. autofunction:: animation
 .. autofunction:: texture
-.. autofunction:: media
+.. autofunction:: audio
+.. autofunction:: video
 .. autofunction:: shader
 .. autofunction:: html
 .. autofunction:: attributed

--- a/doc/programming_guide/examplegame.rst
+++ b/doc/programming_guide/examplegame.rst
@@ -650,7 +650,7 @@ else play the game.  One way to provide visual feedback is to show an engine
 flame behind the player while the player is thrusting.
 
 Loading the flame texture
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The player will now be made of two sprites.  There’s nothing preventing us
 from letting a Sprite own another Sprite, so we’ll just give Player an

--- a/doc/programming_guide/gui.rst
+++ b/doc/programming_guide/gui.rst
@@ -42,7 +42,7 @@ This widget can also take an optional image for 'hover', but we'll skip that for
     )
 
 We now have a PushButton widget, but it won't yet do anything. It will be drawn on
-screen, however, if included as part of a :py:class:`~pyglet.graphics.Batch` as shown
+screen, however, if included as part of a :py:class:`~pyglet.graphics.draw.Batch` as shown
 above. In order to get the widget to react to the mouse, we need to set it to handle
 events dispatched by the Window::
 

--- a/doc/programming_guide/image.rst
+++ b/doc/programming_guide/image.rst
@@ -230,7 +230,7 @@ the following obtains the first four frames in the animation::
     start_frames = explosion_seq[:4]
 
 For efficient rendering, convert the grid into a
-:py:class:`~pyglet.graphics.TextureGrid` (see
+:py:class:`~pyglet.graphics.texture.TextureGrid` (see
 :ref:`guide_texture-grids`)::
 
     explosion_tex_seq = pyglet.graphics.TextureGrid.from_image_grid(explosion_seq)

--- a/doc/programming_guide/image.rst
+++ b/doc/programming_guide/image.rst
@@ -1,22 +1,14 @@
-Images and Sprites
-==================
+Images and Image Data
+=====================
 
 pyglet provides functions for loading and saving images in various formats
-using native operating system services.  If the `Pillow`_ library is installed,
-many additional formats can be supported.   pyglet also includes built-in
-codecs for loading PNG and BMP without external dependencies.
+using native operating system services. If the `Pillow`_ library is installed,
+many additional formats can be supported. pyglet also includes built-in codecs
+for loading PNG and BMP without external dependencies.
 
-In addition to loading, pyglet also supports the following operations
-for both OpenGL textures and framebuffers:
-
-* converting to pyglet image objects
-* saving to disk as screenshots
-* manipulation as image data
-* converting to :py:class:`bytes` of raw pixel data
-
-For most users, the :py:class:`~pyglet.sprite.Sprite` class is the best way
-to draw an image. One or more instances may draw the same image data with
-individually configured values for position, scaling, rotation, and more.
+This page focuses on CPU-side image data, such as loading files and accessing
+or modifying pixel bytes. For drawing images or working with GPU textures, see
+:doc:`texture`.
 
 .. _Pillow: https://pillow.readthedocs.io
 
@@ -28,18 +20,17 @@ Images can be loaded using the :py:func:`pyglet.image.load` function::
     kitten = pyglet.image.load('kitten.png')
 
 If you are distributing your application with included images, consider
-using the :py:mod:`pyglet.resource` module (see  :ref:`guide_resources`).
+using the :py:mod:`pyglet.resource` module (see :ref:`guide_resources`).
 
 Without any additional arguments, :py:func:`pyglet.image.load` will
 attempt to load the filename specified using any available image decoder.
-This will allow you to load PNG, GIF, JPEG, BMP and DDS files,
-and possibly other files as well, depending on your operating system
-and additional installed modules (see the next section for details).
+This allows loading PNG, GIF, JPEG, BMP, DDS, KTX2, and other formats
+depending on your operating system and installed modules.
 If the image cannot be loaded, an
 :py:class:`~pyglet.image.codecs.ImageDecodeException` will be raised.
 
-You can load an image from any file-like object providing a `read` method by
-specifying the `file` keyword parameter::
+You can load an image from any file-like object providing a ``read`` method by
+specifying the ``file`` keyword parameter::
 
     kitten_stream = open('kitten.png', 'rb')
     kitten = pyglet.image.load('kitten.png', file=kitten_stream)
@@ -48,146 +39,13 @@ In this case the filename ``kitten.png`` is optional, but gives a hint to
 the decoder as to the file type (it is otherwise unused when a file object
 is provided).
 
-Displaying images
------------------
-
-Image drawing is usually done in the window's
-:py:meth:`~pyglet.window.Window.on_draw` event handler.
-It is possible to draw individual images directly, but usually you will
-want to create a "sprite" for each appearance of the image on-screen.
-
-Sprites
-^^^^^^^
-
-A Sprite is a full featured class for displaying instances of Images or
-Animations in the window. Image and Animation instances are mainly concerned
-with the image data (size, pixels, etc.), whereas Sprites also include
-additional properties. These include x/y location, scale, rotation, opacity,
-color tint, visibility, and both horizontal and vertical scaling.
-Multiple sprites can share the same image; for example, hundreds of bullet
-sprites might share the same bullet image.
-
-A Sprite is constructed given an image or animation, and can be directly
-drawn with the :py:meth:`~pyglet.sprite.Sprite.draw` method::
-
-    sprite = pyglet.sprite.Sprite(img=image, x=100, y=50)
-
-    @window.event
-    def on_draw():
-        window.clear()
-        sprite.draw()
-
-If created with an animation, sprites automatically handle displaying
-the most up-to-date frame of the animation.  The following example uses a
-scheduled function to gradually move the Sprite across the screen::
-
-    def update(dt):
-        # Move 10 pixels per second
-        sprite.x += dt * 10
-
-    # Call update 60 times a second
-    pyglet.clock.schedule_interval(update, 1/60.)
-
-If you need to draw many sprites, using a :py:class:`~pyglet.graphics.Batch`
-to draw them all at once is strongly recommended.  This is far more efficient
-than calling :py:meth:`~pyglet.sprite.Sprite.draw` on each of them in a loop::
-
-    batch = pyglet.graphics.Batch()
-
-    sprites = [pyglet.sprite.Sprite(image, batch=batch),
-               pyglet.sprite.Sprite(image, batch=batch),
-               # ...  ]
-
-    @window.event
-    def on_draw():
-        window.clear()
-        batch.draw()
-
-When sprites are collected into a batch, no guarantee is made about the order
-in which they will be drawn.  If you need to ensure some sprites are drawn
-before others (for example, landscape tiles might be drawn before character
-sprites, which might be drawn before some particle effect sprites), use two
-or more :py:class:`~pyglet.graphics.Group` objects to specify the
-draw order::
-
-    batch = pyglet.graphics.Batch()
-    background = pyglet.graphics.Group(order=0)
-    foreground = pyglet.graphics.Group(order=1)
-
-    sprites = [pyglet.sprite.Sprite(image, batch=batch, group=background),
-               pyglet.sprite.Sprite(image, batch=batch, group=background),
-               pyglet.sprite.Sprite(image, batch=batch, group=foreground),
-               pyglet.sprite.Sprite(image, batch=batch, group=foreground),
-               # ...]
-
-    @window.event
-    def on_draw():
-        window.clear()
-        batch.draw()
-
-For best performance, you should use as few batches and groups as required.
-(See the :ref:`guide_graphics` section for more details on batch
-and group rendering). This will reduce the number of internal and OpenGL
-operations for drawing each frame.
-
-In addition, try to combine your images into as few textures as possible;
-for example, by loading images with :py:func:`pyglet.resource.image`
-(see :ref:`guide_resources`) or with :ref:`guide_texture-bins-and-atlases`).
-A common pitfall is to use the :py:func:`pyglet.image.load` method to load
-a large number of images.  This will cause a separate texture to be created
-for each image loaded, resulting in a lot of OpenGL texture binding overhead
-for each frame.
-
-Simple image blitting
-^^^^^^^^^^^^^^^^^^^^^
-
-Drawing images directly is less efficient, but may be adequate for
-simple cases. Images can be drawn into a window with the
-:py:meth:`~pyglet.image.AbstractImage.blit` method::
-
-    @window.event
-    def on_draw():
-        window.clear()
-        image.blit(x, y)
-
-The `x` and `y` coordinates locate where to draw the anchor point of the
-image.  For example, to center the image at ``(x, y)``::
-
-    kitten.anchor_x = kitten.width // 2
-    kitten.anchor_y = kitten.height // 2
-    kitten.blit(x, y)
-
-You can also specify an optional `z` component to the
-:py:meth:`~pyglet.image.AbstractImage.blit` method.
-This has no effect unless you have enabled depth testing.  In the following example,
-the second image is drawn *behind* the first, even though it is drawn after it::
-
-    from pyglet.graphics.api.gl import *
-    glEnable(GL_DEPTH_TEST)
-
-    kitten.blit(x, y, 0)
-    kitten.blit(x, y, -0.5)
-
-The default pyglet projection has a depth range of (-8192, 8192) -- images drawn
-with a z value outside this range will not be visible, regardless of whether
-depth testing is enabled or not. (You can create your own Window projection matrix
-if you have specific needs).
-
-Images with an alpha channel can be blended with the existing framebuffer.  To
-do this you need to supply OpenGL with a blend equation.  The following code
-fragment implements the most common form of alpha blending, however other
-techniques are also possible::
-
-    from pyglet.graphics.api.gl import *
-    glEnable(GL_BLEND)
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-
-You would only need to call the code above once during your program, before
-you draw any images (this is not necessary when using only sprites).
+.. note::
+    ``image.blit`` and ``Texture.blit`` were removed in pyglet 3.0. To draw
+    images, create and draw a :py:class:`~pyglet.sprite.Sprite` (see :doc:`texture`).
 
 Supported image decoders
 ------------------------
-The following table shows which codecs are available in pyglet. 
+The following table shows common codecs available in pyglet.
 
     .. list-table::
         :header-rows: 1
@@ -198,7 +56,10 @@ The following table shows which codecs are available in pyglet.
         * - ``pyglet.image.codecs.dds``
           - ``DDSImageDecoder``
           - Reads Microsoft DirectDraw Surface files containing compressed
-            textures
+            textures.
+        * - ``pyglet.image.codecs.ktx2``
+          - ``KTX2ImageDecoder``
+          - Reads Khronos KTX2 compressed texture files.
         * - ``pyglet.image.codecs.wic``
           - ``WICDecoder``
           - Uses Windows Imaging Component services to decode images.
@@ -207,13 +68,13 @@ The following table shows which codecs are available in pyglet.
           - Uses Windows GDI+ services to decode images.
         * - ``pyglet.image.codecs.gdkpixbuf2``
           - ``GdkPixbuf2ImageDecoder``
-          - Uses the GTK-2.0 GDK functions to decode images.
+          - Uses GTK GDK-Pixbuf to decode images.
+        * - ``pyglet.image.codecs.quartz``
+          - ``QuartzImageDecoder``
+          - Uses macOS Quartz services to decode images.
         * - ``pyglet.image.codecs.pil``
           - ``PILImageDecoder``
-          - Wrapper interface around PIL Image class.
-        * - ``pyglet.image.codecs.quicktime``
-          - ``QuickTimeImageDecoder``
-          - Uses Mac OS X QuickTime to decode images.
+          - Wrapper interface around PIL Image.
         * - ``pyglet.image.codecs.png``
           - ``PNGImageDecoder``
           - PNG decoder written in pure Python.
@@ -222,30 +83,25 @@ The following table shows which codecs are available in pyglet.
           - BMP decoder written in pure Python.
 
 Each of these classes registers itself with :py:mod:`pyglet.image` with
-the filename extensions it supports.  The :py:func:`~pyglet.image.load`
-function will try each image decoder with a matching file extension first,
-before attempting the other decoders.  Only if every image decoder fails
-to load an image will :py:class:`~pyglet.image.codecs.ImageDecodeException`
+the filename extensions it supports. The :py:func:`~pyglet.image.load`
+function tries matching extensions first, before attempting other decoders.
+
+Only if every image decoder fails to load an image will :py:class:`~pyglet.image.codecs.ImageDecodeException`
 be raised (the origin of the exception will be the first decoder that
 was attempted).
 
-You can override this behaviour and specify a particular decoding instance to
-use.  For example, in the following example the pure Python PNG decoder is
-always used rather than the operating system's decoder::
+You can override this behavior and specify a particular decoding instance.
+For example, to always use the pure Python PNG decoder::
 
     from pyglet.image.codecs.png import PNGImageDecoder
     kitten = pyglet.image.load('kitten.png', decoder=PNGImageDecoder())
 
-This use is not recommended unless your application has to work around
-specific deficiences in an operating system decoder.
-
 Supported image formats
 -----------------------
 
-The following table lists the image formats that can be loaded on each
-operating system.  If Pillow is installed, any additional formats it
-supports can also be read.  See the `Pillow docs`_ for a list of such
-formats.
+The following table lists common image formats that can be loaded on each
+operating system. If Pillow is installed, any additional formats it
+supports can also be read. See the `Pillow docs`_ for a list of such formats.
 
 .. _Pillow docs: http://pillow.readthedocs.io/
 
@@ -267,11 +123,6 @@ formats.
           - X
           - X
           - X
-        * - ``.exif``
-          - Exif
-          - X
-          -
-          -
         * - ``.gif``
           - Graphics Interchange Format
           - X
@@ -282,315 +133,78 @@ formats.
           - X
           - X
           - X
-        * - ``.jp2 .jpx``
-          - JPEG 2000
-          -
-          - X
-          -
-        * - ``.pcx``
-          - PC Paintbrush Bitmap Graphic
-          -
-          - X
-          -
         * - ``.png``
           - Portable Network Graphic
           - X
           - X
           - X
-        * - ``.pnm``
-          - PBM Portable Any Map Graphic Bitmap
-          -
-          -
-          - X
-        * - ``.ras``
-          - Sun raster graphic
-          -
-          -
-          - X
-        * - ``.tga``
-          - Truevision Targa Graphic
-          -
-          - X
-          -
         * - ``.tif .tiff``
           - Tagged Image File Format
           - X
           - X
           - X
-        * - ``.xbm``
-          - X11 bitmap
-          -
+        * - ``.ktx2``
+          - Khronos Texture 2
           - X
-          - X
-        * - ``.xpm``
-          - X11 icon
-          -
           - X
           - X
 
-The only supported save format is PNG, unless PIL is installed, in which case
-any format it supports can be written.
+The only built-in save format is PNG, unless Pillow is installed, in which
+case additional formats can also be written.
 
-.. [#linux] Requires GTK 2.0 or later.
-
-.. [#dds] Only S3TC compressed surfaces are supported.  Depth, volume and cube
-          textures are not supported.
+.. [#linux] Requires GTK 2.0 or later for native decoding.
+.. [#dds] Only S3TC compressed surfaces are supported. Depth, volume, and cube
+          textures are not supported by the DDS loader.
 
 Working with images
 -------------------
 
-The :py:func:`pyglet.image.load` function returns an
-:py:class:`~pyglet.image.AbstractImage`. The actual class of the object depends
-on the decoder that was used, but all loaded imageswill have the following
-attributes:
+The :py:func:`pyglet.image.load` function usually returns either
+:py:class:`~pyglet.image.ImageData` or
+:py:class:`~pyglet.image.CompressedImageData`.
+
+All loaded images have the following attributes:
 
 `width`
     The width of the image, in pixels.
 `height`
     The height of the image, in pixels.
 `anchor_x`
-    Distance of the anchor point from the left edge of the image, in pixels
+    Distance of the anchor point from the left edge of the image, in pixels.
 `anchor_y`
-    Distance of the anchor point from the bottom edge of the image, in pixels
+    Distance of the anchor point from the bottom edge of the image, in pixels.
 
 The anchor point defaults to (0, 0), though some image formats may contain an
 intrinsic anchor point.  The anchor point is used to align the image to a
 point in space when drawing it.
 
-You may only want to use a portion of the complete image.  You can use the
-:py:meth:`~pyglet.image.AbstractImage.get_region` method to return an image
-of a rectangular region of a source image::
+You may only want to use a portion of an image. You can use
+:py:meth:`~pyglet.image.ImageData.get_region` to return a region::
 
     image_part = kitten.get_region(x=10, y=10, width=100, height=100)
 
-This returns an image with dimensions 100x100.  The region extracted from
-`kitten` is aligned such that the bottom-left corner of the rectangle is 10
-pixels from the left and 10 pixels from the bottom of the image.
+This returns an image with dimensions 100x100. The region extracted from
+``kitten`` is aligned so the bottom-left corner of the rectangle is 10 pixels
+from the left and 10 pixels from the bottom.
 
-Image regions can be used as if they were complete images.  Note that changes
-to an image region may or may not be reflected on the source image, and
-changes to the source image may or may not be reflected on any region images.
-You should not assume either behaviour.
+Image regions can be used as regular images. Changes to a region may or may
+not be reflected in the source image (and vice versa), so you should not
+assume shared write-through behavior.
 
-The AbstractImage hierarchy
----------------------------
-
-The following sections deal with the various concrete image classes.  All
-images subclass :py:class:`~pyglet.image.AbstractImage`, which provides
-the basic interface described in previous sections.
-
-.. figure:: img/abstract_image.png
-
-    The :py:class:`~pyglet.image.AbstractImage` class hierarchy.
-
-An image of any class can be converted into a :py:class:`~pyglet.image.Texture`
-or :py:class:`~pyglet.image.ImageData` using the
-:py:meth:`~pyglet.image.AbstractImage.get_texture` and
-:py:meth:`~pyglet.image.ImageData.get_image_data` methods defined on
-:py:class:`~pyglet.image.AbstractImage`.  For example, to load an image
-and work with it as an OpenGL texture::
-
-    kitten = pyglet.image.load('kitten.png').get_texture()
-
-There is no penalty for accessing one of these methods if object is already
-of the requested class.  The following table shows how concrete classes are
-converted into other classes:
-
-    .. list-table::
-        :header-rows: 1
-        :stub-columns: 1
-
-        * - Original class
-          - ``.get_texture()``
-          - ``.get_image_data()``
-        * - :py:class:`~pyglet.image.Texture`
-          - No change
-          - ``glGetTexImage2D``
-        * - :py:class:`~pyglet.image.TextureRegion`
-          - No change
-          - ``glGetTexImage2D``, crop resulting image.
-        * - :py:class:`~pyglet.image.ImageData`
-          - ``glTexImage2D`` [1]_
-          - No change
-        * - :py:class:`~pyglet.image.ImageDataRegion`
-          - ``glTexImage2D`` [1]_
-          - No change
-        * - :py:class:`~pyglet.image.CompressedImageData`
-          - ``glCompressedTexImage2D`` [2]_
-          - N/A [3]_
-        * - :py:class:`~pyglet.image.BufferImage`
-          - ``glCopyTexSubImage2D`` [4]_
-          - ``glReadPixels``
-
-You should try to avoid conversions which use ``glGetTexImage2D`` or
-``glReadPixels``, as these can impose a substantial performance penalty by
-transferring data in the "wrong" direction of the video bus, especially on
-older hardware.
-
-.. [1]  :py:class:`~pyglet.image.ImageData` caches the texture for future use, so there is no
-        performance penalty for repeatedly blitting an
-        :py:class:`~pyglet.image.ImageData`.
-
-.. [2]  If the required texture compression extension is not present, the
-        image is decompressed in memory and then supplied to OpenGL via
-        ``glTexImage2D``.
-
-.. [3]  It is not currently possible to retrieve :py:class:`~pyglet.image.ImageData` for compressed
-        texture images.  This feature may be implemented in a future release
-        of pyglet.  One workaround is to create a texture from the compressed
-        image, then read the image data from the texture; i.e.,
-        ``compressed_image.get_texture().get_image_data()``.
-
-.. [4]  :py:class:`~pyglet.image.BufferImageMask` cannot be converted to
-        :py:class:`~pyglet.image.Texture`.
-
-Accessing or providing pixel data
----------------------------------
-
-The :py:class:`~pyglet.image.ImageData` class represents an image as a string
-or sequence of pixel data, or as a ctypes pointer.  Details such as the pitch
-and component layout are also stored in the class.  You can access an
-:py:class:`~pyglet.image.ImageData` object for any image with
-:py:meth:`~pyglet.image.ImageData.get_image_data`::
-
-    kitten = pyglet.image.load('kitten.png').get_image_data()
-
-The design of :py:class:`~pyglet.image.ImageData` is to allow applications
-to access the detail in the format they prefer, rather than having to
-understand the many formats that each operating system and OpenGL make use of.
-
-The `pitch` and `format` properties determine how the bytes are arranged.
-`pitch` gives the number of bytes between each consecutive row.  The data is
-assumed to run from left-to-right, bottom-to-top, unless `pitch` is negative,
-in which case it runs from left-to-right, top-to-bottom.  There is no need for
-rows to be tightly packed; larger `pitch` values are often used to align each
-row to machine word boundaries.
-
-The `format` property gives the number and order of color components.  It is a
-string of one or more of the letters corresponding to the components in the
-following table:
-
-    = ============
-    R Red
-    G Green
-    B Blue
-    A Alpha
-    L Luminance
-    I Intensity
-    = ============
-
-For example, a format string of ``"RGBA"`` corresponds to four bytes of
-color data, in the order red, green, blue, alpha.  Note that machine
-endianness has no impact on the interpretation of a format string.
-
-The length of a format string always gives the number of bytes per pixel.  So,
-the minimum absolute pitch for a given image is ``len(kitten.format) *
-kitten.width``.
-
-To retrieve pixel data in a particular format, use the `get_bytes` method,
-specifying the desired format and pitch. The following example reads tightly
-packed rows in ``RGB`` format (the alpha component, if any, will be
-discarded)::
-
-    kitten = kitten.get_image_data()
-    data = kitten.get_bytes('RGB', kitten.width * 3)
-
-`data` always returns a bytes object, however pixel data can be set from a
-ctypes array, stdlib array, list of byte data, string, or ctypes pointer.
-To set the image data use `set_bytes`, again specifying the format and pitch::
-
-    kitten.set_bytes('RGB', kitten.width * 3, data)
-
-You can also create :py:class:`~pyglet.image.ImageData` directly, by providing
-each of these attributes to the constructor. This is any easy way to load
-textures into OpenGL from other programs or libraries.
-
-Performance concerns
-^^^^^^^^^^^^^^^^^^^^
-
-pyglet can use several methods to transform pixel data from one format to
-another.  It will always try to select the most efficient means.  For example,
-when providing texture data to OpenGL, the following possibilities are
-examined in order:
-
-1. Can the data be provided directly using a built-in OpenGL pixel format such
-   as ``GL_RGB`` or ``GL_RGBA``?
-2. Is there an extension present that handles this pixel format?
-3. Can the data be transformed with a single regular expression?
-4. If none of the above are possible, the image will be split into separate
-   scanlines and a regular expression replacement done on each; then the lines
-   will be joined together again.
-
-The following table shows which image formats can be used directly with steps
-1 and 2 above, as long as the image rows are tightly packed (that is, the
-pitch is equal to the width times the number of components).
-
-    .. list-table::
-        :header-rows: 1
-
-        * - Format
-          - Required extensions
-        * - ``"I"``
-          -
-        * - ``"L"``
-          -
-        * - ``"LA"``
-          -
-        * - ``"R"``
-          -
-        * - ``"G"``
-          -
-        * - ``"B"``
-          -
-        * - ``"A"``
-          -
-        * - ``"RGB"``
-          -
-        * - ``"RGBA"``
-          -
-        * - ``"ARGB"``
-          - ``GL_EXT_bgra`` and ``GL_APPLE_packed_pixels``
-        * - ``"ABGR"``
-          - ``GL_EXT_abgr``
-        * - ``"BGR"``
-          - ``GL_EXT_bgra``
-        * - ``"BGRA"``
-          - ``GL_EXT_bgra``
-
-If the image data is not in one of these formats, a regular expression will be
-constructed to pull it into one.  If the rows are not tightly packed, or if
-the image is ordered from top-to-bottom, the rows will be split before the
-regular expression is applied.  Each of these may incur a performance penalty
--- you should avoid such formats for real-time texture updates if possible.
-
-Image sequences and atlases
----------------------------
-
-Sometimes a single image is used to hold several images.  For example, a
-"sprite sheet" is an image that contains each animation frame required for a
-character sprite animation.
-
-pyglet provides convenience classes for extracting the individual images from
-such a composite image as if it were a simple Python sequence.  Discrete
-images can also be packed into one or more larger textures with texture bins
-and atlases.
-
-.. figure:: img/image_sequence.png
-
-    The AbstractImageSequence class hierarchy.
+.. _guide_image-grids:
 
 Image grids
-^^^^^^^^^^^
+-----------
 
 An "image grid" is a single image which is divided into several smaller images
-by drawing an imaginary grid over it.  The following image shows an image that
+by drawing an imaginary grid over it. The following image shows an image that
 can be used for an asteroid explosion animation.
 
 .. figure:: img/explosion.png
 
     An image consisting of eight animation frames arranged in a grid.
 
-This image has one row and eight columns.  This is all the information you
+This image has one row and eight columns. This is all the information you
 need to create an :py:class:`~pyglet.image.ImageGrid` with::
 
     explosion = pyglet.image.load('explosion.png')
@@ -610,95 +224,110 @@ sequence, or as a (row, column) tuple; as shown in the following diagram.
     An image grid with several rows and columns, and the slices that can be
     used to access it.
 
-Image sequences can be sliced like any other sequence in Python.  For example,
+Image sequences can be sliced like any other sequence in Python. For example,
 the following obtains the first four frames in the animation::
 
     start_frames = explosion_seq[:4]
 
-For efficient rendering, you should use a
-:py:class:`~pyglet.image.TextureGrid`.
-This uses a single texture for the grid, and each individual image returned
-from a slice will be a :py:class:`~pyglet.image.TextureRegion`::
+For efficient rendering, convert the grid into a
+:py:class:`~pyglet.graphics.TextureGrid` (see
+:ref:`guide_texture-grids`)::
 
-    explosion_tex_seq = image.TextureGrid(explosion_seq)
+    explosion_tex_seq = pyglet.graphics.TextureGrid.from_image_grid(explosion_seq)
 
-Because :py:class:`~pyglet.image.TextureGrid` is also a
-:py:class:`~pyglet.image.Texture`, you can use it either as individual images
-or as the whole grid at once.
+This uses one underlying texture for the entire grid, and each image returned
+from a slice is a texture region.
 
-3D textures
-^^^^^^^^^^^
+Animations
+----------
 
-:py:class:`~pyglet.image.TextureGrid` is extremely efficient for drawing many
-sprites from a single texture.  One problem you may encounter, however,
-is bleeding between adjacent images.
+The :py:class:`~pyglet.image.Animation` class manages a list of
+:py:class:`~pyglet.image.AnimationFrame` objects, each of
+which references an image and a duration (in seconds).  The storage of
+the images is up to the application developer: they can each be discrete, or
+packed into a texture atlas, or any other technique.
 
-When OpenGL renders a texture to the screen, by default it obtains each pixel
-color by interpolating nearby texels.  You can disable this behaviour by
-switching to the ``pyglet.enums.TextureFilter.NEAREST`` interpolation mode, however you then lose the
-benefits of smooth scaling, distortion, rotation and sub-pixel positioning.
+An animation can be loaded directly from a GIF 89a image file with
+:py:func:`~pyglet.image.load_animation` (supported on Linux, Mac OS X
+and Windows)
+::
 
-You can alleviate the problem by always leaving a 1-pixel clear border around
-each image frame.  This will not solve the problem if you are using
-mipmapping, however.  At this stage you will need a 3D texture.
+    animation = pyglet.image.load_animation('animation.gif')
+    first_frame = animation.frames[0]
+    duration = first_frame.duration
 
-You can create a 3D texture from any sequence of images, or from an
-:py:class:`~pyglet.image.ImageGrid`.  The images must all be of the same
-dimension, however they need not be powers of two (pyglet takes care of
-this by returning :py:class:`~pyglet.image.TextureRegion`
-as with a regular :py:class:`~pyglet.image.Texture`).
+The animation class is exposed as ``pyglet.image.Animation``
+(:py:class:`~pyglet.image.animation.Animation` in the API reference).
+To draw animations efficiently, use :py:class:`~pyglet.sprite.Sprite`
+(see :doc:`texture`).
 
-In the following example, the explosion texture from above is uploaded into a
-3D texture::
+Accessing or providing pixel data
+---------------------------------
 
-    explosion_3d = pyglet.image.Texture3D.create_for_image_grid(explosion_seq)
+The :py:class:`~pyglet.image.ImageData` class represents an image as pixel
+data bytes (or byte-like data), along with details such as pitch and component
+layout. You can access :py:class:`~pyglet.image.ImageData` for any image with
+:py:meth:`~pyglet.image.ImageData.get_image_data`::
 
-You could also have stored each image as a separate file and used
-:py:meth:`pyglet.image.Texture3D.create_for_images` to create the 3D texture.
+    kitten = pyglet.image.load('kitten.png').get_image_data()
 
-Once created, a 3D texture behaves like any other
-:py:class:`~pyglet.image.AbstractImageSequence`; slices return
-:py:class:`~pyglet.image.TextureRegion` for an image plane within the texture.
-Unlike a :py:class:`~pyglet.image.TextureGrid`, though, you cannot blit a
-:py:class:`~pyglet.image.Texture3D` in its entirety.
+The ``pitch`` and ``format`` properties determine how bytes are arranged.
+``pitch`` gives the number of bytes between each consecutive row. Data is
+assumed to run left-to-right, bottom-to-top, unless ``pitch`` is negative.
 
-.. _guide_texture-bins-and-atlases:
+The ``format`` property gives the number and order of color components. It is
+a string containing one or more of these letters:
 
-Texture bins and atlases
-^^^^^^^^^^^^^^^^^^^^^^^^
+    = =========
+    R Red
+    G Green
+    B Blue
+    A Alpha
+    L Luminance
+    I Intensity
+    = =========
 
-Image grids are useful when the artist has good tools to construct the larger
-images of the appropriate format, and the contained images all have the same
-size.  However it is often simpler to keep individual images as separate files
-on disk, and only combine them into larger textures at runtime for efficiency.
+For example, a format string of ``"RGBA"`` corresponds to four bytes per
+pixel in red/green/blue/alpha order.
 
-A :py:class:`~pyglet.image.atlas.TextureAtlas` is initially an empty texture,
-but images of any size can be added to it at any time.  The atlas takes care
-of tracking the "free" areas within the texture, and of placing images at
-appropriate locations within the texture to avoid overlap.
+To retrieve pixel data in a particular format, use ``get_bytes`` with format
+and pitch arguments::
 
-It's possible for a :py:class:`~pyglet.image.atlas.TextureAtlas` to run out
-of space for new images, so applications will need to either know the correct
-size of the texture to allocate initially, or maintain multiple atlases as
-each one fills up.
+    kitten = kitten.get_image_data()
+    data = kitten.get_bytes('RGB', kitten.width * 3)
 
-The :py:class:`~pyglet.image.atlas.TextureBin` class provides a simple means
-to manage multiple atlases. The following example loads a list of images,
-then inserts those images into a texture bin.  The resulting list is a list of
-:py:class:`~pyglet.image.TextureRegion` images that map
-into the larger shared texture atlases::
+``data`` is always returned as ``bytes``. To set image data, use ``set_bytes``::
 
-    images = [
-        pyglet.image.load('img1.png'),
-        pyglet.image.load('img2.png'),
-        # ...
-    ]
+    kitten.set_bytes('RGB', kitten.width * 3, data)
 
-    bin = pyglet.image.atlas.TextureBin()
-    images = [bin.add(image) for image in images]
+You can also create :py:class:`~pyglet.image.ImageData` directly by supplying
+width, height, format, and byte data.
 
-The :py:mod:`pyglet.resource` module (see :ref:`guide_resources`) uses
-texture bins internally to efficiently pack images automatically.
+Performance concerns
+^^^^^^^^^^^^^^^^^^^^
+
+pyglet can use several methods to transform pixel data from one format to
+another. It always tries to select the most efficient route.
+
+If image data is in a non-native format, conversion can require row splitting
+and component reordering on the CPU. This can be expensive for large images,
+so for performance-sensitive code it is best to keep a stable format/pitch
+where possible.
+
+Saving an image
+---------------
+
+Any image can be saved using the ``save`` method::
+
+    kitten.save('kitten.png')
+
+or, specifying a file-like object::
+
+    kitten_stream = open('kitten.png', 'wb')
+    kitten.save('kitten.png', file=kitten_stream)
+
+To save a screenshot of the current back buffer, see the framebuffer section
+in :doc:`texture`.
 
 Animations
 ----------
@@ -732,7 +361,7 @@ the window::
     window = pyglet.window.Window()
 
     animation = pyglet.image.load_animation('animation.gif')
-    bin = pyglet.image.atlas.TextureBin()
+    bin = pyglet.graphics.texture.atlas.TextureBin()
     animation.add_to_texture_bin(bin)
     sprite = pyglet.sprite.Sprite(img=animation)
 
@@ -753,252 +382,3 @@ includes:
 * a sample GIF animation file  (``dinosaur.gif``)
 
 .. _GitHub repository: https://github.com/pyglet/pyglet/
-
-
-Framebuffers
-------------
-To simplify working with framebuffers, pyglet provides the
-:py:class:`~pyglet.graphics.Framebuffer` and :py:class:`~pyglet.graphics.Renderbuffer`
-classes. These work as you would expect, and allow a simple way to add texture
-attachments. Attachment and target types can be specified as ::
-
-    import pyglet
-    from pyglet.enums import TextureFilter, FramebufferAttachment, ComponentFormat
-    from pyglet.graphics import Texture, Renderbuffer, Framebuffer
-
-    window = pyglet.window.Window()
-
-    # Prepare the buffers. One texture (for easy access), and one Renderbuffer:
-    color_buffer = Texture.create(width, height, filters=TextureFilter.NEAREST)
-    depth_buffer = Renderbuffer(window.context, width, height,
-                                component_format=ComponentFormat.D, bit_size=24)
-
-    # Create a Framebuffer, and attach:
-    framebuffer = Framebuffer(context=window.context)
-    framebuffer.attach_texture(color_buffer, attachment=FramebufferAttachment.COLOR0)
-    framebuffer.attach_renderbuffer(depth_buffer, attachment=FramebufferAttachment.DEPTH)
-
-    # When drawing:
-    framebuffer.bind()
-
-
-pyglet also provides a simple abstraction over the "default" framebuffer,
-as components of the :py:class:`~pyglet.image.AbstractImage` hierarchy.
-
-.. figure:: img/buffer_image.png
-
-    The :py:class:`~pyglet.image.BufferImage` hierarchy.
-
-* One or more color buffers, represented by
-  :py:class:`~pyglet.image.ColorBufferImage`
-* An optional depth buffer, represented by
-  :py:class:`~pyglet.image.DepthBufferImage`
-* An optional stencil buffer, with each bit represented by
-  :py:class:`~pyglet.image.BufferImageMask`
-
-You cannot create the buffer images directly; instead you must obtain
-instances via the :py:class:`~pyglet.image.BufferManager`.
-Use :py:func:`~pyglet.image.get_buffer_manager` to get this singleton::
-
-    buffers = image.get_buffer_manager()
-
-Only the back-left color buffer can be obtained (i.e., the front buffer is
-inaccessible, and stereo contexts are not supported by the buffer manager)::
-
-    color_buffer = buffers.get_color_buffer()
-
-This buffer can be treated like any other image.  For example, you could copy
-it to a texture, obtain its pixel data, save it to a file, and so on. This can
-be useful if you want to save a "screen shot" of the running application::
-
-    image_data = color_buffer.get_image_data()
-    image_data.save("screenshot.png")
-
-The depth buffer can be obtained similarly::
-
-    depth_buffer = buffers.get_depth_buffer()
-
-
-The auxiliary buffers and stencil bits are obtained by requesting one, which
-will then be marked as "in-use".  This permits multiple libraries and your
-application to work together without clashes in stencil bits or auxiliary
-buffer names.  For example, to obtain a free stencil bit::
-
-    mask = buffers.get_buffer_mask()
-
-The buffer manager maintains a weak reference to the buffer mask, so that when
-you release all references to it, it will be returned to the pool of available
-masks.
-
-Similarly, a free auxiliary buffer is obtained::
-
-    aux_buffer = buffers.get_aux_buffer()
-
-When using the stencil or auxiliary buffers, make sure you explicitly request
-these when creating the window.  See `OpenGL configuration options` for
-details.
-
-OpenGL imaging
---------------
-
-This section assumes you are familiar with texture mapping in OpenGL (for
-example, chapter 9 of the `OpenGL Programming Guide`_).
-
-To create a texture from any :py:class:`~pyglet.image.AbstractImage`,
-call :py:meth:`~pyglet.image.AbstractImage.get_texture`::
-
-    kitten = image.load('kitten.jpg')
-    texture = kitten.get_texture()
-
-Textures are automatically created and used by
-:py:class:`~pyglet.image.ImageData` when blitted.  Itis useful to use
-textures directly when aiming for high performance or 3D applications.
-
-The :py:class:`~pyglet.image.Texture` class represents any texture object.
-The :py:attr:`~pyglet.image.TextureRegion.target` attribute gives the
-texture target (for example, ``GL_TEXTURE_2D``) and
-:py:attr:`~pyglet.image.TextureRegion.id` the texturename.
-For example, to bind a texture::
-
-    glBindTexture(texture.target, texture.id)
-
-
-
-.. _OpenGL Programming Guide: http://www.opengl-redbook.com/
-
-Texture dimensions
-^^^^^^^^^^^^^^^^^^
-
-Implementations of OpenGL prior to 2.0 require textures to have dimensions
-that are powers of two (i.e., 1, 2, 4, 8, 16, ...).  Because of this
-restriction, pyglet will always create textures of these dimensions (there are
-several non-conformant post-2.0 implementations).  This could have unexpected
-results for a user blitting a texture loaded from a file of non-standard
-dimensions.  To remedy this, pyglet returns a
-:py:class:`~pyglet.image.TextureRegion` of the larger
-texture corresponding to just the part of the texture covered by the original
-image.
-
-A :py:class:`~pyglet.image.TextureRegion` has an `owner` attribute that
-references the larger texture. The following session demonstrates this::
-
-    >>> rgba = image.load('tests/image/rgba.png')
-    >>> rgba
-    <ImageData 235x257>         # The image is 235x257
-    >>> rgba.get_texture()
-    <TextureRegion 235x257>     # The returned texture is a region
-    >>> rgba.get_texture().owner
-    <Texture 256x512>           # The owning texture has power-2 dimensions
-    >>>
-
-A :py:class:`~pyglet.image.TextureRegion` defines a
-:py:attr:`~pyglet.image.TextureRegion.tex_coords` attribute that gives
-the texture coordinates to use for a quad mapping the whole image.
-:py:attr:`~pyglet.image.TextureRegion.tex_coords` is a 4-tuple of 3-tuple
-of floats; i.e., each texture coordinate is given in 3 dimensions.
-The following code can be used to render a quad for a texture region::
-
-    texture = kitten.get_texture()
-    t = texture.tex_coords
-    w, h = texture.width, texture.height
-    array = (GLfloat * 32)(
-         t[0][0], t[0][1], t[0][2], 1.,
-         x,       y,       z,       1.,
-         t[1][0], t[1][1], t[1][2], 1.,
-         x + w,   y,       z,       1.,
-         t[2][0], t[2][1], t[2][2], 1.,
-         x + w,   y + h,   z,       1.,
-         t[3][0], t[3][1], t[3][2], 1.,
-         x,       y + h,   z,       1.)
-
-    glPushClientAttrib(GL_CLIENT_VERTEX_ARRAY_BIT)
-    glInterleavedArrays(GL_T4F_V4F, 0, array)
-    glDrawArrays(GL_QUADS, 0, 4)
-    glPopClientAttrib()
-
-The :py:meth:`~pyglet.image.Texture.blit` method does this.
-
-Use the :py:meth:`pyglet.image.Texture.create` method to create
-either a texture region from a larger power-2 sized texture,
-or a texture with the exact dimensions using  the
-``GL_texture_rectangle_ARB`` extension.
-
-Texture internal format
-^^^^^^^^^^^^^^^^^^^^^^^
-
-pyglet automatically selects an internal format for the texture based on the
-source image's `format` attribute.  The following table describes how it is
-selected.
-
-    .. list-table::
-        :header-rows: 1
-
-        * - Format
-          - Internal format
-        * - Any format with 3 components
-          - ``GL_RGB``
-        * - Any format with 2 components
-          - ``GL_LUMINANCE_ALPHA``
-        * - ``"A"``
-          - ``GL_ALPHA``
-        * - ``"L"``
-          - ``GL_LUMINANCE``
-        * - ``"I"``
-          - ``GL_INTENSITY``
-        * - Any other format
-          - ``GL_RGBA``
-
-Note that this table does not imply any mapping between format components and
-their OpenGL counterparts.  For example, an image with format ``"RG"`` will use
-``GL_LUMINANCE_ALPHA`` as its internal format; the luminance channel will be
-averaged from the red and green components, and the alpha channel will be
-empty (maximal).
-
-Use the :py:meth:`pyglet.image.Texture.create` class method to create a texture
-with a specific internal format.
-
-
-Texture filtering
-^^^^^^^^^^^^^^^^^
-
-By default, all textures are created with smooth (:py:data:`~pyglet.enums.TextureFilter.LINEAR`)
-filtering.
-
-To use a different filter for a specific texture, pass the filtering constant(s)
-to the :py:attr:`pyglet.image.Texture` class via the ``min_filter`` and ``mag_filter``
-arguments.
-
-Pixel art
-"""""""""
-
-To enable nearest-neighbor filtering for retro-style games, set the
-corresponding variables of :py:class:`pyglet.graphics.Texture` to
-:py:data:`~pyglet.enums.TextureFilter.NEAREST`:
-
-.. code-block:: python
-
-   from pyglet.enums import TextureFilter
-   pyglet.graphics.Texture.default_filters = (TextureFilter.NEAREST, TextureFilter.NEAREST)
-
-Afterward, all textures pyglet creates will default
-to nearest-neighbor sampling.
-
-Saving an image
----------------
-
-Any image can be saved using the `save` method::
-
-    kitten.save('kitten.png')
-
-or, specifying a file-like object::
-
-    kitten_stream = open('kitten.png', 'wb')
-    kitten.save('kitten.png', file=kitten_stream)
-
-The following example shows how to grab a screenshot of your application
-window::
-
-    pyglet.image.get_buffer_manager().get_color_buffer().save('screenshot.png')
-
-Note that images can only be saved in the PNG format unless the Pillow library
-is installed.

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -778,7 +778,7 @@ player can draw its current frame directly:
 
 For custom rendering pipelines, you can also access
 :attr:`~pyglet.media.player.VideoPlayer.texture` directly. This is the current video
-frame as a :py:class:`~pyglet.graphics.Texture` (or ``None`` if unavailable).
+frame as a :py:class:`~pyglet.graphics.texture.Texture` (or ``None`` if unavailable).
 Query this property each frame instead of caching it, as the underlying texture
 object will change.
 

--- a/doc/programming_guide/media.rst
+++ b/doc/programming_guide/media.rst
@@ -13,7 +13,7 @@ following are available:
 #. The built-in pyglet WAV file decoder (always available)
 #. Platform-specific APIs and libraries
 #. PyOgg
-#. :ref:`guide-supportedmedia-ffmpeg` version 4, 5, 6, or 7.
+#. :ref:`guide-supportedmedia-ffmpeg` version 4, 5, 6, 7, or 8.
 
 Video is played into OpenGL textures, allowing real-time manipulation
 by applications. Examples include use in 3D environments or shader-based
@@ -304,7 +304,7 @@ FFmpeg
 ^^^^^^
 .. _FFmpeg's license overview: https://www.ffmpeg.org/legal.html
 
-.. note:: The most recent pyglet release can use FFmpeg versions 4.X, 5.X, 6.X, and 7.X
+.. note:: The most recent pyglet release can use FFmpeg versions 4.X, 5.X, 6.X, 7.X, and 8.X
 
           See :ref:`guide-media-ffmpeginstall` to learn more.
 
@@ -390,6 +390,7 @@ See the following to learn more:
   * `The FFmpeg 5.1 license breakdown <https://ffmpeg.org/doxygen/5.1/md_LICENSE.html>`_
   * `The FFmpeg 6.0 license breakdown <https://ffmpeg.org/doxygen/6.0/md_LICENSE.html>`_
   * `The FFmpeg 7.0 license breakdown <https://ffmpeg.org/doxygen/7.0/md_LICENSE.html>`_
+  * `The FFmpeg 8.0 license breakdown <https://ffmpeg.org/doxygen/8.0/md_LICENSE.html>`_
 
 .. _guide-media-ffmpeginstall:
 
@@ -406,6 +407,7 @@ All recent pyglet versions support FFmpeg 4.x.
 * Support for version 5.X requires at least: 1.5.28.
 * Support for version 6.X requires at least: 2.0.8.
 * Support for version 7.X requires at least: 2.0.20.
+* Support for version 8.X requires at least: 2.1.10.
 
 Choose the correct architecture depending on the targeted
 **Python interpreter**. If you're shipping your project with a 32 bits
@@ -620,8 +622,8 @@ Controlling playback
 
 You can implement many functions common to a media player using the
 :py:class:`~pyglet.media.player.AudioPlayer`
-class. Use of this class is also necessary for video playback. There are no
-parameters to its construction::
+class. For video playback, use :py:class:`~pyglet.media.player.VideoPlayer`.
+There are no parameters to AudioPlayer construction::
 
     player = pyglet.media.AudioPlayer()
 
@@ -759,20 +761,26 @@ on a Player as if it was a single source.
 Incorporating video
 -------------------
 
-When a :py:class:`~pyglet.media.player.AudioPlayer` is playing back a source with
-video, use the :attr:`~pyglet.media.AudioPlayer.texture` property to obtain the
-video frame image. This can be used to display the current video image
-synchronised with the audio track, for example::
+Use :py:class:`~pyglet.media.player.VideoPlayer` for sources that include video. The
+player can draw its current frame directly:
+
+::
+
+    video = pyglet.media.load_video("example.mp4")
+    player = pyglet.media.VideoPlayer()
+    player.queue(video)
+    player.play()
 
     @window.event
     def on_draw():
-        player.texture.blit(0, 0)
+        window.clear()
+        player.draw()
 
-The texture is an instance of :class:`pyglet.image.Texture`, with an internal
-format of either ``GL_TEXTURE_2D`` or ``GL_TEXTURE_RECTANGLE_ARB``. While the
-texture will typically be created only once and subsequentally updated each
-frame, you should make no such assumption in your application -- future
-versions of pyglet may use multiple texture objects.
+For custom rendering pipelines, you can also access
+:attr:`~pyglet.media.player.VideoPlayer.texture` directly. This is the current video
+frame as a :py:class:`~pyglet.graphics.Texture` (or ``None`` if unavailable).
+Query this property each frame instead of caching it, as the underlying texture
+object will change.
 
 .. _guide-media-positionalaudio:
 

--- a/doc/programming_guide/migration.rst
+++ b/doc/programming_guide/migration.rst
@@ -123,7 +123,7 @@ Image Grids
 -----------
 The function `pyglet.image.ImageGrid.get_texture_sequence` has been removed. This is no longer recommended,
 as it created it's own texture, further reducing performance. Going forward, it is best to
-use :py:class:`~pyglet.graphics.TextureGrid`. This behaves the same way as :py:class:`~pyglet.image.ImageGrid`, but
+use :py:class:`~pyglet.graphics.texture.TextureGrid`. This behaves the same way as :py:class:`~pyglet.image.ImageGrid`, but
 for textures. This will allow you to use an already existing texture, such as one loaded from an atlas.
 
 

--- a/doc/programming_guide/migration2.rst
+++ b/doc/programming_guide/migration2.rst
@@ -233,7 +233,7 @@ with a :py:meth:`~pyglet.math.Vec2.length` beneath a certain threshold::
 
 Non-Circular Sticks
 """""""""""""""""""
-:py:meth:`Vec2.normalize <pyglet.math.Vec2.normalize` can also help when
+:py:meth:`Vec2.normalize <pyglet.math.Vec2.normalize>` can also help when
 an unusual analog stick input could exceed ``1.0`` in length.
 
 For example, a :py:class:`~pyglet.input.Controller` for a device with a non-circular
@@ -246,7 +246,7 @@ greater than ``1.0``. Normalizating allows concisely clamping the input to ``1.0
 
 
 Accessing Vector Components
-""""""""""""""""""""""""""
+"""""""""""""""""""""""""""
 You can directly access  individual :py:attr:`~pyglet.math.Vec2.x` and
 :py:attr:`~pyglet.math.Vec2.y` attributes or unpack a vector:
 

--- a/doc/programming_guide/quickstart.rst
+++ b/doc/programming_guide/quickstart.rst
@@ -75,11 +75,12 @@ directory and display it within the window::
 
     window = pyglet.window.Window()
     image = pyglet.resource.image('kitten.jpg')
+    sprite = pyglet.sprite.Sprite(image, x=0, y=0)
 
     @window.event
     def on_draw():
         window.clear()
-        image.blit(0, 0)
+        sprite.draw()
 
     pyglet.app.run()
 
@@ -89,9 +90,9 @@ file (rather than the working directory).  To load an image not bundled with
 the application (for example, specified on the command line), you would use
 :func:`pyglet.image.load`.
 
-The :meth:`~pyglet.image.AbstractImage.blit` method draws the image.  The
-arguments ``(0, 0)`` tell pyglet to draw the image at pixel coordinates 0,
-0 in the window (the lower-left corner).
+The :class:`~pyglet.sprite.Sprite` class wraps an image for drawing. The
+``x=0`` and ``y=0`` arguments tell pyglet to position the sprite at pixel
+coordinates 0, 0 in the window (the lower-left corner).
 
 The complete code for this example is located in
 `examples/programming_guide/image_viewer.py`.

--- a/doc/programming_guide/rendering.rst
+++ b/doc/programming_guide/rendering.rst
@@ -170,23 +170,23 @@ object value. In the above example, the name would be ``WindowBlock`` while the 
 
 Normally with OpenGL, you would have to manually assign a global binding point value to each Uniform Block for each Shader Program, as they are created. With Pyglet, the global binding values and assignments are all taken care of internally.
 
-Uniform Blocks can be a convenient way to update uniforms of multiple Shader Programs at once, as their data is shared. This allows you to access the same information from multiple Shader Programs without having to bind every program using it, just to modify the uniform values. This can be achieved through a :py:class:`~pyglet.graphics.shader.UniformBufferObject`.
+Uniform Blocks can be a convenient way to update uniforms of multiple Shader Programs at once, as their data is shared. This allows you to access the same information from multiple Shader Programs without having to bind every program using it, just to modify the uniform values. This can be achieved through a :py:class:`~pyglet.graphics.buffer.UniformBufferObject`.
 
 To modify the uniforms in a :py:class:`~pyglet.graphics.shader.UniformBlock`, you must first create a
-:py:class:`~pyglet.graphics.shader.UniformBufferObject` using the
+:py:class:`~pyglet.graphics.buffer.UniformBufferObject` using the
 :py:meth:`~pyglet.graphics.shader.UniformBlock.create_ubo` method.::
 
     ubo = program.uniform_blocks['WindowBlock'].create_ubo()
 
-The :py:class:`~pyglet.graphics.shader.UniformBufferObject` can then be used as a context manager for easy
+The :py:class:`~pyglet.graphics.buffer.UniformBufferObject` can then be used as a context manager for easy
 access to update its uniforms::
 
         with ubo as window_block:
             window_block.projection[:] = new_matrix
 
-You can also create multiple :py:class:`~pyglet.graphics.shader.UniformBufferObject` instances if you need to swap between different sets of data. Calling :py:meth:`~pyglet.graphics.shader.UniformBufferObject.bind` will bind the buffers data to the associated binding point.
+You can also create multiple :py:class:`~pyglet.graphics.buffer.UniformBufferObject` instances if you need to swap between different sets of data. Calling :py:meth:`~pyglet.graphics.buffer.UniformBufferObject.bind` will bind the buffers data to the associated binding point.
 
-There may come a point where you don't want a specific :py:class:`~pyglet.graphics.shader.ShaderProgram`, or a group of them, to use the same uniform data set as the rest of your shaders. At this point, you will have to modify the binding point of those Uniform Blocks to one that is unused. This can be done through :py:meth:`~pyglet.graphics.shader.UniformBlock.set_binding`. Once the binding has been set, you will have to create a new :py:class:`~pyglet.graphics.shader.UniformBufferObject` using the :py:meth:`~pyglet.graphics.shader.UniformBlock.create_ubo` method again and supply it with your new data set.
+There may come a point where you don't want a specific :py:class:`~pyglet.graphics.shader.ShaderProgram`, or a group of them, to use the same uniform data set as the rest of your shaders. At this point, you will have to modify the binding point of those Uniform Blocks to one that is unused. This can be done through :py:meth:`~pyglet.graphics.shader.UniformBlock.set_binding`. Once the binding has been set, you will have to create a new :py:class:`~pyglet.graphics.buffer.UniformBufferObject` using the :py:meth:`~pyglet.graphics.shader.UniformBlock.create_ubo` method again and supply it with your new data set.
 
 .. warning:: When assigning custom binding points through py:meth:`~pyglet.graphics.shader.UniformBlock.set_binding`, it is recommended to use an unassigned binding point, as unexpected behavior may occur. A warning will be output if such a collision occurs.
 

--- a/doc/programming_guide/text.rst
+++ b/doc/programming_guide/text.rst
@@ -167,8 +167,7 @@ optional `multiline` and `wrap_lines` flags.
 
 Like labels, layouts are positioned through their `x`, `y`,
 `anchor_x` and `anchor_y` properties.
-Note that unlike :py:class:`~pyglet.image.AbstractImage`, the `anchor`
-properties accept a string such as ``"bottom"`` or ``"center"`` instead of a
+The `anchor` properties accept a string such as ``"bottom"`` or ``"center"`` instead of a
 numeric displacement.
 
 .. _guide_formatted-text:

--- a/doc/programming_guide/text.rst
+++ b/doc/programming_guide/text.rst
@@ -597,8 +597,33 @@ a default sans-serif font (Helvetica on Mac OS X, Arial on Windows XP)::
 
     sans_serif = pyglet.font.load(None, 16)
 
+Font groups
+-----------
+
+:py:class:`~pyglet.font.group.FontGroup` lets you define a named set of font
+fallbacks and assign each fallback to specific Unicode ranges. This is useful
+when one label or layout needs multiple scripts or symbol sets, but you still
+want to refer to the result as one logical font.
+
+Create a group, register it, then use the group name anywhere you would usually
+provide a font family name::
+
+    import pyglet
+
+    ui_font = pyglet.font.FontGroup("ui-font")
+    ui_font.add("Noto Sans", 0x0000, 0x024F)       # Basic Latin + Latin supplements
+    ui_font.add("Noto Sans CJK JP", 0x3040, 0x30FF)  # Hiragana + Katakana
+    ui_font.add("Noto Color Emoji", 0x1F300, 0x1FAFF)
+    pyglet.font.add_group(ui_font)
+
+    label = pyglet.text.Label(
+        "Hello こんにちは 😀",
+        font_name="ui-font",
+        font_size=18,
+    )
+
 HarfBuzz shaping
-^^^^^^^^^^^^^^^^
+----------------
 
 Some platforms like Linux do not have any text shaping capability to provide advanced features
 such as ligatures, substitutions, cluster-aware glyph placement, etc. To provide

--- a/doc/programming_guide/texture.rst
+++ b/doc/programming_guide/texture.rst
@@ -1,0 +1,307 @@
+Textures and Rendering
+======================
+
+This page covers GPU-side imaging in pyglet 3.0: drawing images, working with
+textures, texture atlases, and framebuffers.
+
+Texture classes moved from ``pyglet.image`` to ``pyglet.graphics.texture`` in
+pyglet 3.0. Use :py:class:`~pyglet.graphics.Texture` and related classes
+for GPU resources, and keep :py:mod:`pyglet.image` for CPU-side image
+data (see :doc:`image`).
+
+Drawing images
+--------------
+
+For most users, the :py:class:`~pyglet.sprite.Sprite` class is the best way to
+draw an image.
+
+.. note::
+    ``image.blit`` no longer exists in pyglet 3.0. Use sprites for drawing.
+
+Example::
+
+    import pyglet
+
+    window = pyglet.window.Window(800, 600)
+    image = pyglet.image.load("kitten.png")
+    sprite = pyglet.sprite.Sprite(image, x=100, y=80)
+
+    @window.event
+    def on_draw():
+        window.clear()
+        sprite.draw()
+
+    pyglet.app.run()
+
+Sprites can be created from either :py:class:`~pyglet.image.ImageData`,
+:py:class:`~pyglet.image.animation.Animation`, or an existing texture object.
+
+Batched sprites
+^^^^^^^^^^^^^^^
+
+If you need to draw many sprites, use a :py:class:`~pyglet.graphics.draw.Batch`:
+
+::
+
+    batch = pyglet.graphics.Batch()
+    sprites = [pyglet.sprite.Sprite(image, batch=batch) for _ in range(100)]
+
+    @window.event
+    def on_draw():
+        window.clear()
+        batch.draw()
+
+When using batches, draw order can be controlled with
+:py:class:`~pyglet.graphics.draw.Group` objects:
+
+::
+
+    batch = pyglet.graphics.Batch()
+    background = pyglet.graphics.Group(order=0)
+    foreground = pyglet.graphics.Group(order=1)
+
+    pyglet.sprite.Sprite(image, batch=batch, group=background)
+    pyglet.sprite.Sprite(image, batch=batch, group=foreground)
+
+To reduce texture switches, prefer atlased textures (for example via
+:py:meth:`~pyglet.resource.texture`) or use explicit texture bins/atlases as
+described below.
+
+Converting images and textures
+------------------------------
+
+CPU image objects can be uploaded to the GPU with
+:py:meth:`~pyglet.image.ImageData.get_texture`::
+
+    img = pyglet.image.load('kitten.png')
+    texture = img.get_texture()
+
+If you need finer control over texture creation (for example filtering,
+address mode, texture type, or internal format settings), use
+``Texture.create_from_image(...)`` instead of ``get_texture()``.
+
+Reading texture pixels back to CPU memory can be done with
+``Texture.fetch()``::
+
+    image_data = texture.fetch()
+
+These readbacks can be expensive, especially if done every frame.
+
+Writing into textures
+---------------------
+
+To write CPU image data into an existing texture, use ``Texture.upload(...)``.
+This method was previously named ``blit_into``.
+
+::
+
+    image_data = pyglet.image.load('overlay.png').get_image_data()
+    texture = pyglet.graphics.Texture.create(512, 512)
+    texture.upload(image_data, x=0, y=0, z=0)
+
+Texture uploads replace texel data in the target region. They do not perform
+alpha blending with existing texels. Blending only applies when drawing
+geometry/sprites with blend state enabled.
+For render-based updates, see :ref:`guide_drawing-into-a-texture`.
+
+Image sequences and atlases
+---------------------------
+
+Sometimes a single source image is used to hold many sub-images (for example,
+sprite sheets). pyglet provides helpers for this workflow.
+
+.. _guide_texture-grids:
+
+Texture grids
+^^^^^^^^^^^^^
+
+You can define the CPU-side grid first with :py:class:`~pyglet.image.ImageGrid`
+(see :ref:`guide_image-grids` in :doc:`image`). Then convert it to a
+GPU-side :py:class:`~pyglet.graphics.TextureGrid` for efficient
+rendering:
+
+::
+
+    explosion = pyglet.image.load('explosion.png')
+    explosion_grid = pyglet.image.ImageGrid(explosion, 1, 8)
+    explosion_tex_grid = pyglet.graphics.TextureGrid.from_image_grid(explosion_grid)
+
+    first_frame = explosion_tex_grid[0]
+
+:py:class:`~pyglet.graphics.TextureGrid` can also be created directly
+with the same grid arguments as :py:class:`~pyglet.image.ImageGrid`
+(``rows``, ``columns``, optional ``item_width``/``item_height``, and padding),
+but with a texture as the first argument:
+
+::
+
+    texture = explosion.get_texture()
+    explosion_tex_grid = pyglet.graphics.TextureGrid(texture, 1, 8)
+
+``pyglet.graphics.TextureGrid`` is the same class alias exposed as
+:py:class:`~pyglet.graphics.texture.TextureGrid`.
+
+:py:class:`~pyglet.graphics.TextureGrid` items are
+:py:class:`~pyglet.graphics.texture.TextureRegion` objects.
+
+.. _guide_texture-bins-and-atlases:
+
+Texture bins and atlases
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+A :py:class:`~pyglet.graphics.atlas.TextureAtlas` is a large texture that packs
+many smaller images. A :py:class:`~pyglet.graphics.atlas.TextureBin` manages
+multiple atlases as needed.
+
+::
+
+    images = [
+        pyglet.image.load('img1.png'),
+        pyglet.image.load('img2.png'),
+    ]
+
+    bin = pyglet.graphics.atlas.TextureBin()
+    regions = [bin.add(image) for image in images]
+
+The result of ``TextureBin.add`` is typically a
+``TextureRegion``.
+
+
+3D textures
+^^^^^^^^^^^
+
+You can create a :py:class:`~pyglet.graphics.Texture3D` from a sequence
+of images or from an
+:py:class:`~pyglet.image.ImageGrid` (see :ref:`guide_image-grids`)::
+
+    explosion_3d = pyglet.graphics.texture.Texture3D.create_for_image_grid(explosion_grid)
+
+Slicing a :py:class:`~pyglet.graphics.Texture3D` returns
+:py:class:`~pyglet.graphics.texture.TextureRegion` objects for layers.
+
+Framebuffers
+------------
+
+For explicit framebuffer objects, use ``Framebuffer`` and ``Renderbuffer`` in
+:py:mod:`pyglet.graphics.framebuffer`.
+
+::
+
+    import pyglet
+    from pyglet.enums import TextureFilter, FramebufferAttachment, ComponentFormat
+    from pyglet.graphics import Texture, Renderbuffer, Framebuffer
+
+    window = pyglet.window.Window()
+
+    color_buffer = Texture.create(width, height, filters=TextureFilter.NEAREST)
+    depth_buffer = Renderbuffer(window.context, width, height,
+                                component_format=ComponentFormat.D, bit_size=24)
+
+    framebuffer = Framebuffer(context=window.context)
+    framebuffer.attach_texture(color_buffer, attachment=FramebufferAttachment.COLOR0)
+    framebuffer.attach_renderbuffer(depth_buffer, attachment=FramebufferAttachment.DEPTH)
+
+    framebuffer.bind()
+
+.. _guide_drawing-into-a-texture:
+
+Drawing into a texture
+^^^^^^^^^^^^^^^^^^^^^^
+
+Use a framebuffer with a texture attachment when you want to render *into* a
+texture (for post-processing, compositing, dynamic texture generation, etc.).
+
+::
+
+    import pyglet
+    from pyglet.enums import FramebufferAttachment, TextureFilter
+
+    window = pyglet.window.Window(800, 600)
+
+    source_image = pyglet.image.load('source.png')
+    source_sprite = pyglet.sprite.Sprite(source_image, x=100, y=120)
+
+    target_texture = pyglet.graphics.Texture.create(
+        800, 600, filters=TextureFilter.NEAREST
+    )
+    framebuffer = pyglet.graphics.Framebuffer(context=window.context)
+    framebuffer.attach_texture(target_texture, attachment=FramebufferAttachment.COLOR0)
+
+    # This sprite displays the texture we rendered into:
+    result_sprite = pyglet.sprite.Sprite(target_texture, x=0, y=0)
+
+    @window.event
+    def on_draw():
+        # Pass 1: render into texture:
+        framebuffer.bind()
+        window.clear()
+        source_sprite.draw()
+        framebuffer.unbind()
+
+        # Pass 2: render texture to window:
+        window.clear()
+        result_sprite.draw()
+
+    pyglet.app.run()
+
+This is different from ``Texture.upload(...)``: framebuffer rendering runs the
+normal draw pipeline (shaders, blending, draw order), while ``upload`` is a
+direct texel data replacement.
+
+To capture the default framebuffer to an image:
+
+::
+
+    from pyglet.graphics.framebuffer import get_screenshot
+
+    screenshot = get_screenshot()
+    screenshot.save('screenshot.png')
+
+OpenGL texture access
+---------------------
+
+This section assumes familiarity with texture mapping in OpenGL (for example,
+chapter 9 of the `OpenGL Programming Guide`_).
+
+To create a texture from image data:
+
+::
+
+    kitten = pyglet.image.load('kitten.jpg')
+    texture = kitten.get_texture()
+
+A :py:class:`~pyglet.graphics.Texture` has a ``target`` and ``id``:
+
+::
+
+    from pyglet.graphics.api.gl import *
+    glBindTexture(texture.target, texture.id)
+
+.. _OpenGL Programming Guide: http://www.opengl-redbook.com/
+
+Texture filtering
+^^^^^^^^^^^^^^^^^
+
+By default, all textures are created with smooth (:py:data:`~pyglet.enums.TextureFilter.LINEAR`)
+filtering.
+
+To use a different filter for a specific texture, pass the filtering constant(s)
+to the :py:meth:`pyglet.graphics.texture.Texture.create` via the ``filter``
+arguments or :py:meth:`pyglet.graphics.texture.Texture.create_from_image`.
+
+
+Pixel art
+"""""""""
+
+To enable nearest-neighbor filtering for retro-style games, set the
+corresponding variables of :py:class:`pyglet.graphics.Texture` to
+:py:data:`~pyglet.enums.TextureFilter.NEAREST`:
+
+.. code-block:: python
+
+   from pyglet.enums import TextureFilter
+   pyglet.graphics.Texture.default_filters = (TextureFilter.NEAREST, TextureFilter.NEAREST)
+
+Afterward, all textures pyglet creates will default
+to nearest-neighbor sampling.
+

--- a/doc/programming_guide/texture.rst
+++ b/doc/programming_guide/texture.rst
@@ -5,7 +5,7 @@ This page covers GPU-side imaging in pyglet 3.0: drawing images, working with
 textures, texture atlases, and framebuffers.
 
 Texture classes moved from ``pyglet.image`` to ``pyglet.graphics.texture`` in
-pyglet 3.0. Use :py:class:`~pyglet.graphics.Texture` and related classes
+pyglet 3.0. Use :py:class:`~pyglet.graphics.texture.Texture` and related classes
 for GPU resources, and keep :py:mod:`pyglet.image` for CPU-side image
 data (see :doc:`image`).
 
@@ -117,7 +117,7 @@ Texture grids
 
 You can define the CPU-side grid first with :py:class:`~pyglet.image.ImageGrid`
 (see :ref:`guide_image-grids` in :doc:`image`). Then convert it to a
-GPU-side :py:class:`~pyglet.graphics.TextureGrid` for efficient
+GPU-side :py:class:`~pyglet.graphics.texture.TextureGrid` for efficient
 rendering:
 
 ::
@@ -128,7 +128,7 @@ rendering:
 
     first_frame = explosion_tex_grid[0]
 
-:py:class:`~pyglet.graphics.TextureGrid` can also be created directly
+:py:class:`~pyglet.graphics.texture.TextureGrid` can also be created directly
 with the same grid arguments as :py:class:`~pyglet.image.ImageGrid`
 (``rows``, ``columns``, optional ``item_width``/``item_height``, and padding),
 but with a texture as the first argument:
@@ -141,7 +141,7 @@ but with a texture as the first argument:
 ``pyglet.graphics.TextureGrid`` is the same class alias exposed as
 :py:class:`~pyglet.graphics.texture.TextureGrid`.
 
-:py:class:`~pyglet.graphics.TextureGrid` items are
+:py:class:`~pyglet.graphics.texture.TextureGrid` items are
 :py:class:`~pyglet.graphics.texture.TextureRegion` objects.
 
 .. _guide_texture-bins-and-atlases:
@@ -170,13 +170,13 @@ The result of ``TextureBin.add`` is typically a
 3D textures
 ^^^^^^^^^^^
 
-You can create a :py:class:`~pyglet.graphics.Texture3D` from a sequence
+You can create a :py:class:`~pyglet.graphics.texture.Texture3D` from a sequence
 of images or from an
 :py:class:`~pyglet.image.ImageGrid` (see :ref:`guide_image-grids`)::
 
     explosion_3d = pyglet.graphics.texture.Texture3D.create_for_image_grid(explosion_grid)
 
-Slicing a :py:class:`~pyglet.graphics.Texture3D` returns
+Slicing a :py:class:`~pyglet.graphics.texture.Texture3D` returns
 :py:class:`~pyglet.graphics.texture.TextureRegion` objects for layers.
 
 Framebuffers
@@ -270,7 +270,7 @@ To create a texture from image data:
     kitten = pyglet.image.load('kitten.jpg')
     texture = kitten.get_texture()
 
-A :py:class:`~pyglet.graphics.Texture` has a ``target`` and ``id``:
+A :py:class:`~pyglet.graphics.texture.Texture` has a ``target`` and ``id``:
 
 ::
 
@@ -286,15 +286,15 @@ By default, all textures are created with smooth (:py:data:`~pyglet.enums.Textur
 filtering.
 
 To use a different filter for a specific texture, pass the filtering constant(s)
-to the :py:meth:`pyglet.graphics.texture.Texture.create` via the ``filter``
-arguments or :py:meth:`pyglet.graphics.texture.Texture.create_from_image`.
+to ``Texture.create`` via the ``filter`` arguments or
+``Texture.create_from_image``.
 
 
 Pixel art
 """""""""
 
 To enable nearest-neighbor filtering for retro-style games, set the
-corresponding variables of :py:class:`pyglet.graphics.Texture` to
+corresponding variables of :py:class:`pyglet.graphics.texture.Texture` to
 :py:data:`~pyglet.enums.TextureFilter.NEAREST`:
 
 .. code-block:: python

--- a/doc/programming_guide/windowing.rst
+++ b/doc/programming_guide/windowing.rst
@@ -333,7 +333,7 @@ These dialogs are non-blocking and dispatch events when the user completes or
 cancels the operation. They only return path information; your code is
 responsible for opening or saving the file data.
 
-Both :py:class:`FileOpenDialog` and :py:class:`FileSaveDialog` accept
+Both :py:class:`~pyglet.window.dialog.FileOpenDialog` and :py:class:`~pyglet.window.dialog.FileSaveDialog` accept
 ``filetypes`` as a list of ``(label, pattern)`` tuples.
 
 Use wildcard patterns (recommended), and separate multiple extensions in one

--- a/doc/programming_guide/windowing.rst
+++ b/doc/programming_guide/windowing.rst
@@ -177,6 +177,71 @@ diagram:
 
     The position and size of the window relative to the desktop.
 
+DPI and scaling
+^^^^^^^^^^^^^^^
+
+One window can have two different sizes:
+
+* ``window.get_size()``: How big the window appears in your app's coordinate
+  system (the size you usually think in for layout).
+* ``window.get_framebuffer_size()``: How many real pixels are available for
+  drawing.
+
+At 100% display scaling, these are usually the same. On high-DPI displays
+(for example Retina, or 125%/150%/200% scaling), the framebuffer size can be
+larger than the window size.
+
+In simple terms:
+
+* Window size controls "how big it looks."
+* Framebuffer size controls "how many pixels it is drawn with."
+
+More framebuffer pixels usually means sharper output, but also more pixels for
+your app to render.
+
+Useful values and APIs:
+
+* :py:meth:`~pyglet.window.Window.get_size`: Logical window size.
+* :py:meth:`~pyglet.window.Window.get_framebuffer_size`: Physical pixel size of the framebuffer.
+* :py:attr:`~pyglet.window.Window.scale`: DPI scale factor for the window.
+* :py:attr:`~pyglet.window.Window.dpi`: Effective DPI value for the window.
+* ``on_scale`` event: Dispatched when DPI/scale changes at runtime.
+
+The global :py:attr:`pyglet.options.dpi_scaling <pyglet.Options.dpi_scaling>`
+option controls how window DPI scaling behaves. For a complete runnable
+example, see ``examples/dpi_scaled_window.py``.
+
+Typical results:
+
+* 100% scaling display: ``(800, 600)`` window and ``(800, 600)`` framebuffer,
+  scale ``1.0``.
+* 200% scaling display (commonly on macOS Retina with ``"platform"``):
+  ``(800, 600)`` window and ``(1600, 1200)`` framebuffer, scale ``2.0``.
+
+Platform note:
+
+* macOS: In ``"platform"`` mode on Retina displays, framebuffer size is often
+  larger than window size.
+* Windows: In ``"platform"`` mode, framebuffer and window size are usually
+  the same (1:1).
+
+The current modes are:
+
+* ``"platform"`` (default):
+  Follows platform-native DPI behavior. This usually gives the sharpest output.
+  However, your code may need to handle different window and framebuffer
+  sizes, especially for custom viewports, render targets, and fixed-size UI.
+
+* ``"stretch"``:
+  Keeps your requested window coordinate space and stretches content to the
+  framebuffer. This can simplify older code that assumes a fixed size.
+  However, stretched output can look blurry.
+
+When targeting multiple platforms or multi-monitor setups, test DPI behavior
+early. Moving a window between monitors can change scale at runtime, so handle
+the ``on_scale`` event when you need to re-layout UI or
+recompute size-dependent resources.
+
 Appearance
 ----------
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==8.3.0
-sphinx_rtd_theme==3.0.2
+sphinx==9.1.0
+sphinx_rtd_theme==3.1.0
 readthedocs-sphinx-search==0.3.2
-sphinx-autodoc-typehints==3.5.2
+sphinx-autodoc-typehints==3.10.2
 pytest

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import warnings
 import weakref
 
-import os as _os
 from functools import partial
 
 import pyglet
@@ -20,70 +19,8 @@ pyglet.options.debug_media = False
 
 from pyglet.media.exceptions import MediaException
 
-from concurrent.futures import ProcessPoolExecutor as _ProcessPoolExecutor
-
-from pyglet.event import EventDispatcher as _EventDispatcher
+from pyglet.window.dialog import FileOpenDialog
 from pyglet.window import key
-
-
-
-class _Dialog(_EventDispatcher):
-    """Dialog base class
-
-    This base class sets up a ProcessPoolExecutor with a single
-    background Process. This allows the Dialog to display in
-    the background without blocking or interfering with the main
-    application Process. This also limits to a single open Dialog
-    at a time.
-    """
-
-    executor = _ProcessPoolExecutor(max_workers=1)
-    _dialog = None
-
-    @staticmethod
-    def _open_dialog(dialog):
-        import tkinter as tk
-        root = tk.Tk()
-        root.withdraw()
-        return dialog.show()
-
-    def open(self):
-        future = self.executor.submit(self._open_dialog, self._dialog)
-        future.add_done_callback(self._dispatch_event)
-
-    def _dispatch_event(self, future):
-        raise NotImplementedError
-
-
-class FileOpenDialog(_Dialog):
-    def __init__(self, title="Open File", initial_dir=_os.path.curdir, filetypes=None, multiple=False):
-        """
-        :Parameters:
-            `title` : str
-                The Dialog Window name. Defaults to "Open File".
-            `initial_dir` : str
-                The directory to start in.
-            `filetypes` : list of tuple
-                An optional list of tuples containing (name, extension) to filter by.
-                If none are given, all files will be shown and selectable.
-                For example: `[("PNG", ".png"), ("24-bit Bitmap", ".bmp")]`
-            `multiple` : bool
-                True if multiple files can be selected. Defaults to False.
-        """
-        from tkinter import filedialog
-        self._dialog = filedialog.Open(title=title,
-                                       initialdir=initial_dir,
-                                       filetypes=filetypes or (),
-                                       multiple=multiple)
-
-    def _dispatch_event(self, future):
-        pyglet.app.platform_event_loop.post_event(self, "on_dialog_open", future.result())
-
-    def on_dialog_open(self, filenames):
-        """Event for filename choices"""
-
-
-FileOpenDialog.register_event_type('on_dialog_open')
 
 
 class Control(pyglet.event.EventDispatcher):
@@ -210,7 +147,7 @@ class Slider(Control):
     THUMB_WIDTH = 6
     THUMB_HEIGHT = 10
     GROOVE_HEIGHT = 2
-    RESPONSIVNESS = 0.3
+    RESPONSIVENESS = 0.3
 
     def __init__(self, parent):
         super().__init__(parent)

--- a/examples/media/media_player.py
+++ b/examples/media/media_player.py
@@ -194,7 +194,7 @@ class Slider(Control):
         self.capture_events()
         self.dispatch_event('on_begin_scroll')
         self.dispatch_event('on_change', value)
-        pyglet.clock.schedule_once(self.seek_request, self.RESPONSIVNESS)
+        pyglet.clock.schedule_once(self.seek_request, self.RESPONSIVENESS)
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
         # On some platforms, on_mouse_drag is triggered with a high frequency.
@@ -208,7 +208,7 @@ class Slider(Control):
         if self.seek_value is None:
             # We have processed the last recorded mouse position.
             # We re-schedule seek_request
-            pyglet.clock.schedule_once(self.seek_request, self.RESPONSIVNESS)
+            pyglet.clock.schedule_once(self.seek_request, self.RESPONSIVENESS)
         self.seek_value = value
 
     def on_mouse_release(self, x, y, button, modifiers):

--- a/examples/sprite/sprite_batching.py
+++ b/examples/sprite/sprite_batching.py
@@ -1,6 +1,7 @@
 import random
 
 import pyglet
+from pyglet.graphics.draw import Batch
 
 window = pyglet.window.Window(vsync=False)
 
@@ -19,7 +20,7 @@ image.anchor_x = image.width // 2
 image.anchor_y = image.height // 2
 
 # Batching allows rendering groups of objects all at once instead of drawing one by one.
-batch = pyglet.graphics.Batch()
+batch = Batch()
 
 scales = [1.0, 0.75, 0.5, 0.25]
 

--- a/examples/sprite/sprite_batching.py
+++ b/examples/sprite/sprite_batching.py
@@ -42,10 +42,6 @@ for i in range(1000):
     sprites.append(sprite)
 
 
-text = pyglet.text.Label("Hello World!", x=window.width // 2, y=window.height // 2, batch=batch)
-text2 = pyglet.text.Label("               asf af Hello World!", x=window.width // 2, y=window.height // 2, batch=batch)
-
-
 @window.event
 def on_draw():
     window.clear()

--- a/pyglet/__init__.py
+++ b/pyglet/__init__.py
@@ -103,7 +103,7 @@ class Options:
 
     debug_graphics_batch: bool = False
     """If ``True``, prints batch information being drawn, including :py:class:`~pyglet.graphics.Group`'s, VertexDomains,
-    and :py:class:`~pyglet.graphics.Texture` information. This can be useful to see how many Group's are being
+    and :py:class:`~pyglet.graphics.texture.Texture` information. This can be useful to see how many Group's are being
     consolidated."""
 
     debug_lib: bool = False

--- a/pyglet/experimental/geoshader_sprite.py
+++ b/pyglet/experimental/geoshader_sprite.py
@@ -245,7 +245,7 @@ class Sprite(event.EventDispatcher):
         """Create a sprite.
 
         :Parameters:
-            `img` : `~pyglet.image.AbstractImage` or `~pyglet.image.Animation`
+            `img` :
                 Image or animation to display.
             `x` : int
                 X coordinate of the sprite.
@@ -418,11 +418,7 @@ class Sprite(event.EventDispatcher):
 
     @property
     def image(self):
-        """Image or animation to display.
-
-        :type: :py:class:`~pyglet.image.AbstractImage` or
-               :py:class:`~pyglet.image.Animation`
-        """
+        """Image or animation to display."""
         if self._animation:
             return self._animation
         return self._texture

--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -8,11 +8,23 @@ See the :ref:`guide_graphics` for details on how to use this graphics API.
 """
 from __future__ import annotations
 
-from pyglet.graphics import api  # noqa: F401
-from pyglet.graphics.draw import Group, ShaderGroup  # noqa: F401
-from pyglet.graphics.state import State  # noqa: F401
-from pyglet.graphics.api import Batch, get_default_shader, get_default_batch, core, Shader, ShaderProgram, ComputeShaderProgram  # noqa: F401
-from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray   # noqa: F401
-from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas   # noqa: F401
-from pyglet.graphics.framebuffer import Framebuffer, Renderbuffer  # noqa: F401
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyglet.graphics import api  # noqa: F401
+    from pyglet.graphics.draw import Group, ShaderGroup, Batch
+    from pyglet.graphics.shader import Shader, ShaderProgram, ComputeShaderProgram  # noqa: F401
+    from pyglet.graphics.state import State  # noqa: F401
+    from pyglet.graphics.api import get_default_shader, get_default_batch # noqa: F401
+    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray   # noqa: F401
+    from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas   # noqa: F401
+    from pyglet.graphics.framebuffer import Framebuffer, Renderbuffer  # noqa: F401
+else:
+    from pyglet.graphics import api  # noqa: F401
+    from pyglet.graphics.draw import Group, ShaderGroup  # noqa: F401
+    from pyglet.graphics.state import State  # noqa: F401
+    from pyglet.graphics.api import Batch, get_default_shader, get_default_batch, core, Shader, ShaderProgram, ComputeShaderProgram  # noqa: F401
+    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray   # noqa: F401
+    from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas   # noqa: F401
+    from pyglet.graphics.framebuffer import Framebuffer, Renderbuffer  # noqa: F401
 

--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -12,19 +12,21 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyglet.graphics import api  # noqa: F401
-    from pyglet.graphics.draw import Group, ShaderGroup, Batch
+    from pyglet.graphics.draw import Group, ShaderGroup, Batch  # noqa: F401
     from pyglet.graphics.shader import Shader, ShaderProgram, ComputeShaderProgram  # noqa: F401
     from pyglet.graphics.state import State  # noqa: F401
-    from pyglet.graphics.api import get_default_shader, get_default_batch # noqa: F401
-    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray   # noqa: F401
-    from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas   # noqa: F401
+    from pyglet.graphics.shader import get_default_shader  # noqa: F401
+    from pyglet.graphics.draw import get_default_batch  # noqa: F401
+    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
+    from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas  # noqa: F401
     from pyglet.graphics.framebuffer import Framebuffer, Renderbuffer  # noqa: F401
 else:
     from pyglet.graphics import api  # noqa: F401
-    from pyglet.graphics.draw import Group, ShaderGroup  # noqa: F401
+    from pyglet.graphics.draw import Group, ShaderGroup, Batch, get_default_batch  # noqa: F401
+    from pyglet.graphics.shader import Shader, ShaderProgram, ComputeShaderProgram, get_default_shader  # noqa: F401
     from pyglet.graphics.state import State  # noqa: F401
-    from pyglet.graphics.api import Batch, get_default_shader, get_default_batch, core, Shader, ShaderProgram, ComputeShaderProgram  # noqa: F401
-    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray   # noqa: F401
-    from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas   # noqa: F401
+    from pyglet.graphics.api import core  # noqa: F401
+    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
+    from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas  # noqa: F401
     from pyglet.graphics.framebuffer import Framebuffer, Renderbuffer  # noqa: F401
 

--- a/pyglet/graphics/api/__init__.py
+++ b/pyglet/graphics/api/__init__.py
@@ -9,7 +9,8 @@ from pyglet.graphics.api.base import ResourceManagement, NullBackend
 
 if TYPE_CHECKING:
     from pyglet.graphics.api.base import GraphicsConfig
-    from pyglet.graphics.shader import ShaderType
+    from pyglet.graphics.draw import Batch
+    from pyglet.graphics.shader import ShaderType, ShaderProgram
 
 core = NullBackend()
 
@@ -26,43 +27,19 @@ if pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_ES_3):
 
     core = OpenGLBackend(gl_api=pyglet.options.backend)
 
-    from pyglet.graphics.api.gl.draw import GLBatch as Batch
-    from pyglet.graphics.api.gl.draw import get_default_shader, get_default_batch
-    from pyglet.graphics.api.gl.shader import (
-        GLComputeShaderProgram as ComputeShaderProgram,
-        GLShader as Shader,
-        GLShaderProgram as ShaderProgram,
-    )
-
 elif pyglet.options.backend in (GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2):
     from pyglet.graphics.api.gl2.global_opengl import OpenGL2Backend
 
     core = OpenGL2Backend(gl_api=pyglet.options.backend)
-
-    from pyglet.graphics.api.gl2.draw import GL2Batch as Batch
-    from pyglet.graphics.api.gl2.draw import get_default_shader, get_default_batch
-    from pyglet.graphics.api.gl2.shader import ShaderProgram, Shader, ComputeShaderProgram
 
 elif pyglet.options.backend == GraphicsAPI.WEBGL:
     from pyglet.graphics.api.webgl import WebGLBackend
 
     core = WebGLBackend()
 
-    from pyglet.graphics.api.webgl.draw import WebGLBatch as Batch
-    from pyglet.graphics.api.webgl.draw import get_default_shader, get_default_batch
-    from pyglet.graphics.api.webgl.shader import (
-        WebGLComputeShaderProgram as ComputeShaderProgram,
-        WebGLShader as Shader,
-        WebGLShaderProgram as ShaderProgram,
-    )
-
 elif pyglet.options.backend == GraphicsAPI.VULKAN:
     from pyglet.graphics.api.vulkan.instance import VulkanGlobal
     core = VulkanGlobal()
-
-    from pyglet.graphics.api.vulkan.draw import Batch
-    from pyglet.graphics.api.vulkan.draw import get_default_shader, get_default_batch
-    from pyglet.graphics.api.vulkan.shader import ShaderProgram, Shader
 
 else:
     raise Exception(f"Invalid rendering backend. Choose one of {[str(a) for a in GraphicsAPI]}.")
@@ -86,3 +63,15 @@ def have_extension(extension_name: str) -> bool:
 
 def get_cached_shader(name: str, *sources: tuple[str, ShaderType]) -> ShaderProgram:
     return core.get_cached_shader(name, *sources)
+
+
+def get_default_batch() -> Batch:
+    from pyglet.graphics.draw import get_default_batch as _get_default_batch
+
+    return _get_default_batch()
+
+
+def get_default_shader() -> ShaderProgram:
+    from pyglet.graphics.shader import get_default_shader as _get_default_shader
+
+    return _get_default_shader()

--- a/pyglet/graphics/api/gl/draw.py
+++ b/pyglet/graphics/api/gl/draw.py
@@ -19,74 +19,6 @@ if TYPE_CHECKING:
     from pyglet.graphics.api.gl.vertexdomain import GLIndexedVertexList, GLVertexList
 
 
-# Default Shader source:
-
-_vertex_texture_source: str = """#version 330 core
-    in vec3 position;
-    in vec4 colors;
-    in vec3 tex_coords;
-    out vec4 vertex_colors;
-    out vec3 texture_coords;
-
-    uniform WindowBlock
-    {
-        mat4 projection;
-        mat4 view;
-    } window;
-
-    void main()
-    {
-        gl_Position = window.projection * window.view * vec4(position, 1.0);
-
-        vertex_colors = colors;
-        texture_coords = tex_coords;
-    }
-"""
-
-_fragment_texture_source: str = """#version 330 core
-    in vec4 vertex_colors;
-    in vec3 texture_coords;
-    out vec4 final_colors;
-
-    uniform sampler2D our_texture;
-
-    void main()
-    {
-        final_colors = texture(our_texture, texture_coords.xy) + vertex_colors;
-    }
-"""
-
-_vertex_primitive_source: str = """#version 330 core
-    in vec3 position;
-    in vec4 colors;
-
-    out vec4 vertex_colors;
-
-    uniform WindowBlock
-    {
-        mat4 projection;
-        mat4 view;
-    } window;
-
-    void main()
-    {
-        gl_Position = window.projection * window.view * vec4(position, 1.0);
-
-        vertex_colors = colors;
-    }
-"""
-
-_fragment_primitive_source: str = """#version 330 core
-    in vec4 vertex_colors;
-    out vec4 final_colors;
-
-    void main()
-    {
-        final_colors = vertex_colors;
-    }
-"""
-
-
 def get_default_batch() -> GLBatch:
     """Batch used globally for objects that have no Batch specified."""
     return pyglet.graphics.api.core.get_default_batch()
@@ -95,16 +27,6 @@ def get_default_batch() -> GLBatch:
     # except AttributeError:
     #     pyglet.graphics.api.core.current_context.pyglet_graphics_default_batch = Batch()
     #     return pyglet.graphics.api.core.current_context.pyglet_graphics_default_batch
-
-
-def get_default_shader() -> ShaderProgram:
-    """A default basic shader for default batches."""
-    return pyglet.graphics.api.core.get_cached_shader(
-        "default_graphics",
-        (_vertex_primitive_source, 'vertex'),
-        (_fragment_primitive_source, 'fragment'),
-    )
-
 
 _domain_class_map: dict[tuple[bool, bool], type[vertexdomain.GLVertexDomain]] = {
     # Indexed, Instanced : Domain

--- a/pyglet/graphics/api/gl/global_opengl.py
+++ b/pyglet/graphics/api/gl/global_opengl.py
@@ -13,7 +13,7 @@ from pyglet.graphics.api.base import (
     NullContext,
     UBOMatrixTransformations,
 )
-from pyglet.graphics.api.gl.shader import GLShader as Shader, GLShaderProgram as ShaderProgram
+from pyglet.graphics.shader import Shader, ShaderProgram
 
 if TYPE_CHECKING:
     from pyglet.config.gl import GLSurfaceConfig

--- a/pyglet/graphics/api/gl/shader.py
+++ b/pyglet/graphics/api/gl/shader.py
@@ -24,7 +24,7 @@ from ctypes import (
     create_string_buffer,
     sizeof, c_void_p,
 )
-from typing import TYPE_CHECKING, Any, Callable, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Sequence, Type, Union, overload
 
 import pyglet
 from pyglet.graphics.api.gl import GLException, gl, OpenGLSurfaceContext
@@ -41,7 +41,7 @@ from pyglet.graphics.shader import (
     AttributeView,
     _build_uniform_struct_from_uniforms,
     GraphicsAttribute,
-    Shader,
+    _AbstractShader,
     UBOBindingManager,
     UniformArrayBase,
     UniformBase,
@@ -517,7 +517,7 @@ def _introspect_attributes(ctx, program_id: int) -> dict[str, Attribute]:
     return attributes
 
 
-def _link_program(ctx, *shaders: Shader) -> int:
+def _link_program(ctx: OpenGLSurfaceContext, *shaders: GLShader) -> int:
     """Link one or more Shaders into a ShaderProgram.
 
     Returns:
@@ -903,7 +903,7 @@ class GLShaderSource(ShaderSource):
         raise ShaderException(msg)
 
 
-class GLShader(Shader):
+class GLShader(_AbstractShader):
     """OpenGL shader.
 
     Shader objects are compiled on instantiation.
@@ -1054,21 +1054,6 @@ class GLShaderProgram(ShaderProgram):
         return self._id
 
     @property
-    def uniforms(self) -> dict[str, Any]:
-        """Uniform metadata dictionary.
-
-        This property returns a dictionary containing metadata of all
-        Uniforms that were introspected in this ShaderProgram. Modifying
-        this dictionary has no effect. To set or get a uniform, the uniform
-        name is used as a key on the ShaderProgram instance. For example::
-
-            my_shader_program[uniform_name] = 123
-            value = my_shader_program[uniform_name]
-
-        """
-        return {n: {'location': u.location, 'length': u.length, 'size': u.size} for n, u in self._uniforms.items()}
-
-    @property
     def shader_storage_blocks(self) -> dict[str, GLShaderStorageBlock]:
         """A dictionary of introspected Shader Storage Blocks."""
         return self._shader_storage_blocks
@@ -1077,13 +1062,6 @@ class GLShaderProgram(ShaderProgram):
         self._context.glUseProgram(self._id)
 
     def stop(self) -> None:
-        self._context.glUseProgram(0)
-
-    __enter__ = use
-    bind = use
-    unbind = stop
-
-    def __exit__(self, *_) -> None:  # noqa: ANN002
         self._context.glUseProgram(0)
 
     def delete(self) -> None:
@@ -1133,8 +1111,33 @@ class GLShaderProgram(ShaderProgram):
         except GLException as err:
             raise ShaderException from err
 
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: None = None,
+                            instances: None = None, batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> VertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] = ...,
+                            instances: None = None, batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> IndexedVertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: None = None,
+                            instances: dict[str, int] = ..., batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> InstanceVertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] = ...,
+                            instances: dict[str, int] = ..., batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> InstanceIndexedVertexList:
+        ...
+
     def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] | None = None,
-                            instances: dict[str, int] | None = None, batch: Batch | None = None, group: Group | None = None,
+                            instances: dict[str, int] | None = None,
+                            batch: Batch | None = None, group: Group | None = None,
                             **data: Any) -> VertexList | InstanceVertexList | IndexedVertexList | InstanceIndexedVertexList:
         assert isinstance(mode, GeometryMode), f"Mode {mode} is not geometry mode."
         attributes = {}
@@ -1186,66 +1189,6 @@ class GLShaderProgram(ShaderProgram):
             vlist.set_attribute_data(name, array)
 
         return vlist
-
-    def vertex_list(self, count: int, mode: GeometryMode, batch: Batch | None = None, group: Group | None = None,
-                    **data: Any) -> VertexList:
-        """Create a VertexList.
-
-        Args:
-            count:
-                The number of vertices in the list.
-            mode:
-                OpenGL drawing mode enumeration; for example, one of
-                ``GL_POINTS``, ``GL_LINES``, ``GL_TRIANGLES``, etc.
-                This determines how the list is drawn in the given batch.
-            batch:
-                Batch to add the VertexList to, or ``None`` if a Batch will not be used.
-                Using a Batch is strongly recommended.
-            group:
-                Group to add the VertexList to, or ``None`` if no group is required.
-            data:
-                Attribute formats and initial data for the vertex list.
-
-        """
-        return self._vertex_list_create(count, mode, None, None, batch=batch, group=group, **data)
-
-    def vertex_list_instanced(self, count: int, mode: GeometryMode, instance_attributes: Sequence[str],
-                              batch: Batch | None = None, group: Group | None = None, **data: Any) -> InstanceVertexList:
-        assert len(instance_attributes) > 0, "You must provide at least one attribute name to be instanced."
-        return self._vertex_list_create(count, mode, None, instance_attributes, batch=batch, group=group, **data)
-
-    def vertex_list_indexed(self, count: int, mode: GeometryMode, indices: Sequence[int],
-                            batch: Batch | None = None, group: Group | None = None, **data: Any) -> IndexedVertexList:
-        """Create a IndexedVertexList.
-
-        Args:
-            count:
-                The number of vertices in the list.
-            mode:
-                OpenGL drawing mode enumeration; for example, one of
-                ``GL_POINTS``, ``GL_LINES``, ``GL_TRIANGLES``, etc.
-                This determines how the list is drawn in the given batch.
-            indices:
-                Sequence of integers giving indices into the vertex list.
-            batch:
-                Batch to add the VertexList to, or ``None`` if a Batch will not be used.
-                Using a Batch is strongly recommended.
-            group:
-                Group to add the VertexList to, or ``None`` if no group is required.
-            data:
-                Attribute formats and initial data for the vertex list.
-        """
-        return self._vertex_list_create(count, mode, indices, None, batch=batch, group=group, **data)
-
-    def vertex_list_instanced_indexed(self, count: int, *, mode: GeometryMode, indices: Sequence[int],
-                                      instance_attributes: Sequence[str],
-                                      batch: Batch | None = None, group: Group | None = None,
-                                      **data: Any) -> IndexedVertexList:
-        assert len(instance_attributes) > 0, "You must provide at least one attribute name to be instanced."
-        return self._vertex_list_create(count, mode, indices, instance_attributes, batch=batch, group=group, **data)
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(id={self.id})"
 
 
 class GLComputeShaderProgram:

--- a/pyglet/graphics/api/gl/shader.py
+++ b/pyglet/graphics/api/gl/shader.py
@@ -1332,3 +1332,43 @@ class GLComputeShaderProgram:
             return uniform.get()
         except GLException as err:
             raise ShaderException from err
+
+
+_default_vertex_source: str = """#version 330 core
+    in vec3 position;
+    in vec4 colors;
+
+    out vec4 vertex_colors;
+
+    uniform WindowBlock
+    {
+        mat4 projection;
+        mat4 view;
+    } window;
+
+    void main()
+    {
+        gl_Position = window.projection * window.view * vec4(position, 1.0);
+
+        vertex_colors = colors;
+    }
+"""
+
+_default_fragment_source: str = """#version 330 core
+    in vec4 vertex_colors;
+    out vec4 final_colors;
+
+    void main()
+    {
+        final_colors = vertex_colors;
+    }
+"""
+
+
+def get_default_shader() -> GLShaderProgram:
+    """A default basic shader for default batches."""
+    return pyglet.graphics.api.core.get_cached_shader(
+        "default_graphics",
+        (_default_vertex_source, 'vertex'),
+        (_default_fragment_source, 'fragment'),
+    )

--- a/pyglet/graphics/api/gl2/draw.py
+++ b/pyglet/graphics/api/gl2/draw.py
@@ -15,7 +15,7 @@ import pyglet
 from pyglet.graphics.api.gl.enums import geometry_map
 from pyglet.graphics.api.gl2.vertexdomain import VertexList, IndexedVertexList, VertexDomain, IndexedVertexDomain, \
     InstancedVertexDomain, InstancedIndexedVertexDomain
-from pyglet.graphics.draw import _DomainKey, Batch as BaseBatch, Group
+from pyglet.graphics.draw import _DomainKey, Batch, Group
 
 
 _debug_graphics_batch = pyglet.options.debug_graphics_batch
@@ -27,38 +27,6 @@ if TYPE_CHECKING:
     from pyglet.enums import GeometryMode
     from pyglet.graphics.api.gl2.shader import ShaderProgram
 
-
-
-
-# Default Shader source (Primitives):
-
-_vertex_source: str = """#version 110
-    attribute vec3 position;
-    attribute vec4 colors;
-
-    varying vec4 vertex_colors;
-
-    uniform mat4 u_projection;
-    uniform mat4 u_view;
-
-    void main()
-    {
-        gl_Position = u_projection * u_view * vec4(position, 1.0);
-
-        vertex_colors = colors;
-    }
-"""
-
-_fragment_source: str = """#version 110
-    varying vec4 vertex_colors;
-
-    void main()
-    {
-        gl_FragColor = vertex_colors;
-    }
-"""
-
-
 def get_default_batch() -> GL2Batch:
     """Batch used globally for objects that have no Batch specified."""
     return pyglet.graphics.api.core.get_default_batch()
@@ -67,16 +35,6 @@ def get_default_batch() -> GL2Batch:
     # except AttributeError:
     #     pyglet.graphics.api.core.current_context.pyglet_graphics_default_batch = Batch()
     #     return pyglet.graphics.api.core.current_context.pyglet_graphics_default_batch
-
-
-def get_default_shader() -> ShaderProgram:
-    """A default basic shader for default batches."""
-    return pyglet.graphics.api.core.get_cached_shader(
-        "default_graphics",
-        (_vertex_source, 'vertex'),
-        (_fragment_source, 'fragment'),
-    )
-
 
 _domain_class_map: dict[tuple[bool, bool], type[VertexDomain]] = {
     # Indexed, Instanced : Domain
@@ -89,7 +47,7 @@ _domain_class_map: dict[tuple[bool, bool], type[VertexDomain]] = {
 
 
 
-class GL2Batch(BaseBatch):
+class GL2Batch(Batch):
     """Manage a collection of drawables for batched rendering.
 
     Many drawable pyglet objects accept an optional `Batch` argument in their

--- a/pyglet/graphics/api/gl2/global_opengl.py
+++ b/pyglet/graphics/api/gl2/global_opengl.py
@@ -8,7 +8,7 @@ import pyglet
 from pyglet.enums import GraphicsAPI
 from pyglet.graphics.api.gl.global_opengl import OpenGLBackend
 from pyglet.graphics.api.base import WindowTransformations
-from pyglet.graphics.api.gl2.shader import ShaderProgram, Shader
+from pyglet.graphics.shader import ShaderProgram, Shader
 
 from pyglet.math import Mat4
 

--- a/pyglet/graphics/api/gl2/shader.py
+++ b/pyglet/graphics/api/gl2/shader.py
@@ -185,3 +185,39 @@ class ComputeShaderProgram:
 
     def __init__(self, source: str) -> None:
         raise NotImplementedError
+
+
+_default_vertex_source: str = """#version 110
+    attribute vec3 position;
+    attribute vec4 colors;
+
+    varying vec4 vertex_colors;
+
+    uniform mat4 u_projection;
+    uniform mat4 u_view;
+
+    void main()
+    {
+        gl_Position = u_projection * u_view * vec4(position, 1.0);
+
+        vertex_colors = colors;
+    }
+"""
+
+_default_fragment_source: str = """#version 110
+    varying vec4 vertex_colors;
+
+    void main()
+    {
+        gl_FragColor = vertex_colors;
+    }
+"""
+
+
+def get_default_shader() -> ShaderProgram:
+    """A default basic shader for default batches."""
+    return pyglet.graphics.api.core.get_cached_shader(
+        "default_graphics",
+        (_default_vertex_source, 'vertex'),
+        (_default_fragment_source, 'fragment'),
+    )

--- a/pyglet/graphics/api/gl2/shader.py
+++ b/pyglet/graphics/api/gl2/shader.py
@@ -172,10 +172,6 @@ class ShaderProgram(GLShaderProgram):  # noqa: D101
     _uniform_blocks: None
     __slots__ = '_attributes', '_context', '_id', '_uniform_blocks', '_uniforms'
 
-    def __init__(self, *shaders: Shader) -> None:
-        """Initialize the ShaderProgram using at least two Shader instances."""
-        super().__init__(*shaders)
-
     def _get_uniform_blocks(self) -> None:
         """Return Uniform Block information."""
         return

--- a/pyglet/graphics/api/gl2/shapes.py
+++ b/pyglet/graphics/api/gl2/shapes.py
@@ -3,7 +3,7 @@ import pyglet
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pyglet.graphics.api import ShaderProgram
+    from pyglet.graphics.shader import ShaderProgram
 
 vertex_source = """#version 110
     attribute vec2 position;

--- a/pyglet/graphics/api/webgl/__init__.py
+++ b/pyglet/graphics/api/webgl/__init__.py
@@ -14,7 +14,7 @@ from pyglet.graphics.api.base import (
     UBOMatrixTransformations,
     NullContext,
 )
-from pyglet.graphics.api.webgl.shader import WebGLShader as Shader, WebGLShaderProgram as ShaderProgram
+from pyglet.graphics.shader import Shader, ShaderProgram
 from pyglet.math import Mat4
 
 if TYPE_CHECKING:

--- a/pyglet/graphics/api/webgl/draw.py
+++ b/pyglet/graphics/api/webgl/draw.py
@@ -16,40 +16,6 @@ if TYPE_CHECKING:
     from pyglet.graphics.api.webgl.context import OpenGLSurfaceContext
     from pyglet.graphics.state import State
 
-
-# Default Shader source:
-
-_vertex_source: str = """#version 330 core
-    in vec3 position;
-    in vec4 colors;
-
-    out vec4 vertex_colors;
-
-    uniform WindowBlock
-    {
-        mat4 projection;
-        mat4 view;
-    } window;
-
-    void main()
-    {
-        gl_Position = window.projection * window.view * vec4(position, 1.0);
-
-        vertex_colors = colors;
-    }
-"""
-
-_fragment_source: str = """#version 330 core
-    in vec4 vertex_colors;
-    out vec4 final_colors;
-
-    void main()
-    {
-        final_colors = vertex_colors;
-    }
-"""
-
-
 def get_default_batch() -> WebGLBatch:
     """Batch used globally for objects that have no Batch specified."""
     return pyglet.graphics.api.core.get_default_batch()
@@ -58,16 +24,6 @@ def get_default_batch() -> WebGLBatch:
     # except AttributeError:
     #     pyglet.graphics.api.core.current_context.pyglet_graphics_default_batch = Batch()
     #     return pyglet.graphics.api.core.current_context.pyglet_graphics_default_batch
-
-
-def get_default_shader() -> ShaderProgram:
-    """A default basic shader for default batches."""
-    return pyglet.graphics.api.core.get_cached_shader(
-        "default_graphics",
-        (_vertex_source, 'vertex'),
-        (_fragment_source, 'fragment'),
-    )
-
 
 _domain_class_map: dict[tuple[bool, bool], type[vertexdomain.WebGLVertexDomain]] = {
     # Indexed, Instanced : Domain

--- a/pyglet/graphics/api/webgl/shader.py
+++ b/pyglet/graphics/api/webgl/shader.py
@@ -17,7 +17,7 @@ from ctypes import (
     cast,
     sizeof,
 )
-from typing import TYPE_CHECKING, Any, Callable, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Sequence, Type, Union, overload
 
 import pyglet
 
@@ -33,6 +33,7 @@ from pyglet.graphics.api.webgl.gl import (
     GL_UNIFORM_BUFFER,
 )
 from pyglet.graphics.shader import (
+    _AbstractShader,
     Attribute,
     Shader,
     ShaderException,
@@ -59,8 +60,6 @@ class GLException(Exception):
 
 
 if TYPE_CHECKING:
-    from _weakref import CallableProxyType
-
     from pyglet.customtypes import CTypesPointer, DataTypes, CType
     from pyglet.graphics import Batch, Group
     from pyglet.graphics.api.webgl.context import OpenGLSurfaceContext
@@ -384,7 +383,7 @@ class WebGLUniformBlock(BaseUniformBlock):  # noqa: D101
 
     def __init__(
         self,
-        program: ShaderProgram,
+        program: WebGLShaderProgram,
         name: str,
         index: int,
         size: int,
@@ -550,7 +549,7 @@ def _introspect_uniforms(gl_ctx: WebGLRenderingContext, program_id: WebGLProgram
 
 
 def _introspect_uniform_blocks(
-    ctx: OpenGLSurfaceContext, program: ShaderProgram | WebGLComputeShaderProgram,
+    ctx: OpenGLSurfaceContext, program: WebGLShaderProgram | WebGLComputeShaderProgram,
 ) -> dict[str, WebGLUniformBlock]:
     uniform_blocks = {}
     gl_ctx: WebGL2RenderingContext = ctx.gl
@@ -678,7 +677,7 @@ class GLShaderSource(ShaderSource):
         raise ShaderException(msg)
 
 
-class WebGLShader(Shader):
+class WebGLShader(_AbstractShader):
     """OpenGL shader.
 
     Shader objects are compiled on instantiation.
@@ -829,32 +828,10 @@ class WebGLShaderProgram(ShaderProgram):
     def id(self) -> WebGLProgram | None:
         return self._id
 
-    @property
-    def uniforms(self) -> dict[str, Any]:
-        """Uniform metadata dictionary.
-
-        This property returns a dictionary containing metadata of all
-        Uniforms that were introspected in this ShaderProgram. Modifying
-        this dictionary has no effect. To set or get a uniform, the uniform
-        name is used as a key on the ShaderProgram instance. For example::
-
-            my_shader_program[uniform_name] = 123
-            value = my_shader_program[uniform_name]
-
-        """
-        return {n: {'location': u.location, 'length': u.length, 'size': u.size} for n, u in self._uniforms.items()}
-
     def use(self) -> None:
         self._gl.useProgram(self._id)
 
     def stop(self) -> None:
-        self._gl.useProgram(None)
-
-    __enter__ = use
-    bind = use
-    unbind = stop
-
-    def __exit__(self, *_) -> None:  # noqa: ANN002
         self._gl.useProgram(None)
 
     def delete(self) -> None:
@@ -908,8 +885,33 @@ class WebGLShaderProgram(ShaderProgram):
             raise ShaderException from err
 
 
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: None = None,
+                            instances: None = None, batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> VertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] = ...,
+                            instances: None = None, batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> IndexedVertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: None = None,
+                            instances: dict[str, int] = ..., batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> InstanceVertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] = ...,
+                            instances: dict[str, int] = ..., batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> InstanceIndexedVertexList:
+        ...
+
     def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] | None = None,
-                            instances: dict[str, int] | None = None, batch: Batch | None = None, group: Group | None = None,
+                            instances: dict[str, int] | None = None,
+                            batch: Batch | None = None, group: Group | None = None,
                             **data: Any) -> VertexList | InstanceVertexList | IndexedVertexList | InstanceIndexedVertexList:
         assert isinstance(mode, GeometryMode), f"Mode {mode} is not geometry mode."
         attributes = {}
@@ -958,88 +960,6 @@ class WebGLShaderProgram(ShaderProgram):
             vlist.set_attribute_data(name, array)
 
         return vlist
-
-
-    def vertex_list(
-        self, count: int, mode: GeometryMode, batch: Batch | None = None, group: Group | None = None, **data: Any,
-    ) -> VertexList:
-        """Create a VertexList.
-
-        Args:
-            count:
-                The number of vertices in the list.
-            mode:
-                OpenGL drawing mode enumeration; for example, one of
-                ``GL_POINTS``, ``GL_LINES``, ``GL_TRIANGLES``, etc.
-                This determines how the list is drawn in the given batch.
-            batch:
-                Batch to add the VertexList to, or ``None`` if a Batch will not be used.
-                Using a Batch is strongly recommended.
-            group:
-                Group to add the VertexList to, or ``None`` if no group is required.
-            data:
-                Attribute formats and initial data for the vertex list.
-
-        """
-        return self._vertex_list_create(count, mode, None, None, batch=batch, group=group, **data)
-
-    def vertex_list_instanced(
-        self,
-        count: int,
-        mode: GeometryMode,
-        instance_attributes: Sequence[str],
-        batch: Batch | None = None,
-        group: Group | None = None,
-        **data: Any,
-    ) -> VertexList:
-        assert len(instance_attributes) > 0, "You must provide at least one attribute name to be instanced."
-        return self._vertex_list_create(count, mode, None, instance_attributes, batch=batch, group=group, **data)
-
-    def vertex_list_indexed(
-        self,
-        count: int,
-        mode: GeometryMode,
-        indices: Sequence[int],
-        batch: Batch | None = None,
-        group: Group | None = None,
-        **data: Any,
-    ) -> IndexedVertexList:
-        """Create a IndexedVertexList.
-
-        Args:
-            count:
-                The number of vertices in the list.
-            mode:
-                OpenGL drawing mode enumeration; for example, one of
-                ``GL_POINTS``, ``GL_LINES``, ``GL_TRIANGLES``, etc.
-                This determines how the list is drawn in the given batch.
-            indices:
-                Sequence of integers giving indices into the vertex list.
-            batch:
-                Batch to add the VertexList to, or ``None`` if a Batch will not be used.
-                Using a Batch is strongly recommended.
-            group:
-                Group to add the VertexList to, or ``None`` if no group is required.
-            data:
-                Attribute formats and initial data for the vertex list.
-        """
-        return self._vertex_list_create(count, mode, indices, None, batch=batch, group=group, **data)
-
-    def vertex_list_instanced_indexed(
-        self,
-        count: int,
-        mode: GeometryMode,
-        indices: Sequence[int],
-        instance_attributes: Sequence[str],
-        batch: Batch | None = None,
-        group: Group | None = None,
-        **data: Any,
-    ) -> IndexedVertexList:
-        assert len(instance_attributes) > 0, "You must provide at least one attribute name to be instanced."
-        return self._vertex_list_create(count, mode, indices, instance_attributes, batch=batch, group=group, **data)
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(id={self.id})"
 
 
 class WebGLComputeShaderProgram:

--- a/pyglet/graphics/api/webgl/shader.py
+++ b/pyglet/graphics/api/webgl/shader.py
@@ -968,3 +968,43 @@ class WebGLComputeShaderProgram:
     def __init__(self, source: str) -> None:
         """Create an OpenGL ComputeShaderProgram from source."""
         raise ShaderException("Compute Shaders are not supported in WebGL.")
+
+
+_default_vertex_source: str = """#version 330 core
+    in vec3 position;
+    in vec4 colors;
+
+    out vec4 vertex_colors;
+
+    uniform WindowBlock
+    {
+        mat4 projection;
+        mat4 view;
+    } window;
+
+    void main()
+    {
+        gl_Position = window.projection * window.view * vec4(position, 1.0);
+
+        vertex_colors = colors;
+    }
+"""
+
+_default_fragment_source: str = """#version 330 core
+    in vec4 vertex_colors;
+    out vec4 final_colors;
+
+    void main()
+    {
+        final_colors = vertex_colors;
+    }
+"""
+
+
+def get_default_shader() -> WebGLShaderProgram:
+    """A default basic shader for default batches."""
+    return pyglet.graphics.api.core.get_cached_shader(
+        "default_graphics",
+        (_default_vertex_source, 'vertex'),
+        (_default_fragment_source, 'fragment'),
+    )

--- a/pyglet/graphics/atlas.py
+++ b/pyglet/graphics/atlas.py
@@ -5,7 +5,7 @@ This can have major performance benefits when dealing with a large number of ima
 
 :py:class:`~pyglet.image.atlas.TextureAtlas` maintains one texture; :py:class:`TextureBin`
 manages a collection of atlases of a given size. :py:class:`TextureArrayBin` works similarly
-except for :py:class:`~pyglet.graphics.TextureArray`s instead of altases.
+except for :py:class:`~pyglet.graphics.texture.TextureArray`s instead of altases.
 
 This module is used internally by the :py:mod:`~pyglet.resource` module.
 
@@ -140,7 +140,7 @@ class TextureAtlas:
     by allowing all the Images to be drawn together with a single
     Texture bind, rather than multiple tiny Texture binds per draw.
 
-    When creating a TextureAtlas instance, a new :py:class:`~pyglet.graphics.Texture`
+    When creating a TextureAtlas instance, a new :py:class:`~pyglet.graphics.texture.Texture`
     object will be created at the requested size. If the maximum texture
     size supported by the OpenGL driver is less than requested, the
     smaller of the two will be used.
@@ -159,7 +159,7 @@ class TextureAtlas:
         """Add ImageData to the atlas.
 
         Given :py:class:`~pyglet.image.ImageData`, add it to the Atlas and
-        return a new :py:class:`~pyglet.graphics.TextureRegion` object. An
+        return a new :py:class:`~pyglet.graphics.texture.TextureRegion` object. An
         optional ``border`` argument can be passed, which will leave the
         specified number of blank pixels around the added ImageData. This
         can be useful in certain situations and blend modes, where
@@ -234,7 +234,7 @@ class TextureArrayBin:
     def add(self, img: ImageData) -> TextureArrayRegion:
         """Add an image into this texture array bin.
 
-        This method calls :py:meth:`~pyglet.graphics.TextureArray.add` for the first
+        This method calls :py:meth:`~pyglet.graphics.texture.TextureArray.add` for the first
         array that has room for the image.
 
         ``TextureArraySizeExceeded`` is raised if the image exceeds the dimensions of

--- a/pyglet/graphics/draw.py
+++ b/pyglet/graphics/draw.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import sys
 import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, Sequence, TYPE_CHECKING
 
 import pyglet
-from pyglet.enums import BlendFactor, BlendOp, CompareOp, GeometryMode
+from pyglet.enums import BlendFactor, BlendOp, CompareOp, GeometryMode, GraphicsAPI
 
 from pyglet.graphics.state import (
     State,
@@ -574,4 +575,41 @@ class ShaderGroup(Group):
     def __init__(self, program: ShaderProgram, order: int = 0, parent: Group | None = None) -> None:
         super().__init__(order, parent)
         self.set_shader_program(program)
+
+
+def get_default_batch() -> Batch:
+    """The built in batch object used for objects that have no specified batch."""
+    msg = "Default batch is not available for this backend."
+    raise RuntimeError(msg)
+
+
+_is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
+
+if not _is_pyglet_doc_run:
+    if pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_ES_3):
+        from pyglet.graphics.api.gl.draw import (
+            GLBatch,
+            get_default_batch as _backend_get_default_batch,
+        )
+
+        Batch = GLBatch
+        get_default_batch = _backend_get_default_batch
+
+    elif pyglet.options.backend in (GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2):
+        from pyglet.graphics.api.gl2.draw import (
+            GL2Batch,
+            get_default_batch as _backend_get_default_batch,
+        )
+
+        Batch = GL2Batch
+        get_default_batch = _backend_get_default_batch
+
+    elif pyglet.options.backend == GraphicsAPI.WEBGL:
+        from pyglet.graphics.api.webgl.draw import (
+            WebGLBatch,
+            get_default_batch as _backend_get_default_batch,
+        )
+
+        Batch = WebGLBatch
+        get_default_batch = _backend_get_default_batch
 

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -8,7 +8,7 @@ import weakref
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Literal, Sequence, Any, TYPE_CHECKING, Callable, Protocol
+from typing import Literal, Sequence, Any, TYPE_CHECKING, Callable, Protocol, overload
 
 
 if TYPE_CHECKING:
@@ -65,8 +65,10 @@ class Sampler:
     stages: Sequence[ShaderType] = ("fragment",)
 
 
-class ShaderProgram(ABC):
+class _AbstractShaderProgram(ABC):
+    _id: int | None
     _attributes: dict[str, Attribute]
+    _uniforms: dict[str, Any]
     _uniform_blocks: dict[str, UniformBlock]
     _samplers: dict[str, Sampler]
 
@@ -78,11 +80,17 @@ class ShaderProgram(ABC):
         # Attribute description
         self._attributes = {}
 
+        # Uniform description
+        self._uniforms = {}
+
         # Uniform Block description
         self._uniform_blocks = {}
 
+        # Sampler descriptions
+        self._samplers = {}
+
     @property
-    def id(self):
+    def id(self) -> int | None:
         return self._id
 
     @property
@@ -134,8 +142,82 @@ class ShaderProgram(ABC):
         """
         return self._uniform_blocks
 
+    @property
+    def samplers(self) -> dict[str, Sampler]:
+        """A dictionary of introspected samplers.
+
+        This property returns a dictionary of
+        :py:class:`~pyglet.graphics.shader.Sampler` instances keyed by sampler name.
+        """
+        return self._samplers
+
+    @property
+    def uniforms(self) -> dict[str, Any]:
+        """Uniform metadata dictionary.
+
+        This property returns a dictionary containing metadata of all
+        Uniforms that were introspected in this ShaderProgram. Modifying
+        this dictionary has no effect. To set or get a uniform, the uniform
+        name is used as a key on the ShaderProgram instance. For example::
+
+            my_shader_program[uniform_name] = 123
+            value = my_shader_program[uniform_name]
+
+        """
+        return {n: {'location': u.location, 'length': u.length, 'size': u.size} for n, u in self._uniforms.items()}
+
+    def use(self) -> None:
+        """Bind this shader program for rendering commands."""
+        raise NotImplementedError
+
+    def bind(self) -> None:
+        """Alias for :meth:`use`."""
+        self.use()
+
+    def stop(self) -> None:
+        """Unbind this shader program from rendering commands."""
+        raise NotImplementedError
+
+    def unbind(self) -> None:
+        """Alias for :meth:`stop`."""
+        self.stop()
+
+    def delete(self) -> None:
+        """Delete this shader program and release backend resources."""
+        raise NotImplementedError
+
+    def __enter__(self) -> None:
+        self.use()
+
+    def __exit__(self, *_) -> None:  # noqa: ANN002
+        self.stop()
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: None = None,
+                            instances: None = None, batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> VertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] = ...,
+                            instances: None = None, batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> IndexedVertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: None = None,
+                            instances: dict[str, int] = ..., batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> InstanceVertexList:
+        ...
+
+    @overload
+    def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] = ...,
+                            instances: dict[str, int] = ..., batch: Batch | None = None, group: Group | None = None,
+                            **data: Any) -> InstanceIndexedVertexList:
+        ...
+
     def _vertex_list_create(self, count: int, mode: GeometryMode, indices: Sequence[int] | None = None,
-                            instances: Sequence[str] | None = None, batch: Batch | None = None, group: Group | None = None,
+                            instances: dict[str, int] | None = None, batch: Batch | None = None, group: Group | None = None,
                             **data: Any) -> VertexList | InstanceVertexList | IndexedVertexList | InstanceIndexedVertexList:
         raise NotImplementedError
 
@@ -190,13 +272,34 @@ class ShaderProgram(ABC):
         return self._vertex_list_create(count, mode, indices, None, batch=batch, group=group, **data)
 
     def vertex_list_instanced_indexed(self, count: int, *, mode: GeometryMode, indices: Sequence[int],
-                                      instance_attributes: Sequence[str], batch: Batch | None = None, group: Group | None = None,
+                                      instance_attributes: dict[str, int], batch: Batch | None = None, group: Group | None = None,
                                       **data: Any) -> InstanceIndexedVertexList:
         assert len(instance_attributes) > 0, "You must provide at least one attribute name to be instanced."
         return self._vertex_list_create(count, mode, indices, instance_attributes, batch=batch, group=group, **data)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(id={self.id})"
+
+
+class ShaderProgram(_AbstractShaderProgram):
+    """Backend-agnostic shader program container.
+
+    Concrete backends are responsible for compiling/linking shaders,
+    introspecting attributes and uniforms, and providing API-specific
+    program state management.
+    """
+
+    def __init__(self, *shaders: Shader) -> None:
+        """Initialize a shader program from one or more Shader objects.
+
+        Args:
+            shaders:
+                One or more :py:class:`~pyglet.graphics.shader.Shader`
+                instances to be linked into a program by the active backend.
+                At least one shader is required.
+        """
+        super().__init__(*shaders)
+
 
 class ShaderSource(abc.ABC):
     """String source of shader used during load of a Shader instance."""
@@ -206,7 +309,7 @@ class ShaderSource(abc.ABC):
         """Return the validated shader source."""
 
 
-class Shader(abc.ABC):
+class _AbstractShader(abc.ABC):
     """Graphics shader.
 
     Shader objects may be compiled on instantiation if OpenGL or already compiled in Vulkan.
@@ -237,6 +340,29 @@ class Shader(abc.ABC):
     @abstractmethod
     def get_string_class() -> type[ShaderSource]:
         """Return the proper ShaderSource class used to validate the shader."""
+
+class Shader(_AbstractShader):
+    """Graphics shader.
+
+    Shader objects may be compiled on instantiation if OpenGL or already compiled in Vulkan.
+    You can reuse a Shader object in multiple ShaderPrograms.
+    """
+    _src_str: str
+    type: ShaderType
+
+    def __init__(self, source_string: str, shader_type: ShaderType) -> None:
+        """Initialize a shader type."""
+        super().__init__(source_string, shader_type)
+
+    @classmethod
+    def supported_shaders(cls: type[_AbstractShader]) -> tuple[ShaderType, ...]:
+        """Return the supported shader types for this shader class."""
+        raise NotImplementedError
+
+    @staticmethod
+    def get_string_class() -> type[ShaderSource]:
+        """Return the proper ShaderSource class used to validate the shader."""
+        raise NotImplementedError
 
 DataTypeTuple = ('?', 'f', 'i', 'I', 'h',  'H', 'b', 'B', 'q','Q')
 

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import ctypes
 import re
+import sys
 import warnings
 import weakref
 from abc import ABC, abstractmethod
@@ -10,6 +11,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Literal, Sequence, Any, TYPE_CHECKING, Callable, Protocol, overload
 
+import pyglet
+from pyglet.enums import GraphicsAPI
 
 if TYPE_CHECKING:
     from pyglet.graphics.buffer import UniformBufferObject
@@ -289,7 +292,7 @@ class ShaderProgram(_AbstractShaderProgram):
     program state management.
     """
 
-    def __init__(self, *shaders: Shader) -> None:
+    def __init__(self, *shaders: _AbstractShader) -> None:
         """Initialize a shader program from one or more Shader objects.
 
         Args:
@@ -299,6 +302,14 @@ class ShaderProgram(_AbstractShaderProgram):
                 At least one shader is required.
         """
         super().__init__(*shaders)
+
+
+class ComputeShaderProgram:
+    """Backend-agnostic compute shader program container."""
+
+    def __init__(self, source: str) -> None:
+        msg = f"{self.__class__.__name__} is backend-specific and must be provided by the active backend."
+        raise NotImplementedError(msg)
 
 
 class ShaderSource(abc.ABC):
@@ -900,3 +911,34 @@ class UniformBlock:
     def __repr__(self) -> str:
         return (f"{self.__class__.__name__}(program={self.program.id}, location={self.index}, size={self.size}, "
                 f"binding={self.binding})")
+
+
+def get_default_shader() -> ShaderProgram:
+    """A default shader for rendering primitives."""
+    raise NotImplementedError
+
+_is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
+
+if not _is_pyglet_doc_run:
+    if pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_ES_3):
+        from pyglet.graphics.api.gl.shader import (
+            GLComputeShaderProgram as ComputeShaderProgram,
+            GLShader as Shader,
+            GLShaderProgram as ShaderProgram,
+        )
+        from pyglet.graphics.api.gl.shader import get_default_shader
+    elif pyglet.options.backend in (GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2):
+        from pyglet.graphics.api.gl2.shader import ComputeShaderProgram, Shader, ShaderProgram
+        from pyglet.graphics.api.gl2.shader import get_default_shader
+    elif pyglet.options.backend == GraphicsAPI.WEBGL:
+        from pyglet.graphics.api.webgl.shader import (
+            WebGLComputeShaderProgram as ComputeShaderProgram,
+            WebGLShader as Shader,
+            WebGLShaderProgram as ShaderProgram,
+        )
+        from pyglet.graphics.api.webgl.shader import get_default_shader
+    elif pyglet.options.backend == GraphicsAPI.VULKAN:
+        from pyglet.graphics.api.vulkan.shader import ComputeShaderProgram, Shader, ShaderProgram
+    else:
+        msg = f"Unsupported backend: {pyglet.options.backend}"
+        raise RuntimeError(msg)

--- a/pyglet/graphics/texture.py
+++ b/pyglet/graphics/texture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Generic, Iterator, Literal, Protocol, Sequence, TYPE_CHECKING, TypeVar, overload
 
 import pyglet
@@ -33,8 +34,8 @@ TTexture = TypeVar("TTexture", bound="Texture")
 class TextureSequence(_AbstractImageSequence, Generic[TTexture]):
     """Interface for a sequence of textures.
 
-    Typical implementations store multiple :py:class:`~pyglet.graphics.TextureRegion`s
-    within one :py:class:`~pyglet.graphics.Texture` to minimise state changes.
+    Typical implementations store multiple :py:class:`~pyglet.graphics.texture.TextureRegion`s
+    within one :py:class:`~pyglet.graphics.texture.Texture` to minimise state changes.
     """
 
     @overload
@@ -857,7 +858,7 @@ class TextureGrid(_AbstractGrid[TextureRegion]):
         texture_grid = TextureGrid(image_grid)
 
     The texture grid can be accessed as a single texture, or as a sequence
-    of :py:class:`~pyglet.graphics.TextureRegion`.  When accessing as a sequence, you can specify
+    of :py:class:`~pyglet.graphics.texture.TextureRegion`.  When accessing as a sequence, you can specify
     integer indexes, in which the images are arranged in rows from the
     bottom-left to the top-right::
 
@@ -1002,52 +1003,55 @@ class CompressedTexture(_AbstractImage):
         raise NotImplementedError(msg)
 
 
-if pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2, GraphicsAPI.OPENGL_ES_3):
-    from pyglet.graphics.api.gl.framebuffer import (  # noqa: F401
-        GLFramebuffer as Framebuffer,
-        GLRenderbuffer as Renderbuffer,
-        get_max_color_attachments,
-        get_screenshot,
-    )
-    from pyglet.graphics.api.gl.texture import (
-        GLCompressedTexture,
-        GLCompressedTexture as CompressedTexture,  # noqa: F401
-        GLTexture,
-        GLTexture as Texture,  # noqa: F401
-        GLTextureRegion,
-        GLTextureRegion as TextureRegion,  # noqa: F401
-        GLTexture3D,
-        GLTexture3D as Texture3D,  # noqa: F401
-        GLTextureArray,
-        GLTextureArray as TextureArray,  # noqa: F401
-        GLTextureArrayRegion,
-        GLTextureArrayRegion as TextureArrayRegion,  # noqa: F401
-        GLTextureGrid,
-        GLTextureGrid as TextureGrid,  # noqa: F401
-        get_max_texture_size,
-        get_max_array_texture_layers,
-    )
-elif pyglet.options.backend == GraphicsAPI.WEBGL:
-    from pyglet.graphics.api.webgl.framebuffer import (  # noqa: F401
-        WebGLFramebuffer as Framebuffer,
-        WebGLRenderbuffer as Renderbuffer,
-        get_max_color_attachments,
-        get_screenshot,
-    )
-    from pyglet.graphics.api.webgl.texture import (
-        WebGLTexture,
-        WebGLTexture as Texture,  # noqa: F401
-        WebGLTextureRegion as TextureRegion,  # noqa: F401
-        WebGLTexture3D,
-        WebGLTexture3D as Texture3D,  # noqa: F401
-        WebGLTextureArray,
-        WebGLTextureArray as TextureArray,  # noqa: F401
-        WebGLTextureArrayRegion,
-        WebGLTextureArrayRegion as TextureArrayRegion,  # noqa: F401
-        WebGLTextureGrid,
-        WebGLTextureGrid as TextureGrid,  # noqa: F401
-        get_max_texture_size,  # noqa: F401
-        get_max_array_texture_layers,  # noqa: F401
-    )
-elif pyglet.options.backend == GraphicsAPI.VULKAN:
-    raise NotImplementedError("Vulkan is not yet implemented")
+_is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
+
+if not _is_pyglet_doc_run:
+    if pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2, GraphicsAPI.OPENGL_ES_3):
+        from pyglet.graphics.api.gl.framebuffer import (  # noqa: F401
+            GLFramebuffer as Framebuffer,
+            GLRenderbuffer as Renderbuffer,
+            get_max_color_attachments,
+            get_screenshot,
+        )
+        from pyglet.graphics.api.gl.texture import (
+            GLCompressedTexture,
+            GLCompressedTexture as CompressedTexture,  # noqa: F401
+            GLTexture,
+            GLTexture as Texture,  # noqa: F401
+            GLTextureRegion,
+            GLTextureRegion as TextureRegion,  # noqa: F401
+            GLTexture3D,
+            GLTexture3D as Texture3D,  # noqa: F401
+            GLTextureArray,
+            GLTextureArray as TextureArray,  # noqa: F401
+            GLTextureArrayRegion,
+            GLTextureArrayRegion as TextureArrayRegion,  # noqa: F401
+            GLTextureGrid,
+            GLTextureGrid as TextureGrid,  # noqa: F401
+            get_max_texture_size,
+            get_max_array_texture_layers,
+        )
+    elif pyglet.options.backend == GraphicsAPI.WEBGL:
+        from pyglet.graphics.api.webgl.framebuffer import (  # noqa: F401
+            WebGLFramebuffer as Framebuffer,
+            WebGLRenderbuffer as Renderbuffer,
+            get_max_color_attachments,
+            get_screenshot,
+        )
+        from pyglet.graphics.api.webgl.texture import (
+            WebGLTexture,
+            WebGLTexture as Texture,  # noqa: F401
+            WebGLTextureRegion as TextureRegion,  # noqa: F401
+            WebGLTexture3D,
+            WebGLTexture3D as Texture3D,  # noqa: F401
+            WebGLTextureArray,
+            WebGLTextureArray as TextureArray,  # noqa: F401
+            WebGLTextureArrayRegion,
+            WebGLTextureArrayRegion as TextureArrayRegion,  # noqa: F401
+            WebGLTextureGrid,
+            WebGLTextureGrid as TextureGrid,  # noqa: F401
+            get_max_texture_size,  # noqa: F401
+            get_max_array_texture_layers,  # noqa: F401
+        )
+    elif pyglet.options.backend == GraphicsAPI.VULKAN:
+        raise NotImplementedError("Vulkan is not yet implemented")

--- a/pyglet/graphics/texture.py
+++ b/pyglet/graphics/texture.py
@@ -450,8 +450,8 @@ class Texture(_AbstractImage):
         """Create a copy of this image applying a simple transformation.
 
         The transformation is applied to the texture coordinates only;
-        :py:meth:`~pyglet.image.AbstractImage.get_image_data` will return the
-        untransformed data. The transformation is applied around the anchor point.
+        :py:meth:`~pyglet.graphics.texture.Texture.get_image_data` will fetch the
+        untransformed data from the GPU. The transformation is applied around the anchor point.
 
         Args:
             flip_x:

--- a/pyglet/image/animation.py
+++ b/pyglet/image/animation.py
@@ -100,7 +100,7 @@ class Animation:
 
         This method is useful for determining texture space requirements: due
         to the use of ``anchor_x`` the actual required viewing area during
-         playback may be larger.
+        playback may be larger.
         """
         return max([frame.image.width for frame in self.frames])
 

--- a/pyglet/image/base.py
+++ b/pyglet/image/base.py
@@ -636,13 +636,13 @@ class ImageGrid(_AbstractGrid[Union[ImageData, ImageDataRegion]], _AbstractImage
 
     The grid can be accessed either as a complete image, or as a sequence of images.
 
-    Any :py:class:`~pyglet.graphics.TextureGrid` generated via the method below will create
+    Any :py:class:`~pyglet.graphics.texture.TextureGrid` generated via the method below will create
     a separate texture resource::
 
         image_grid = ImageGrid(...)
         texture_grid = image_grid.get_texture_sequence()
 
-    For existing Texture's, it is recommended to use :py:class:`~pyglet.graphics.TextureGrid` directly.
+    For existing Texture's, it is recommended to use :py:class:`~pyglet.graphics.texture.TextureGrid` directly.
     """
 
     _texture_grid: TextureGrid | None = None
@@ -706,9 +706,9 @@ class ImageGrid(_AbstractGrid[Union[ImageData, ImageDataRegion]], _AbstractImage
         return self.image.get_image_data()
 
     def get_texture_sequence(self) -> TextureGrid:
-        """Create a :py:class:`~pyglet.graphics.TextureGrid` resource from the underlying image data.
+        """Create a :py:class:`~pyglet.graphics.texture.TextureGrid` resource from the underlying image data.
 
-        It is recommended to use :py:class:`~pyglet.graphics.TextureGrid` directly.
+        It is recommended to use :py:class:`~pyglet.graphics.texture.TextureGrid` directly.
         """
         warnings.warn("Use pyglet.graphics.TextureGrid instead", DeprecationWarning)
         if not self._texture_grid:

--- a/pyglet/media/codecs/base.py
+++ b/pyglet/media/codecs/base.py
@@ -130,7 +130,7 @@ class AudioData:
         duration: float = 0.0,
         events: list[MediaEvent] | None = None,
     ) -> None:
-        """Events (List[:class:`pyglet.media.drivers.base.MediaEvent`]):
+        """Create an audio packet.
 
         Args:
             data:
@@ -145,7 +145,7 @@ class AudioData:
                 List of events contained within this packet. Events are timestamped relative to this audio packet.
 
         .. deprecated:: 2.0.10
-        `timestamp` and `duration` are unused and will be removed eventually.
+           `timestamp` and `duration` are unused and will be removed eventually.
         """
         if isinstance(data, bytes):
             # bytes are treated specially by ctypes and can be cast to a void pointer, get

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -14,6 +14,7 @@ from pyglet.util import debug_print
 _debug = debug_print('debug_media')
 
 if TYPE_CHECKING:
+    from pyglet.graphics.draw import Batch
     from pyglet.graphics import Texture
 
 
@@ -520,7 +521,14 @@ class VideoPlayer(AudioPlayer):
     """High-level sound and video player."""
     _sprite: pyglet.sprite.Sprite | None
 
-    def __init__(self, batch: pyglet.graphics.Batch | None = None) -> None:
+    def __init__(self, batch: Batch | None = None) -> None:
+        """Initialize the Video Player.
+
+        Args:
+            batch:
+                An optional Batch to draw the video with. If no Batch is specified, the
+                default batch will be used.
+        """
         super().__init__()
         self._texture = None
         self._sprite = None

--- a/pyglet/resource.py
+++ b/pyglet/resource.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from pyglet.graphics.texture import Texture, TextureRegion, TextureArrayRegion
     from typing import Literal
 
-    from pyglet.graphics import Shader
+    from pyglet.graphics.shader import Shader
     from pyglet.image import ImageData
     from pyglet.image.animation import Animation
     from pyglet.graphics.atlas import TextureBin, TextureArrayBin
@@ -526,7 +526,7 @@ class Loader:
     def image(self, name: str) -> ImageData:
         """Load an image and decode the properties associated with it.
 
-        This data is not GPU backed, and represents the raw pixel data, format, and pitch. See :py:class:`~pyglet.image.IamgeData`
+        This data is not GPU backed, and represents the raw pixel data, format, and pitch. See :py:class:`~pyglet.image.ImageData`
         """
         self._ensure_index()
         if name in self._cached_images:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -72,12 +72,13 @@ from typing import TYPE_CHECKING, Sequence, Tuple, Union
 
 import pyglet
 from pyglet.extlibs import earcut
-from pyglet.graphics import Batch, Group, ShaderProgram
+from pyglet.graphics import Group
 from pyglet.enums import BlendFactor, GeometryMode, GraphicsAPI
 from pyglet.math import Vec2
 
 if TYPE_CHECKING:
     from pyglet.graphics.shader import ShaderProgram
+    from pyglet.graphics.draw import Batch
 
 
 if pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_ES_3):

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -3,7 +3,7 @@
 This module provides classes for a variety of simplistic 2D shapes,
 such as Rectangles, Circles, and Lines. These shapes are made
 internally from OpenGL primitives, and provide excellent performance
-when drawn as part of a :py:class:`~pyglet.graphics.Batch`.
+when drawn as part of a :py:class:`~pyglet.graphics.draw.Batch`.
 Convenience methods are provided for positioning, changing color, opacity,
 and rotation.
 The Python ``in`` operator can be used to check whether a point is inside a shape.
@@ -442,7 +442,7 @@ class ShapeBase(ABC):
         .. warning:: Avoid this inefficient method for everyday use!
 
                      Regular drawing should add shapes to a :py:class:`Batch`
-                     and call its :py:meth:`~Batch.draw` method.
+                     and call its :py:meth:`~pyglet.graphics.draw.Batch.draw` method.
 
         """
         ctx = pyglet.graphics.api.core.current_context

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -34,8 +34,8 @@ animations, you can set the ``subpixel`` parameter to ``True`` when creating
 the sprite (:since: pyglet 1.2).
 
 The sprite's positioning, rotation and scaling all honor the original
-image's anchor (:py:attr:`~pyglet.image.AbstractImage.anchor_x`,
-:py:attr:`~pyglet.image.AbstractImage.anchor_y`).
+image's anchor (:py:attr:`~pyglet.image.ImageData.anchor_x`,
+:py:attr:`~pyglet.image.ImageData.anchor_y`).
 
 
 Drawing multiple sprites

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -75,10 +75,12 @@ from pyglet import event, clock
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
     from pyglet.graphics.texture import Texture
+    from pyglet.graphics.draw import Batch
+    from pyglet.graphics.shader import ShaderProgram
 
-from pyglet.graphics import Group, Batch, ShaderProgram
+from pyglet.graphics import Group
 from pyglet.enums import BlendFactor, GeometryMode, GraphicsAPI
-from pyglet.image.base import Animation
+from pyglet.image.base import Animation, ImageData
 from pyglet.graphics.texture import TextureArrayRegion
 
 
@@ -145,7 +147,7 @@ class Sprite(event.EventDispatcher):
     group_class: ClassVar[type[SpriteGroup | Group]] = SpriteGroup
 
     def __init__(self,
-                 img: Texture | Animation,
+                 img: ImageData | Texture | Animation,
                  x: float = 0, y: float = 0, z: float = 0,
                  blend_src: BlendFactor = BlendFactor.SRC_ALPHA,
                  blend_dest: BlendFactor = BlendFactor.ONE_MINUS_SRC_ALPHA,
@@ -300,7 +302,7 @@ class Sprite(event.EventDispatcher):
         self._create_vertex_list()
 
     @property
-    def batch(self) -> Batch:
+    def batch(self) -> Batch | None:
         """Graphics batch.
 
         The sprite can be migrated from one batch to another, or removed from

--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -43,14 +43,14 @@ from os.path import splitext as _splitext
 from typing import TYPE_CHECKING, Any, BinaryIO, Literal
 
 import pyglet
-from pyglet.font import base
 
 from pyglet.text import caret, document, layout  # noqa: F401
 
 
 if TYPE_CHECKING:
+    from pyglet.font import base
     from pyglet.customtypes import AnchorX, AnchorY, HorizontalAlign
-    from pyglet.graphics import Batch, Group
+    from pyglet.graphics.draw import Batch, Group
     from pyglet.graphics.shader import ShaderProgram
     from pyglet.resource import Location
     from pyglet.text.document import AbstractDocument, FormattedDocument, UnformattedDocument

--- a/tests/unit/text/test_caret.py
+++ b/tests/unit/text/test_caret.py
@@ -28,7 +28,7 @@ def disable_automatic_caret_blinking(monkeypatch):
 # Brittle tangle of mocks due to tightly coupled Caret/Layout design
 @pytest.fixture
 def mock_layout():
-    from pyglet.graphics.api import ShaderProgram
+    from pyglet.graphics.shader import ShaderProgram
     from pyglet.graphics.vertexdomain import IndexedVertexList
 
     # Create layout mock


### PR DESCRIPTION
Updates various doc things for missing doc pages.

Also allows people to now import Batch via pyglet.graphics.draw without getting the stub version and erroring.

Update various type hints that would be flagged in IDE's as being incompatible.
Separate the image and texture sections.
Update sections to remove blit references.
Update links
Update doc build versions.
Update ffmpeg version.
Update media player example to use new built in dialog options.
Move get_default_shader to the shader module.
Consolidate ShaderProgram code for backends to reduce duplicate code.
Add small section about DPI in window section.
Add example about drawing into a texture using a framebuffer.
Fix texture classes not filling out in docs.