### PR TITLE
Fix buffer creation issues

### DIFF
--- a/pyglet/graphics/api/gl/buffer.py
+++ b/pyglet/graphics/api/gl/buffer.py
@@ -59,6 +59,12 @@ class GLBufferObject(AbstractBuffer):
     id: int | None
     usage: int
     target: int
+
+    # If the buffer data has been allocated yet.
+    _allocated: bool
+
+    # Even if it's allocated, there may be garbage in there. Mark when actual data exists.
+    _data_uploaded: bool
     _context: OpenGLSurfaceContext
 
     def __init__(
@@ -76,10 +82,8 @@ class GLBufferObject(AbstractBuffer):
         buffer_id = GLuint()
         self._context.glGenBuffers(1, buffer_id)
         self.id = buffer_id.value
-
-        self.bind()
-        data = (GLubyte * self.size)()
-        self._context.glBufferData(self.target, self.size, data, self.usage)
+        self._allocated = False
+        self._data_uploaded = False
 
     def _validate_byte_range(self, offset: int, length: int) -> None:
         assert offset >= 0 and length >= 0, "Offset and length must be non-negative."  # noqa: PT018
@@ -93,7 +97,25 @@ class GLBufferObject(AbstractBuffer):
     def unbind(self) -> None:
         self._context.glBindBuffer(self.target, 0)
 
+    def _ensure_allocated(self) -> None:
+        if self._allocated:
+            return
+        self.bind()
+        self._context.glBufferData(self.target, self.size, None, self.usage)
+        self._allocated = True
+
+    def _require_uploaded_data(self) -> None:
+        assert self._data_uploaded, (
+            "Buffer data has not been uploaded yet. "
+            "Call set_bytes/set_bytes_region, commit, or write through a mapped pointer first."
+        )
+
+    def _set_data_uploaded(self) -> None:
+        self._allocated = True
+        self._data_uploaded = True
+
     def get_bytes(self) -> bytes:
+        self._require_uploaded_data()
         self.bind()
         ptr = self._context.glMapBufferRange(self.target, 0, self.size, GL_MAP_READ_BIT)
         data = ctypes.string_at(ptr, self.size)
@@ -101,6 +123,7 @@ class GLBufferObject(AbstractBuffer):
         return data
 
     def get_bytes_region(self, offset: int, length: int) -> bytes:
+        self._require_uploaded_data()
         self._validate_byte_range(offset, length)
         self.bind()
         ptr = self._context.glMapBufferRange(self.target, offset, length, GL_MAP_READ_BIT)
@@ -113,25 +136,30 @@ class GLBufferObject(AbstractBuffer):
         assert len(raw) == self.size, f"Expected {self.size} bytes for full upload, got {len(raw)}."
         self.bind()
         self._context.glBufferData(self.target, self.size, raw, self.usage)
+        self._set_data_uploaded()
 
     def set_bytes_region(self, offset: int, data: bytes | bytearray | memoryview) -> None:
         # BufferObject updates are whole-buffer by design. Patch the local
         # bytes and re-upload the full content.
         raw = bytes(data)
         self._validate_byte_range(offset, len(raw))
-        whole = bytearray(self.get_bytes())
+        whole = bytearray(self.get_bytes()) if self._data_uploaded else bytearray(self.size)
         whole[offset:offset + len(raw)] = raw
         self.set_bytes(whole)
 
     def invalidate(self) -> None:
         self.bind()
         self._context.glBufferData(self.target, self.size, None, self.usage)
+        self._allocated = True
+        self._data_uploaded = False
 
     def delete(self) -> None:
         if self.id is None:
             return
         self._context.glDeleteBuffers(1, GLuint(self.id))
         self.id = None
+        self._allocated = False
+        self._data_uploaded = False
 
     def __del__(self) -> None:
         if self.id is not None:
@@ -143,16 +171,29 @@ class GLBufferObject(AbstractBuffer):
 
     def resize(self, size: int) -> None:
         assert size >= 0, "Size must be non-negative."
-        copy_size = min(size, self.size)
-        temp = (ctypes.c_byte * max(size, 1))()
+        if size == self.size:
+            return
+        if not self._allocated:
+            self.size = size
+            self._data_uploaded = False
+            return
+
+        old_size = self.size
+        copy_size = min(size, old_size) if self._data_uploaded else 0
+        temp = (ctypes.c_byte * max(size, 1))() if self._data_uploaded and size > 0 else None
         self.bind()
-        if copy_size > 0:
+        if copy_size > 0 and temp is not None:
             data = self._context.glMapBufferRange(self.target, 0, copy_size, GL_MAP_READ_BIT)
             ctypes.memmove(temp, data, copy_size)
             self._context.glUnmapBuffer(self.target)
-
         self.size = size
-        self._context.glBufferData(self.target, self.size, temp if size > 0 else None, self.usage)
+        if temp is None:
+            self._context.glBufferData(self.target, self.size, None, self.usage)
+            self._data_uploaded = False
+        else:
+            self._context.glBufferData(self.target, self.size, temp, self.usage)
+            self._data_uploaded = True
+        self._allocated = True
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(id={self.id}, size={self.size})"
@@ -167,6 +208,9 @@ class GLMappedBufferObject(GLBufferObject, BaseMappedBufferObject):
         # GLES3 only supports mapping a range.
         self._supports_range_only = self._context.info.get_opengl_api() == GraphicsAPI.OPENGL_ES_3
 
+        # Mapping doesn't necessarily mean it wrote something... try to track if it wrote something.
+        self._last_map_includes_write = False
+
     @staticmethod
     def _to_map_range_bits(bits: int) -> int:
         if bits == GL_WRITE_ONLY:
@@ -178,11 +222,14 @@ class GLMappedBufferObject(GLBufferObject, BaseMappedBufferObject):
         return bits
 
     def map(self, bits: int = GL_WRITE_ONLY) -> CTypesPointer[ctypes.c_byte]:
+        self._ensure_allocated()
         self.bind()
         if self._supports_range_only:
             range_bits = self._to_map_range_bits(bits)
+            self._last_map_includes_write = (range_bits & GL_MAP_WRITE_BIT) != 0
             ptr = self._context.glMapBufferRange(self.target, 0, self.size, range_bits)
         else:
+            self._last_map_includes_write = bits in (GL_WRITE_ONLY, GL_READ_WRITE)
             ptr = self._context.glMapBuffer(self.target, bits)
         return ctypes.cast(ptr, ctypes.POINTER(ctypes.c_byte * self.size)).contents
 
@@ -193,11 +240,17 @@ class GLMappedBufferObject(GLBufferObject, BaseMappedBufferObject):
         ptr_type: type[CTypesPointer],
         bits: int = GL_MAP_WRITE_BIT,
     ) -> CTypesPointer:
+        self._validate_byte_range(start, size)
+        self._ensure_allocated()
         self.bind()
+        self._last_map_includes_write = (bits & GL_MAP_WRITE_BIT) != 0
         return ctypes.cast(self._context.glMapBufferRange(self.target, start, size, bits), ptr_type).contents
 
     def unmap(self) -> None:
         self._context.glUnmapBuffer(self.target)
+        if self._last_map_includes_write:
+            self._set_data_uploaded()
+        self._last_map_includes_write = False
 
 
 class GLBackedBufferObject(BaseBackedBufferObject, GLBufferObject):
@@ -264,20 +317,20 @@ class GLBackedBufferObject(BaseBackedBufferObject, GLBufferObject):
 
         self.bind()
         size = self._dirty_max - self._dirty_min
-        if size > 0:
-            if size == self.size:
-                self._context.glBufferData(self.target, self.size, self.store.get_bytes(), self.usage)
-            else:
-                self._context.glBufferSubData(
-                    self.target,
-                    self._dirty_min,
-                    size,
-                    self.store.get_bytes(self._dirty_min, size),
-                )
+        if not self._allocated or not self._data_uploaded or size == self.size:
+            self._context.glBufferData(self.target, self.size, self.store.get_bytes(), self.usage)
+        else:
+            self._context.glBufferSubData(
+                self.target,
+                self._dirty_min,
+                size,
+                self.store.get_bytes(self._dirty_min, size),
+            )
+        self._set_data_uploaded()
 
-            self._dirty_min = sys.maxsize
-            self._dirty_max = 0
-            self._dirty = False
+        self._dirty_min = sys.maxsize
+        self._dirty_max = 0
+        self._dirty = False
 
     @lru_cache(maxsize=None)  # noqa: B019
     def get_region(self, start: int, count: int):
@@ -409,11 +462,15 @@ class GLTransformFeedbackBufferObject(GLBufferObject, TransformFeedbackBuffer):
         TransformFeedbackBuffer.__init__(self, size=size, data_type=data_type)
 
     def bind_base(self, index: int) -> None:
+        self._ensure_allocated()
         self._context.glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, index, self.id)
+        self._data_uploaded = True
 
     def bind_range(self, index: int, offset: int, size: int) -> None:
         self._validate_byte_range(offset, size)
+        self._ensure_allocated()
         self._context.glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index, self.id, offset, size)
+        self._data_uploaded = True
 
 
 class GLTextureBufferObject(GLBufferObject, TextureBuffer):

--- a/pyglet/graphics/api/webgl/buffer.py
+++ b/pyglet/graphics/api/webgl/buffer.py
@@ -59,6 +59,12 @@ class WebGLBufferObject(AbstractBuffer):
     id: WebGLBuffer | None
     usage: int
     target: int
+
+    # If the buffer data has been allocated yet.
+    _allocated: bool
+
+    # Even if it's allocated, there may be garbage in there. Mark when actual data exists.
+    _data_uploaded: bool
     _context: OpenGLSurfaceContext
 
     def __init__(
@@ -75,8 +81,8 @@ class WebGLBufferObject(AbstractBuffer):
         self._gl = context.gl
 
         self.id = self._gl.createBuffer()
-        self.bind()
-        self._gl.bufferData(self.target, self.size, self.usage)
+        self._allocated = False
+        self._data_uploaded = False
 
     def _validate_byte_range(self, offset: int, length: int) -> None:
         assert offset >= 0 and length >= 0, "Offset and length must be non-negative."
@@ -90,17 +96,36 @@ class WebGLBufferObject(AbstractBuffer):
     def unbind(self) -> None:
         self._gl.bindBuffer(self.target, None)
 
+    def _ensure_allocated(self) -> None:
+        if self._allocated:
+            return
+        self.bind()
+        self._gl.bufferData(self.target, self.size, self.usage)
+        self._allocated = True
+
+    def _require_uploaded_data(self) -> None:
+        assert self._data_uploaded, (
+            "Buffer data has not been uploaded yet. "
+            "Call set_bytes/set_bytes_region, commit, or write through a mapped pointer first."
+        )
+
+    def _set_data_uploaded(self) -> None:
+        self._allocated = True
+        self._data_uploaded = True
+
     def get_buffer_size(self) -> int:
         self.bind()
         return self._gl.getBufferParameter(self.target, GL_BUFFER_SIZE)
 
     def get_bytes(self) -> bytes:
+        self._require_uploaded_data()
         self.bind()
         data = js.Uint8Array.new(self.size)
         self._gl.getBufferSubData(self.target, 0, data)
         return bytes(data.buffer.to_py(depth=1))
 
     def get_bytes_region(self, offset: int, length: int) -> bytes:
+        self._require_uploaded_data()
         self._validate_byte_range(offset, length)
         self.bind()
         data = js.Uint8Array.new(length)
@@ -112,25 +137,30 @@ class WebGLBufferObject(AbstractBuffer):
         assert len(raw) == self.size, f"Expected {self.size} bytes for full upload, got {len(raw)}."
         self.bind()
         self._gl.bufferData(self.target, _to_js_uint8(raw), self.usage)
+        self._set_data_uploaded()
 
     def set_bytes_region(self, offset: int, data: bytes | bytearray | memoryview) -> None:
         # BufferObject updates are whole-buffer by design. Patch the local
         # bytes and re-upload the full content.
         raw = bytes(data)
         self._validate_byte_range(offset, len(raw))
-        whole = bytearray(self.get_bytes())
+        whole = bytearray(self.get_bytes()) if self._data_uploaded else bytearray(self.size)
         whole[offset:offset + len(raw)] = raw
         self.set_bytes(whole)
 
     def invalidate(self) -> None:
         self.bind()
         self._gl.bufferData(self.target, self.size, self.usage)
+        self._allocated = True
+        self._data_uploaded = False
 
     def delete(self) -> None:
         if self.id is None:
             return
         self._gl.deleteBuffer(self.id)
         self.id = None
+        self._allocated = False
+        self._data_uploaded = False
 
     def __del__(self) -> None:
         if self.id is not None:
@@ -141,24 +171,34 @@ class WebGLBufferObject(AbstractBuffer):
                 pass  # Interpreter is shutting down
 
     def resize(self, size: int) -> None:
+        if size == self.size:
+            return
+        if not self._allocated:
+            self.size = size
+            self._data_uploaded = False
+            return
+
         # Copy data from old buffer into new buffer, then replace.
         old_id = self.id
         new_id = self._gl.createBuffer()
+        copy_size = min(self.size, size) if self._data_uploaded else 0
 
         self._gl.bindBuffer(self._gl.COPY_READ_BUFFER, old_id)
         self._gl.bindBuffer(self._gl.COPY_WRITE_BUFFER, new_id)
         self._gl.bufferData(self._gl.COPY_WRITE_BUFFER, size, self._gl.DYNAMIC_DRAW)
-
-        self._gl.copyBufferSubData(
-            self._gl.COPY_READ_BUFFER,
-            self._gl.COPY_WRITE_BUFFER,
-            0,
-            0,
-            min(self.size, size),
-        )
+        if copy_size > 0:
+            self._gl.copyBufferSubData(
+                self._gl.COPY_READ_BUFFER,
+                self._gl.COPY_WRITE_BUFFER,
+                0,
+                0,
+                copy_size,
+            )
         self._gl.deleteBuffer(old_id)
         self.id = new_id
         self.size = size
+        self._allocated = True
+        self._data_uploaded = copy_size > 0
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(id={self.id}, size={self.size})"
@@ -238,19 +278,19 @@ class WebGLBackedBufferObject(BaseBackedBufferObject, WebGLBufferObject):
 
         self.bind()
         size = self._dirty_max - self._dirty_min
-        if size > 0:
-            if size == self.size:
-                self._gl.bufferData(self.target, _to_js_uint8(self.store.get_bytes()), self.usage)
-            else:
-                self._gl.bufferSubData(
-                    self.target,
-                    self._dirty_min,
-                    _to_js_uint8(self.store.get_bytes(self._dirty_min, size)),
-                )
+        if not self._allocated or not self._data_uploaded or size == self.size:
+            self._gl.bufferData(self.target, _to_js_uint8(self.store.get_bytes()), self.usage)
+        else:
+            self._gl.bufferSubData(
+                self.target,
+                self._dirty_min,
+                _to_js_uint8(self.store.get_bytes(self._dirty_min, size)),
+            )
+        self._set_data_uploaded()
 
-            self._dirty_min = sys.maxsize
-            self._dirty_max = 0
-            self._dirty = False
+        self._dirty_min = sys.maxsize
+        self._dirty_max = 0
+        self._dirty = False
 
     @lru_cache(maxsize=None)  # noqa: B019
     def get_region(self, start: int, count: int):
@@ -382,11 +422,15 @@ class WebGLTransformFeedbackBufferObject(WebGLBufferObject, TransformFeedbackBuf
         TransformFeedbackBuffer.__init__(self, size=size, data_type=data_type)
 
     def bind_base(self, index: int) -> None:
+        self._ensure_allocated()
         self._gl.bindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, index, self.id)
+        self._data_uploaded = True
 
     def bind_range(self, index: int, offset: int, size: int) -> None:
         self._validate_byte_range(offset, size)
+        self._ensure_allocated()
         self._gl.bindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index, self.id, offset, size)
+        self._data_uploaded = True
 
 
 class WebGLTextureBufferObject(WebGLBufferObject, TextureBuffer):

--- a/tests/integration/graphics/opengl_core/test_buffers.py
+++ b/tests/integration/graphics/opengl_core/test_buffers.py
@@ -35,7 +35,8 @@ def test_buffer_object_create_resize_and_delete(gl3_context):
 
     buffer = GLBufferObject(ctx, 16)
     assert buffer.size == 16
-    assert len(buffer.get_bytes()) == 16
+    with pytest.raises(AssertionError):
+        buffer.get_bytes()
 
     payload = bytes(range(16))
     buffer.set_bytes(payload)
@@ -59,6 +60,40 @@ def test_buffer_object_create_resize_and_delete(gl3_context):
     buffer.delete()
 
 
+@require_graphics_api(GraphicsAPIGroups.GL3)
+def test_index_buffer_creation_vao_element_buffer(gl3_context):
+    """This makes sure creating an index buffer does not overwrite the existing VAO's bound index buffer."""
+    from pyglet.graphics.api.gl import GL_ELEMENT_ARRAY_BUFFER, GL_ELEMENT_ARRAY_BUFFER_BINDING, GLint, GLuint
+
+    gl3_context.switch_to()
+    ctx = gl3_context.context
+
+    vao = GLuint()
+    ctx.glGenVertexArrays(1, vao)
+    created = None
+    anchor = None
+    ctx.glBindVertexArray(vao)
+    try:
+        anchor = GLBufferObject(ctx, 8, target=GL_ELEMENT_ARRAY_BUFFER)
+        anchor.set_bytes(b"\x00" * 8)
+
+        bound_before = GLint()
+        ctx.glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, bound_before)
+        assert bound_before.value == anchor.id
+
+        created = GLIndexedBufferObject(ctx, size=8, data_type="I", stride=4, count=1)
+        bound_after = GLint()
+        ctx.glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, bound_after)
+        assert bound_after.value == anchor.id
+    finally:
+        if created is not None:
+            created.delete()
+        if anchor is not None:
+            anchor.delete()
+        ctx.glBindVertexArray(0)
+        ctx.glDeleteVertexArrays(1, vao)
+
+
 def test_buffer_object_assertions(gl3_context):
     gl3_context.switch_to()
     ctx = gl3_context.context
@@ -66,6 +101,8 @@ def test_buffer_object_assertions(gl3_context):
 
     with pytest.raises(AssertionError):
         buffer.set_bytes(b"\x00")
+    with pytest.raises(AssertionError):
+        buffer.get_bytes()
     with pytest.raises(AssertionError):
         buffer.get_bytes_region(-1, 1)
     with pytest.raises(AssertionError):
@@ -129,6 +166,22 @@ def test_backed_index_buffer_commit_resize_and_delete(gl3_context):
 
     buffer.delete()
     assert buffer.id is None
+    buffer.delete()
+
+
+def test_backed_index_buffer_first_partial_commit_allocates_and_uploads(gl3_context):
+    gl3_context.switch_to()
+    ctx = gl3_context.context
+
+    buffer = GLIndexedBufferObject(ctx, size=16, data_type="I", stride=4, count=1)
+
+    buffer.set_data_region([7], start=0, length=4)
+    buffer.commit()
+
+    gpu_data = GLBufferObject.get_bytes(buffer)
+    typed_gpu = (ctypes.c_uint32 * 4).from_buffer_copy(gpu_data)
+    assert tuple(typed_gpu) == (7, 0, 0, 0)
+
     buffer.delete()
 
 


### PR DESCRIPTION
Make it so buffers do not bind and allocate data on class creation.

This fixes an issue with newly created index buffer objects overwriting whatever VAO's bound index buffer is, on creation.

The classes will just ensure allocation when needed and we just keep track of if it has data or not to prevent reading garbage data.

Open to suggestions on making this better. Not sure if it opens up any other issues.

The only other thought I had was to make allocating explicit, such as needing to call `buffer.allocate(data)` that could be done when required, but would require more changes in more places since things like `commit` assume we already have data and so forth. It might make things faster without all the checks needed to lazily allocate, but this should work for now. 