### PR TITLE
Instancing improvements

### DIFF
--- a/doc/programming_guide/rendering.rst
+++ b/doc/programming_guide/rendering.rst
@@ -410,6 +410,22 @@ Example (indexed instancing)::
 If you lose track of your instances or wish to get them by index, you can do so via the helper method on the mesh
 vertex list: ``instance = vlist.get_instance_by_index(0)``.
 
+Instanced vertex lists also provide helper APIs for ordering:
+
+* ``vlist.instance_count`` to inspect the number of active instances.
+* ``vlist.get_instance_index(instance)`` to get the current slot for an instance.
+* ``vlist.swap_instances(a, b)`` to swap two instances.
+* ``vlist.move_instance_to_index(instance, index)`` to move one instance to a specific index.
+* ``vlist.move_to_back([inst1, inst2, ...])`` to move a subset to lower indices (drawn earlier).
+* ``vlist.move_to_top([inst1, inst2, ...])`` to move a subset to higher indices (drawn later).
+* ``vlist.set_instance_order([...])`` to set the full exact order of all active instances.
+
+.. note:: Moving instances may involve shifting existing instances around in the buffer, which can be slow.
+
+Groups control draw order between different vertex lists, but not between
+instances inside the same instanced vertex list. Use the ordering helpers above
+when you need explicit ordering among instances of a single mesh.
+
 Resource Management
 ~~~~~~~~~~~~~~~~~~~
 

--- a/examples/graphics/instancing_order.py
+++ b/examples/graphics/instancing_order.py
@@ -1,0 +1,150 @@
+"""Instanced ordering helpers.
+
+Instances inside a single instanced vertex list share one group. Because of
+that, Group ordering cannot order individual instances within that list.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pyglet
+from pyglet.enums import GeometryMode
+from pyglet.window import key
+
+window = pyglet.window.Window(width=720, height=420, caption="Instancing Order")
+
+batch = pyglet.graphics.Batch()
+
+vertex_source = """#version 330 core
+    in vec3 position;
+    in vec3 translate;
+    in vec4 colors;
+    out vec4 vertex_colors;
+
+    uniform WindowBlock
+    {
+        mat4 projection;
+        mat4 view;
+    } window;
+
+    void main()
+    {
+        mat4 m_translate = mat4(1.0);
+        m_translate[3][0] = translate.x;
+        m_translate[3][1] = translate.y;
+        m_translate[3][2] = translate.z;
+        gl_Position = window.projection * window.view * m_translate * vec4(position, 1.0);
+        vertex_colors = colors;
+    }
+"""
+
+fragment_source = """#version 330 core
+    in vec4 vertex_colors;
+    out vec4 final_colors;
+
+    void main()
+    {
+        final_colors = vertex_colors;
+    }
+"""
+
+program = pyglet.graphics.ShaderProgram(
+    pyglet.graphics.Shader(vertex_source, "vertex"),
+    pyglet.graphics.Shader(fragment_source, "fragment"),
+)
+
+group = pyglet.graphics.ShaderGroup(program=program)
+vlist = program.vertex_list_instanced_indexed(
+    4,
+    mode=GeometryMode.TRIANGLES,
+    indices=[0, 1, 2, 0, 2, 3],
+    instance_attributes={"translate": 1, "colors": 1},
+    batch=batch,
+    group=group,
+    position=("f", (0, 0, 0, 180, 0, 0, 180, 180, 0, 0, 180, 0)),
+    translate=("f", (220, 120, 0)),
+    colors=("f", (1, 0, 0, 1)),
+)
+
+instances_by_name = {
+    "Red": vlist.create_instance(translate=(220, 120, 0), colors=(1.0, 0.0, 0.0, 1.0)),
+    "Green": vlist.create_instance(translate=(230, 130, 0), colors=(0.0, 1.0, 0.0, 1.0)),
+    "Blue": vlist.create_instance(translate=(240, 140, 0), colors=(0.0, 0.0, 1.0, 1.0)),
+    "Yellow": vlist.create_instance(translate=(250, 150, 0), colors=(1.0, 1.0, 0.0, 1.0)),
+}
+name_by_instance = {instance: name for name, instance in instances_by_name.items()}
+
+instructions = pyglet.text.Label(
+    "1: Move Blue to back\n"
+    "2: Move Blue to top\n"
+    "3: Swap Red/Yellow\n"
+    "4: Move Green to index 0\n"
+    "5: Explicit full order\n"
+    "6: Random full order",
+    x=12,
+    y=window.height - 12,
+    anchor_x="left",
+    anchor_y="top",
+    multiline=True,
+    width=window.width - 24,
+)
+order_label = pyglet.text.Label(
+    "",
+    x=12,
+    y=14,
+    anchor_x="left",
+    anchor_y="bottom",
+)
+
+
+def update_order_label() -> None:
+    names = []
+    for i in range(vlist.instance_count):
+        instance = vlist.get_instance_by_index(i)
+        names.append(name_by_instance[instance])
+    order_label.text = f"Current draw order (first -> last): {names}"
+
+
+update_order_label()
+
+
+@window.event
+def on_key_press(symbol: int, modifiers: int) -> None:  # noqa: ARG001
+    if symbol == key._1:
+        vlist.move_to_back([instances_by_name["Blue"]])
+    elif symbol == key._2:
+        vlist.move_to_top([instances_by_name["Blue"]])
+    elif symbol == key._3:
+        vlist.swap_instances(instances_by_name["Red"], instances_by_name["Yellow"])
+    elif symbol == key._4:
+        vlist.move_instance_to_index(instances_by_name["Green"], 0)
+    elif symbol == key._5:
+        vlist.set_instance_order(
+            [
+                instances_by_name["Yellow"],
+                instances_by_name["Blue"],
+                instances_by_name["Green"],
+                instances_by_name["Red"],
+            ],
+        )
+    elif symbol == key._6:
+        randomized = list(instances_by_name.values())
+        random.shuffle(randomized)
+        vlist.set_instance_order(randomized)
+    else:
+        return
+
+    update_order_label()
+
+
+@window.event
+def on_draw() -> None:
+    window.clear()
+    batch.draw()
+    instructions.draw()
+    order_label.draw()
+
+
+if __name__ == "__main__":
+    pyglet.app.run()

--- a/pyglet/graphics/api/gl/vertexdomain.py
+++ b/pyglet/graphics/api/gl/vertexdomain.py
@@ -220,13 +220,56 @@ class GLInstanceVertexList(GLVertexList):
 
     @property
     def instance_count(self) -> int:
+        """Number of active instances in this vertex list."""
         return self.instance_bucket.instance_count
 
     def get_instance_by_index(self, index: int) -> VertexInstance | None:
-        return self.instance_bucket.allocator.slot_to_inst.get(index)
+        """Get an instance by its current slot index."""
+        return self.instance_bucket.get_instance_by_index(index)
 
     def get_instance_index(self, instance: VertexInstance) -> int | None:
-        return self.instance_bucket.allocator.inst_to_slot.get(instance)
+        """Get the current slot index for an instance."""
+        return self.instance_bucket.get_instance_index(instance)
+
+    def swap_instances(self, first: VertexInstance, second: VertexInstance) -> None:
+        """Swap two instances in-place.
+
+        Useful when changing draw order without rebuilding all instance data.
+        This can still be expensive if instance attributes are large.
+        """
+        self.instance_bucket.swap_instances(first, second)
+
+    def move_instance_to_index(self, instance: VertexInstance, index: int) -> None:
+        """Move one instance to a target slot index.
+
+        Other instances shift as needed to keep slots contiguous.
+
+        This may be expensive when moving across many slots.
+        """
+        self.instance_bucket.move_instance_to_index(instance, index)
+
+    def set_instance_order(self, order: Sequence[VertexInstance]) -> None:
+        """Set the exact full order of all active instances.
+
+        This can be expensive for large lists.
+        """
+        self.instance_bucket.set_instance_order(order)
+
+    def move_to_back(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the back in the given order.
+
+        Back means lower indices (drawn earlier). Unspecified instances remain
+        after the moved prefix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_back(instances)
+
+    def move_to_top(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the top in the given order.
+
+        Top means higher indices (drawn later). Unspecified instances remain
+        before the moved suffix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_top(instances)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:
@@ -317,18 +360,60 @@ class GLInstanceIndexedVertexList(GLVertexList):
         # Move instance data.
         old_domain.instance_domain.move_all(self.instance_bucket, new_bucket)
 
-    def create_instance(self, **attributes: Any) -> None:
+    def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
 
     @property
     def instance_count(self) -> int:
+        """Number of active instances in this vertex list."""
         return self.instance_bucket.instance_count
 
     def get_instance_by_index(self, index: int) -> VertexInstance | None:
-        return self.instance_bucket.allocator.slot_to_inst.get(index)
+        """Get an instance by its current slot index."""
+        return self.instance_bucket.get_instance_by_index(index)
 
     def get_instance_index(self, instance: VertexInstance) -> int | None:
-        return self.instance_bucket.allocator.inst_to_slot.get(instance)
+        """Get the current slot index for an instance."""
+        return self.instance_bucket.get_instance_index(instance)
+
+    def swap_instances(self, first: VertexInstance, second: VertexInstance) -> None:
+        """Swap two instances in-place.
+
+        Useful when changing draw order without rebuilding all instance data.
+        This can still be expensive if instance attributes are large.
+        """
+        self.instance_bucket.swap_instances(first, second)
+
+    def move_instance_to_index(self, instance: VertexInstance, index: int) -> None:
+        """Move one instance to a target slot index.
+
+        Other instances shift as needed to keep slots contiguous.
+        This may be expensive when moving across many slots.
+        """
+        self.instance_bucket.move_instance_to_index(instance, index)
+
+    def set_instance_order(self, order: Sequence[VertexInstance]) -> None:
+        """Set the exact full order of all active instances.
+
+        This can be expensive for large lists.
+        """
+        self.instance_bucket.set_instance_order(order)
+
+    def move_to_back(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the back in the given order.
+
+        Back means lower indices (drawn earlier). Unspecified instances remain
+        after the moved prefix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_back(instances)
+
+    def move_to_top(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the top in the given order.
+
+        Top means higher indices (drawn later). Unspecified instances remain
+        before the moved suffix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_top(instances)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:

--- a/pyglet/graphics/api/gl/vertexdomain.py
+++ b/pyglet/graphics/api/gl/vertexdomain.py
@@ -218,8 +218,15 @@ class GLInstanceVertexList(GLVertexList):
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
 
+    @property
+    def instance_count(self) -> int:
+        return self.instance_bucket.instance_count
+
     def get_instance_by_index(self, index: int) -> VertexInstance | None:
         return self.instance_bucket.allocator.slot_to_inst.get(index)
+
+    def get_instance_index(self, instance: VertexInstance) -> int | None:
+        return self.instance_bucket.allocator.inst_to_slot.get(instance)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:
@@ -261,7 +268,7 @@ class GLInstanceIndexedVertexList(GLVertexList):
 
     Use :py:meth:`IndexedVertexDomain.create` to construct this list.
     """
-    domain: GLIndexedVertexDomain | GLInstancedIndexedVertexDomain
+    domain: GLInstancedIndexedVertexDomain
     indexed: bool = True
     instanced: bool = True
 
@@ -269,8 +276,9 @@ class GLInstanceIndexedVertexList(GLVertexList):
     index_start: int
 
     instance_bucket: InstanceBucket
+    supports_base_vertex: bool
 
-    def __init__(self, domain: GLIndexedVertexDomain, group: Group, start: int, count: int,
+    def __init__(self, domain: GLInstancedIndexedVertexDomain, group: Group, start: int, count: int,
                  index_start: int, index_count: int, index_type: DataTypes, base_vertex: int,
                  instance_bucket: InstanceBucket) -> None:
         self.index_start = index_start
@@ -283,8 +291,16 @@ class GLInstanceIndexedVertexList(GLVertexList):
 
     def delete(self) -> None:
         """Delete this group."""
+        key = (self.index_start, self.index_count)
+
+        # Invalidate all instance handles associated with this list.
+        for instance in list(self.instance_bucket.allocator.slot_to_inst.values()):
+            instance.slot = -1
+        self.instance_bucket.allocator.clear()
+
         super().delete()
         self.domain.index_stream.dealloc(self.index_start, self.index_count)
+        self.domain._instance_map.pop(key, None)
 
     def migrate(self, domain: GLInstancedIndexedVertexDomain) -> None:
         old_domain = self.domain
@@ -303,6 +319,16 @@ class GLInstanceIndexedVertexList(GLVertexList):
 
     def create_instance(self, **attributes: Any) -> None:
         return self.instance_bucket.create_instance(**attributes)
+
+    @property
+    def instance_count(self) -> int:
+        return self.instance_bucket.instance_count
+
+    def get_instance_by_index(self, index: int) -> VertexInstance | None:
+        return self.instance_bucket.allocator.slot_to_inst.get(index)
+
+    def get_instance_index(self, instance: VertexInstance) -> int | None:
+        return self.instance_bucket.allocator.inst_to_slot.get(instance)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:

--- a/pyglet/graphics/api/webgl/vertexdomain.py
+++ b/pyglet/graphics/api/webgl/vertexdomain.py
@@ -58,6 +58,7 @@ from pyglet.graphics.vertexdomain import (
     IndexedVertexDomain,
     VertexGroupBucket,
     _RunningIndexSupport,
+    _InstancedRunningIndexSupport,
     InstanceIndexedVertexList,
     InstancedIndexedVertexDomain,
     InstancedVertexDomain,
@@ -550,7 +551,7 @@ class WebGLInstancedIndexedVertexDomain(InstancedIndexedVertexDomain):
     _vertex_class = WebGLInstanceIndexedVertexList
 
     def _create_vertex_class(self) -> type:
-        return type(self._vertex_class.__name__, (_RunningIndexSupport, self._vertex_class),
+        return type(self._vertex_class.__name__, (_InstancedRunningIndexSupport, self._vertex_class),
                                       self.vertex_buffers._property_dict)  # noqa: SLF001
 
     def _create_vao(self) -> GLVertexArrayBinding:

--- a/pyglet/graphics/instance.py
+++ b/pyglet/graphics/instance.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import weakref
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 if TYPE_CHECKING:
     from pyglet.graphics.vertexdomain import InstanceStream, VertexArrayBinding, InstanceVertexList, InstanceIndexedVertexList
@@ -14,7 +14,7 @@ class InstanceAllocator:
     """Allocator for instances within a bucket."""
     count: int
     slot_to_handle: dict[int, VertexInstance]
-    handle_to_slot: dict[VertexInstance, int]
+    inst_to_slot: dict[VertexInstance, int]
 
     def __init__(self) -> None:  # noqa: D107
         self.count = 0
@@ -110,6 +110,159 @@ class InstanceBucket:
         if attributes:
             self.stream.set_region(slot, 1, attributes)
         return v_instance
+
+    def get_instance_by_index(self, index: int) -> VertexInstance | None:
+        """Return the instance currently stored at ``index`` or ``None``."""
+        return self.allocator.slot_to_inst.get(index)
+
+    def get_instance_index(self, instance: VertexInstance) -> int | None:
+        """Return the active slot index for ``instance`` or ``None``."""
+        return self.allocator.inst_to_slot.get(instance)
+
+    def _get_required_slot(self, instance: VertexInstance) -> int:
+        slot = self.allocator.inst_to_slot.get(instance)
+        if slot is None:
+            msg = "Instance does not belong to this vertex list."
+            raise ValueError(msg)
+        return slot
+
+    def _swap_slots(self, first_slot: int, second_slot: int) -> None:
+        if first_slot == second_slot:
+            return
+
+        first_instance = self.allocator.slot_to_inst[first_slot]
+        second_instance = self.allocator.slot_to_inst[second_slot]
+
+        for buffer in self.stream.attrib_name_buffers.values():
+            # Tuple to make a copy otherwise it's the actual memory.
+            first_data = tuple(buffer.get_region(first_slot, 1))
+            second_data = tuple(buffer.get_region(second_slot, 1))
+            buffer.set_region(first_slot, 1, second_data)
+            buffer.set_region(second_slot, 1, first_data)
+
+        self.allocator.slot_to_inst[first_slot] = second_instance
+        self.allocator.slot_to_inst[second_slot] = first_instance
+        self.allocator.inst_to_slot[first_instance] = second_slot
+        self.allocator.inst_to_slot[second_instance] = first_slot
+        first_instance.slot = second_slot
+        second_instance.slot = first_slot
+
+    def swap_instances(self, first: VertexInstance, second: VertexInstance) -> None:
+        """Swap two instances in-place.
+
+        This operation updates per-instance attribute rows for both slots.
+
+        Args:
+            first:
+                The first instance to swap.
+            second:
+                The second instance to swap.
+        """
+        first_slot = self._get_required_slot(first)
+        second_slot = self._get_required_slot(second)
+        self._swap_slots(first_slot, second_slot)
+
+    def move_instance_to_index(self, instance: VertexInstance, index: int) -> None:
+        """Move ``instance`` to an absolute slot index.
+
+        The moved instance ends up at ``index``. Other instances shift to keep
+        a contiguous slot layout.
+        This may be expensive when moving across many slots.
+
+        Args:
+            instance:
+                The instance to move.
+            index:
+                Target slot index in ``[0, instance_count - 1]``.
+        """
+        count = self.instance_count
+        if index < 0 or index >= count:
+            msg = f"Index out of range: {index} (instance_count={count})"
+            raise IndexError(msg)
+
+        current_slot = self._get_required_slot(instance)
+        if current_slot == index:
+            return
+
+        if current_slot > index:
+            for slot in range(current_slot, index, -1):
+                self._swap_slots(slot, slot - 1)
+        else:
+            for slot in range(current_slot, index):
+                self._swap_slots(slot, slot + 1)
+
+    def set_instance_order(self, order: Sequence[VertexInstance]) -> None:
+        """Set the exact full order of all active instances.
+
+        This can be expensive for large lists because many slot swaps may be
+        required.
+
+        Args:
+            order:
+                Sequence containing every active instance exactly once.
+        """
+        count = self.instance_count
+        if len(order) != count:
+            msg = f"Order length mismatch. Expected {count}, got {len(order)}."
+            raise ValueError(msg)
+
+        if len(set(order)) != count:
+            msg = "Order contains duplicate instances."
+            raise ValueError(msg)
+
+        active = set(self.allocator.inst_to_slot.keys())
+        requested = set(order)
+        if requested != active:
+            msg = "Order must contain every active instance exactly once."
+            raise ValueError(msg)
+
+        for target_slot, instance in enumerate(order):
+            current_slot = self.allocator.inst_to_slot[instance]
+            if current_slot != target_slot:
+                self._swap_slots(current_slot, target_slot)
+
+    def move_to_back(self, instances: Sequence[VertexInstance]) -> None:
+        """Move the provided instances to the back in the given order.
+
+        "Back" means lower indices (drawn earlier). Instances not listed remain
+        after the moved prefix, preserving their relative order.
+        This may be expensive when moving many instances.
+
+        Args:
+            instances:
+                Instances to move to back slots ``[0..len(instances)-1]``.
+        """
+        if len(set(instances)) != len(instances):
+            msg = "Instances to move contain duplicates."
+            raise ValueError(msg)
+
+        for instance in instances:
+            self._get_required_slot(instance)
+
+        for target_slot, instance in enumerate(instances):
+            self.move_instance_to_index(instance, target_slot)
+
+    def move_to_top(self, instances: Sequence[VertexInstance]) -> None:
+        """Move the provided instances to the top in the given order.
+
+        "Top" means higher indices (drawn later). Instances not listed remain
+        before the moved suffix, preserving their relative order.
+        This may be expensive when moving many instances.
+
+        Args:
+            instances:
+                Instances to move to the ending slots in the given order.
+        """
+        if len(set(instances)) != len(instances):
+            msg = "Instances to move contain duplicates."
+            raise ValueError(msg)
+
+        for instance in instances:
+            self._get_required_slot(instance)
+
+        top_start = self.instance_count - len(instances)
+        for offset in range(len(instances) - 1, -1, -1):
+            self.move_instance_to_index(instances[offset], top_start + offset)
 
     def delete_instance(self, vi: VertexInstance) -> None:
         # When removing an instance, take the last slot and move to the removed slot to maintain contiguous allocation.

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -179,13 +179,55 @@ class InstanceVertexList(VertexList):
 
     @property
     def instance_count(self) -> int:
+        """Number of active instances in this vertex list."""
         return self.instance_bucket.instance_count
 
     def get_instance_by_index(self, index: int) -> VertexInstance | None:
-        return self.instance_bucket.allocator.slot_to_inst.get(index)
+        """Get an instance by its current slot index."""
+        return self.instance_bucket.get_instance_by_index(index)
 
     def get_instance_index(self, instance: VertexInstance) -> int | None:
-        return self.instance_bucket.allocator.inst_to_slot.get(instance)
+        """Get the current slot index for an instance."""
+        return self.instance_bucket.get_instance_index(instance)
+
+    def swap_instances(self, first: VertexInstance, second: VertexInstance) -> None:
+        """Swap two instances in-place.
+
+        Useful when changing draw order without rebuilding all instance data.
+        This can still be expensive if instance attributes are large.
+        """
+        self.instance_bucket.swap_instances(first, second)
+
+    def move_instance_to_index(self, instance: VertexInstance, index: int) -> None:
+        """Move one instance to a target slot index.
+
+        Other instances shift as needed to keep slots contiguous.
+        This may be expensive when moving across many slots.
+        """
+        self.instance_bucket.move_instance_to_index(instance, index)
+
+    def set_instance_order(self, order: Sequence[VertexInstance]) -> None:
+        """Set the exact full order of all active instances.
+
+        This can be expensive for large lists.
+        """
+        self.instance_bucket.set_instance_order(order)
+
+    def move_to_back(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the back in the given order.
+
+        Back means lower indices (drawn earlier). Unspecified instances remain
+        after the moved prefix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_back(instances)
+
+    def move_to_top(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the top in the given order.
+
+        Top means higher indices (drawn later). Unspecified instances remain
+        before the moved suffix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_top(instances)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:
@@ -440,13 +482,55 @@ class InstanceIndexedVertexList(VertexList):
 
     @property
     def instance_count(self) -> int:
+        """Number of active instances in this vertex list."""
         return self.instance_bucket.instance_count
 
     def get_instance_by_index(self, index: int) -> VertexInstance | None:
-        return self.instance_bucket.allocator.slot_to_inst.get(index)
+        """Get an instance by its current slot index."""
+        return self.instance_bucket.get_instance_by_index(index)
 
     def get_instance_index(self, instance: VertexInstance) -> int | None:
-        return self.instance_bucket.allocator.inst_to_slot.get(instance)
+        """Get the current slot index for an instance."""
+        return self.instance_bucket.get_instance_index(instance)
+
+    def swap_instances(self, first: VertexInstance, second: VertexInstance) -> None:
+        """Swap two instances in-place.
+
+        Useful when changing draw order without rebuilding all instance data.
+        This can still be expensive if instance attributes are large.
+        """
+        self.instance_bucket.swap_instances(first, second)
+
+    def move_instance_to_index(self, instance: VertexInstance, index: int) -> None:
+        """Move one instance to a target slot index.
+
+        Other instances shift as needed to keep slots contiguous.
+        This may be expensive when moving across many slots.
+        """
+        self.instance_bucket.move_instance_to_index(instance, index)
+
+    def set_instance_order(self, order: Sequence[VertexInstance]) -> None:
+        """Set the exact full order of all active instances.
+
+        This can be expensive for large lists.
+        """
+        self.instance_bucket.set_instance_order(order)
+
+    def move_to_back(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the back in the given order.
+
+        Back means lower indices (drawn earlier). Unspecified instances remain
+        after the moved prefix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_back(instances)
+
+    def move_to_top(self, instances: Sequence[VertexInstance]) -> None:
+        """Move a subset of instances to the top in the given order.
+
+        Top means higher indices (drawn later). Unspecified instances remain
+        before the moved suffix. This can be expensive for large lists.
+        """
+        self.instance_bucket.move_to_top(instances)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -142,6 +142,7 @@ class VertexList:
         self.domain.vertex_buffers.copy_data(new_start, domain.vertex_buffers, self.start, self.count)
         self.domain.vertex_buffers.allocator.dealloc(self.start, self.count)
         self.domain = domain
+        self.group = group
         self.start = new_start
         domain.alloc_to_group(self, group)
         assert self.bucket is not None
@@ -149,6 +150,7 @@ class VertexList:
     def update_group(self, group: Group) -> None:
         current_bucket = self.bucket
         self.domain.dealloc_from_group(self)
+        self.group = group
         new_bucket = self.domain.alloc_to_group(self, group)
         assert new_bucket != current_bucket, "Changing group resulted in the same bucket."
 
@@ -174,6 +176,16 @@ class InstanceVertexList(VertexList):
 
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
+
+    @property
+    def instance_count(self) -> int:
+        return self.instance_bucket.instance_count
+
+    def get_instance_by_index(self, index: int) -> VertexInstance | None:
+        return self.instance_bucket.allocator.slot_to_inst.get(index)
+
+    def get_instance_index(self, instance: VertexInstance) -> int | None:
+        return self.instance_bucket.allocator.inst_to_slot.get(instance)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:
@@ -206,6 +218,7 @@ class _IndexSupport:
         self.domain.vertex_buffers.copy_data(new_start, domain.vertex_buffers, self.start, self.count)
         self.domain.vertex_buffers.allocator.dealloc(self.start, self.count)
         self.domain = domain
+        self.group = group
         self.start = new_start
 
 class _LocalIndexSupport(_IndexSupport):
@@ -220,6 +233,7 @@ class _LocalIndexSupport(_IndexSupport):
     domain: IndexedVertexDomain | InstancedIndexedVertexDomain
     index_count: int
     index_start: int
+    index_type: DataTypes
 
     @property
     def indices(self) -> list[int]:
@@ -242,6 +256,7 @@ class _LocalIndexSupport(_IndexSupport):
         new_idx_start = self.domain.safe_index_alloc(src_idx_count)
         self.domain.index_stream.set_region(new_idx_start, src_idx_count, data)
         self.index_start = new_idx_start
+
         domain.alloc_to_group(self, group)  # Allocate after new index start.
 
 
@@ -288,7 +303,47 @@ class _RunningIndexSupport(_IndexSupport):
         new_idx_start = self.domain.safe_index_alloc(src_idx_count)
         self.domain.index_stream.set_region(new_idx_start, src_idx_count, data)
         self.index_start = new_idx_start
+
         domain.alloc_to_group(self, group)  # Allocate after new index start.
+
+
+class _InstancedIndexSupport:
+    domain: InstancedIndexedVertexDomain
+    instance_bucket: InstanceBucket
+    index_count: int
+    index_start: int
+    index_type: DataTypes
+    supports_base_vertex: bool
+    start: int
+    base_vertex: int
+
+    def _migrate_instance_bucket(self, old_domain: InstancedIndexedVertexDomain,
+                                 new_domain: InstancedIndexedVertexDomain) -> None:
+        base_vertex = self.start if self.supports_base_vertex else 0
+        self.base_vertex = base_vertex
+        new_bucket = new_domain.instance_domain.get_elements_bucket(
+            mode=0,
+            first_index=self.index_start,
+            index_count=self.index_count,
+            index_type=self.index_type,
+            base_vertex=base_vertex,
+        )
+        old_domain.instance_domain.move_all(self.instance_bucket, new_bucket)
+        self.instance_bucket = new_bucket
+
+
+class _InstancedLocalIndexSupport(_LocalIndexSupport, _InstancedIndexSupport):
+    def migrate(self, domain: InstancedIndexedVertexDomain, group: Group) -> None:
+        old_domain = self.domain
+        super().migrate(domain, group)
+        self._migrate_instance_bucket(old_domain, domain)
+
+
+class _InstancedRunningIndexSupport(_RunningIndexSupport, _InstancedIndexSupport):
+    def migrate(self, domain: InstancedIndexedVertexDomain, group: Group) -> None:
+        old_domain = self.domain
+        super().migrate(domain, group)
+        self._migrate_instance_bucket(old_domain, domain)
 
 
 class IndexedVertexList(VertexList):
@@ -330,7 +385,7 @@ class InstanceIndexedVertexList(VertexList):
 
     Use :py:meth:`IndexedVertexDomain.create` to construct this list.
     """
-    domain: IndexedVertexDomain | InstancedIndexedVertexDomain
+    domain: InstancedIndexedVertexDomain
     indexed: bool = True
     instanced: bool = True
 
@@ -353,15 +408,22 @@ class InstanceIndexedVertexList(VertexList):
 
     def delete(self) -> None:
         """Delete this group."""
-        raise Exception
-        super().delete()
-        self.domain.index_allocator.dealloc(self.index_start, self.index_count)
+        key = (self.index_start, self.index_count)
 
-    def migrate(self, domain: InstancedIndexedVertexDomain) -> None:
+        # Invalidate all instance handles associated with this list.
+        for instance in list(self.instance_bucket.allocator.slot_to_inst.values()):
+            instance.slot = -1
+        self.instance_bucket.allocator.clear()
+
+        super().delete()
+        self.domain.index_stream.dealloc(self.index_start, self.index_count)
+        self.domain._instance_map.pop(key, None)
+
+    def migrate(self, domain: InstancedIndexedVertexDomain, group: Group) -> None:
         old_domain = self.domain
 
         # Moved vertex data here.
-        super().migrate(domain)
+        super().migrate(domain, group)
 
         # Remove from bucket and enter into new bucket.
         new_bucket = domain.instance_domain.get_elements_bucket(mode=0,
@@ -371,9 +433,20 @@ class InstanceIndexedVertexList(VertexList):
 
         # Move instance data.
         old_domain.instance_domain.move_all(self.instance_bucket, new_bucket)
+        self.instance_bucket = new_bucket
 
-    def create_instance(self, **attributes: Any) -> None:
+    def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
+
+    @property
+    def instance_count(self) -> int:
+        return self.instance_bucket.instance_count
+
+    def get_instance_by_index(self, index: int) -> VertexInstance | None:
+        return self.instance_bucket.allocator.slot_to_inst.get(index)
+
+    def get_instance_index(self, instance: VertexInstance) -> int | None:
+        return self.instance_bucket.allocator.inst_to_slot.get(instance)
 
     def set_attribute_data(self, name: str, data: Any) -> None:
         if self.initial_attribs[name].fmt.is_instanced:
@@ -492,7 +565,7 @@ class VertexDomain(ABC):
     def get_drawable_bucket(self, group: Group) -> VertexGroupBucket | None:
         """Get a bucket that exists and has vertices to draw (not empty)."""
         bucket = self._vertex_buckets.get(group)
-        if bucket is None or (bucket and bucket.is_empty):
+        if bucket is None or bucket.is_empty:
             return None
 
         return bucket
@@ -655,6 +728,8 @@ class IndexedVertexDomain(VertexDomain):
 
 
 class InstancedVertexDomain(VertexDomain):
+    _instance_map: dict[tuple[int, int], InstanceBucket]
+
     def __init__(self, context: SurfaceContext, initial_count: int, attribute_meta: dict[str, Attribute]) -> None:
         super().__init__(context, initial_count, attribute_meta)
         self.instance_domain = self.create_instance_domain(initial_count)
@@ -683,6 +758,8 @@ class InstancedVertexDomain(VertexDomain):
         return vlist
 
 class InstancedIndexedVertexDomain(IndexedVertexDomain):
+    _instance_map: dict[tuple[int, int], InstanceBucket]
+
     def __init__(self, context: SurfaceContext, initial_count: int, attribute_meta: dict[str, Attribute],
                  index_type: DataTypes = "I") -> None:
         super().__init__(context, initial_count, attribute_meta, index_type)
@@ -735,7 +812,7 @@ class InstancedIndexedVertexDomain(IndexedVertexDomain):
         return vertex_list
 
     def _create_vertex_class(self) -> type:
-        mixin = _LocalIndexSupport if self._supports_base_vertex else _RunningIndexSupport
+        mixin = _InstancedLocalIndexSupport if self._supports_base_vertex else _InstancedRunningIndexSupport
         # Make a custom VertexList class w/ properties for each attribute in the ShaderProgram:
         return type(self._vertex_class.__name__, (mixin, self._vertex_class),
                                       self.vertex_buffers._property_dict)  # noqa: SLF001

--- a/tests/integration/graphics/opengl_core/test_opengl_instancing.py
+++ b/tests/integration/graphics/opengl_core/test_opengl_instancing.py
@@ -181,6 +181,77 @@ def test_get_instance_by_index_indexed(vlist_factory):
     assert vlist.get_instance_index(inst2) == 1
 
 
+def _assert_instance_order(vlist, expected) -> None:
+    assert vlist.instance_count == len(expected)
+    for index, instance in enumerate(expected):
+        assert vlist.get_instance_by_index(index) is instance
+        assert vlist.get_instance_index(instance) == index
+
+
+def test_instance_reorder_helpers_non_indexed(vlist_non_indexed_factory):
+    vlist = vlist_non_indexed_factory(
+        (
+            0.0, 0.0, 0.0,
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+        ),
+    )
+
+    inst_a = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
+    inst_b = vlist.create_instance(colors=(0, 1, 0, 1), translate=(10, 0, 0))
+    inst_c = vlist.create_instance(colors=(0, 0, 1, 1), translate=(20, 0, 0))
+    inst_d = vlist.create_instance(colors=(1, 1, 0, 1), translate=(30, 0, 0))
+
+    _assert_instance_order(vlist, [inst_a, inst_b, inst_c, inst_d])
+
+    vlist.swap_instances(inst_a, inst_d)
+    _assert_instance_order(vlist, [inst_d, inst_b, inst_c, inst_a])
+
+    vlist.move_instance_to_index(inst_a, 1)
+    _assert_instance_order(vlist, [inst_d, inst_a, inst_b, inst_c])
+
+    vlist.move_to_back([inst_c, inst_d])
+    _assert_instance_order(vlist, [inst_c, inst_d, inst_a, inst_b])
+
+    vlist.move_to_top([inst_c, inst_a])
+    _assert_instance_order(vlist, [inst_d, inst_b, inst_c, inst_a])
+
+    vlist.set_instance_order([inst_b, inst_a, inst_d, inst_c])
+    _assert_instance_order(vlist, [inst_b, inst_a, inst_d, inst_c])
+
+    with pytest.raises(IndexError):
+        vlist.move_instance_to_index(inst_a, 8)
+
+    with pytest.raises(ValueError):
+        vlist.set_instance_order([inst_a, inst_b, inst_c])  # missing one instance
+
+
+def test_instance_reorder_helpers_indexed(vlist_factory):
+    vlist = vlist_factory((0.0,) * 12)
+
+    inst_a = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
+    inst_b = vlist.create_instance(colors=(0, 1, 0, 1), translate=(10, 0, 0))
+    inst_c = vlist.create_instance(colors=(0, 0, 1, 1), translate=(20, 0, 0))
+    inst_d = vlist.create_instance(colors=(1, 1, 0, 1), translate=(30, 0, 0))
+
+    _assert_instance_order(vlist, [inst_a, inst_b, inst_c, inst_d])
+
+    vlist.swap_instances(inst_a, inst_d)
+    _assert_instance_order(vlist, [inst_d, inst_b, inst_c, inst_a])
+
+    vlist.move_instance_to_index(inst_a, 1)
+    _assert_instance_order(vlist, [inst_d, inst_a, inst_b, inst_c])
+
+    vlist.move_to_back([inst_c, inst_d])
+    _assert_instance_order(vlist, [inst_c, inst_d, inst_a, inst_b])
+
+    vlist.move_to_top([inst_c, inst_a])
+    _assert_instance_order(vlist, [inst_d, inst_b, inst_c, inst_a])
+
+    vlist.set_instance_order([inst_b, inst_a, inst_d, inst_c])
+    _assert_instance_order(vlist, [inst_b, inst_a, inst_d, inst_c])
+
+
 def test_instanced_indexed_migrate_moves_instances(shader_program, vlist_factory):
     from pyglet.graphics import Batch, ShaderGroup
 

--- a/tests/integration/graphics/opengl_core/test_opengl_instancing.py
+++ b/tests/integration/graphics/opengl_core/test_opengl_instancing.py
@@ -66,18 +66,38 @@ def shader_program(gl3_context):
 def vlist_factory(shader_program):
     """Helper to create a fresh instanced vertex list bound to the shared program."""
     from pyglet.enums import GeometryMode
-    def make(verts, indices=(0,1,2,0,2,3)):
+    def make(verts, indices=(0,1,2,0,2,3), batch=None, group=None):
         return shader_program.vertex_list_instanced_indexed(
             4,
             mode=GeometryMode.TRIANGLES,
             indices=list(indices),
             instance_attributes={"colors": 1, "translate": 1},
-            batch=None,
-            group=None,
+            batch=batch,
+            group=group,
             position=("f", tuple(verts)),
             colors=("f", (1.0, 0.0, 0.0, 1.0)),
             translate=("f", (500.0, 500.0, 0.0)),
         )
+    return make
+
+
+@pytest.fixture
+def vlist_non_indexed_factory(shader_program):
+    """Helper to create a fresh non-indexed instanced vertex list bound to the shared program."""
+    from pyglet.enums import GeometryMode
+
+    def make(verts, batch=None, group=None):
+        return shader_program.vertex_list_instanced(
+            3,
+            mode=GeometryMode.TRIANGLES,
+            instance_attributes={"colors": 1, "translate": 1},
+            batch=batch,
+            group=group,
+            position=("f", tuple(verts)),
+            colors=("f", (1.0, 0.0, 0.0, 1.0)),
+            translate=("f", (500.0, 500.0, 0.0)),
+        )
+
     return make
 
 
@@ -101,6 +121,168 @@ def test_instancing_count(vlist_factory):
 
     assert vlist.instance_bucket is not None
     assert vlist.instance_bucket.instance_count == instance_count  # the initial list
+
+
+def test_get_instance_by_index_non_indexed(vlist_non_indexed_factory):
+    vlist = vlist_non_indexed_factory(
+        (
+            0.0, 0.0, 0.0,
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+        ),
+    )
+
+    inst0 = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
+    inst1 = vlist.create_instance(colors=(0, 1, 0, 1), translate=(10, 0, 0))
+    inst2 = vlist.create_instance(colors=(0, 0, 1, 1), translate=(20, 0, 0))
+
+    assert vlist.instance_count == 3
+    assert vlist.get_instance_by_index(0) is inst0
+    assert vlist.get_instance_by_index(1) is inst1
+    assert vlist.get_instance_by_index(2) is inst2
+    assert vlist.get_instance_by_index(3) is None
+    assert vlist.get_instance_index(inst0) == 0
+    assert vlist.get_instance_index(inst1) == 1
+    assert vlist.get_instance_index(inst2) == 2
+
+    inst1.delete()
+
+    # Deletion compacts slots by moving the last instance into the freed slot.
+    assert vlist.instance_count == 2
+    assert vlist.get_instance_by_index(1) is inst2
+    assert vlist.get_instance_by_index(2) is None
+    assert vlist.get_instance_index(inst1) is None
+    assert vlist.get_instance_index(inst2) == 1
+
+
+def test_get_instance_by_index_indexed(vlist_factory):
+    vlist = vlist_factory((0.0,) * 12)
+
+    inst0 = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
+    inst1 = vlist.create_instance(colors=(0, 1, 0, 1), translate=(10, 0, 0))
+    inst2 = vlist.create_instance(colors=(0, 0, 1, 1), translate=(20, 0, 0))
+
+    assert vlist.instance_count == 3
+    assert vlist.get_instance_by_index(0) is inst0
+    assert vlist.get_instance_by_index(1) is inst1
+    assert vlist.get_instance_by_index(2) is inst2
+    assert vlist.get_instance_by_index(3) is None
+    assert vlist.get_instance_index(inst0) == 0
+    assert vlist.get_instance_index(inst1) == 1
+    assert vlist.get_instance_index(inst2) == 2
+
+    inst1.delete()
+
+    # Deletion compacts slots by moving the last instance into the freed slot.
+    assert vlist.instance_count == 2
+    assert vlist.get_instance_by_index(1) is inst2
+    assert vlist.get_instance_by_index(2) is None
+    assert vlist.get_instance_index(inst1) is None
+    assert vlist.get_instance_index(inst2) == 1
+
+
+def test_instanced_indexed_migrate_moves_instances(shader_program, vlist_factory):
+    from pyglet.graphics import Batch, ShaderGroup
+
+    source_batch = Batch()
+    target_batch = Batch()
+    source_group = ShaderGroup(program=shader_program)
+    target_group = ShaderGroup(program=shader_program)
+
+    source = vlist_factory((0.0,) * 12, batch=source_batch, group=source_group)
+    target = vlist_factory((1.0,) * 12, batch=target_batch, group=target_group)
+
+    old_domain = source.domain
+    old_bucket = source.instance_bucket
+
+    inst0 = source.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
+    inst1 = source.create_instance(colors=(0, 1, 0, 1), translate=(5, 0, 0))
+
+    source.migrate(target.domain, target.group)
+
+    assert source.domain is target.domain
+    assert source.instance_bucket is not old_bucket
+    assert source.instance_bucket.instance_count == 2
+    assert old_bucket.instance_count == 0
+    assert source.get_instance_by_index(0) is inst0
+    assert source.get_instance_by_index(1) is inst1
+    assert inst0.bucket is source.instance_bucket
+    assert inst1.bucket is source.instance_bucket
+    assert source.domain is not old_domain
+
+
+def test_instanced_indexed_vertex_list_delete_clears_instances(vlist_factory):
+    vlist = vlist_factory((0.0,) * 12)
+
+    inst0 = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
+    inst1 = vlist.create_instance(colors=(0, 1, 0, 1), translate=(10, 0, 0))
+
+    assert vlist.instance_bucket.instance_count == 2
+
+    vlist.delete()
+
+    assert vlist.instance_count == 0
+    assert vlist.get_instance_by_index(0) is None
+    assert vlist.get_instance_index(inst0) is None
+    assert vlist.get_instance_index(inst1) is None
+    assert inst0.slot == -1
+    assert inst1.slot == -1
+
+
+def test_instanced_vertex_list_migrate_new_domain_and_group(shader_program, vlist_non_indexed_factory):
+    from pyglet.enums import GeometryMode
+    from pyglet.graphics import Batch, ShaderGroup
+
+    verts = (
+        0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0,
+        0.0, 1.0, 0.0,
+    )
+    source_batch = Batch()
+    target_batch = Batch()
+    source_group = ShaderGroup(program=shader_program, order=0)
+    target_group = ShaderGroup(program=shader_program, order=1)
+
+    source = vlist_non_indexed_factory(verts, batch=source_batch, group=source_group)
+    target = vlist_non_indexed_factory(verts, batch=target_batch, group=target_group)
+
+    old_domain = source.domain
+
+    source_batch.migrate(source, GeometryMode.TRIANGLES, target_group, target_batch)
+
+    assert source.domain is target.domain
+    assert source.domain is not old_domain
+    assert source.group is target_group
+    assert source.bucket is source.domain.get_drawable_bucket(target_group)
+    assert (source.start, source.count) in source.bucket.ranges
+    assert old_domain.get_drawable_bucket(source_group) is None
+
+
+def test_instanced_vertex_list_migrate_new_group_same_domain(shader_program, vlist_non_indexed_factory):
+    from pyglet.enums import GeometryMode
+    from pyglet.graphics import Batch, ShaderGroup
+
+    verts = (
+        0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0,
+        0.0, 1.0, 0.0,
+    )
+    batch = Batch()
+    source_group = ShaderGroup(program=shader_program, order=0)
+    target_group = ShaderGroup(program=shader_program, order=1)
+
+    vlist = vlist_non_indexed_factory(verts, batch=batch, group=source_group)
+    old_domain = vlist.domain
+    old_bucket = vlist.bucket
+
+    batch.migrate(vlist, GeometryMode.TRIANGLES, target_group, batch)
+
+    assert vlist.domain is old_domain
+    assert vlist.bucket is not old_bucket
+    assert vlist.group is target_group
+    assert vlist.bucket is old_domain.get_drawable_bucket(target_group)
+    assert (vlist.start, vlist.count) in vlist.bucket.ranges
+    assert old_domain.get_drawable_bucket(source_group) is None
 
 
 def test_missing_instance_attribute_raises(vlist_factory):


### PR DESCRIPTION
This improves instancing by adding ability to order the instances of an instance vertex list.  This is because using groups to order them is not possible as Groups only order based on the domains, so it needs it's own separate ordering system. While it is not really meant for constant sorting as it can be slow to move data in buffers, it at least gives users some control.

Adds the following helper functions for instanced vertex lists:
* ``vlist.instance_count`` to inspect the number of active instances.
* ``vlist.get_instance_index(instance)`` to get the current slot for an instance.
* ``vlist.swap_instances(a, b)`` to swap two instances.
* ``vlist.move_instance_to_index(instance, index)`` to move one instance to a specific index.
* ``vlist.move_to_back([inst1, inst2, ...])`` to move a subset to lower indices (drawn earlier).
* ``vlist.move_to_top([inst1, inst2, ...])`` to move a subset to higher indices (drawn later).
* ``vlist.set_instance_order([...])`` to set the full exact order of all active instances.

Open to feedback about improving it if there is a better way.