### PR TITLE
Text adjustments

### DIFF
--- a/pyglet/font/base.py
+++ b/pyglet/font/base.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from typing import Any, BinaryIO, ClassVar
 
 from pyglet import image
-from pyglet.gl import GL_LINEAR, GL_RGBA, GL_TEXTURE_2D
+from pyglet.gl import GL_LINEAR, GL_RGBA, GL_TEXTURE_2D, GL_NEAREST
 
 _OTHER_GRAPHEME_EXTEND = {
     chr(x) for x in [0x09be, 0x09d7, 0x0be3, 0x0b57, 0x0bbe, 0x0bd7, 0x0cc2,
@@ -271,8 +271,8 @@ class Font:
     glyph_fit: int = 100
 
     texture_internalformat: int = GL_RGBA
-    texture_min_filter: int = GL_LINEAR
-    texture_mag_filter: int = GL_LINEAR
+    texture_min_filter: int = GL_NEAREST
+    texture_mag_filter: int = GL_NEAREST
 
     # These should also be set by subclass when known
     ascent: int = 0

--- a/pyglet/text/layout/base.py
+++ b/pyglet/text/layout/base.py
@@ -461,23 +461,25 @@ class _GlyphBox(_AbstractBox):
         vertices = []
         tex_coords = []
         baseline = 0
-        x1 = line_x
+        x1 = round(line_x)
         for start, end, baseline_ in context.baseline_iter.ranges(i, i + n_glyphs):
             baseline = layout._parse_distance(baseline_)  # noqa: SLF001
             assert len(self.glyphs[start - i:end - i]) == end - start
-            for (kern, glyph, glyph_pos) in self.glyphs[start - i:end - i]:
-                x1 += kern
+            y1 = round(line_y + baseline)
+            for kern, glyph, glyph_pos in self.glyphs[start - i:end - i]:
+                x1 += round(kern)
                 v0, v1, v2, v3 = glyph.vertices
-                v0 += x1 + glyph_pos.x_offset
-                v2 += x1 + glyph_pos.x_offset
-                v1 += line_y + baseline + glyph_pos.y_offset
-                v3 += line_y + baseline + glyph_pos.y_offset
-                vertices.extend(map(round, [v0, v1, 0, v2, v1, 0, v2, v3, 0, v0, v3, 0]))
-                t = glyph.tex_coords
-                tex_coords.extend(t)
-                x1 += glyph.advance + glyph_pos.x_advance
-                v1 += glyph_pos.y_advance
-                v3 += glyph_pos.y_advance
+                # Translate the whole glyph as a block. Rounding v0/v1/v2/v3 can distort vertices.
+                gx = x1 + round(glyph_pos.x_offset)
+                gy = y1 + round(glyph_pos.y_offset)
+                vertices.extend([
+                    v0 + gx, v1 + gy, 0,
+                    v2 + gx, v1 + gy, 0,
+                    v2 + gx, v3 + gy, 0,
+                    v0 + gx, v3 + gy, 0,
+                ])
+                tex_coords.extend(glyph.tex_coords)
+                x1 += round(glyph.advance + glyph_pos.x_advance)
 
         # Text color
         colors = []
@@ -1143,7 +1145,8 @@ class TextLayout:
         for line in self._lines:
             acc_anchor_x = self._anchor_left
             for box in line.boxes:
-                box.update_anchor(acc_anchor_x, anchor_y)
+                place_anchor_x = round(acc_anchor_x) if self._rotation == 0 else acc_anchor_x
+                box.update_anchor(place_anchor_x, anchor_y)
                 acc_anchor_x += box.advance
 
     @property
@@ -2001,7 +2004,8 @@ class TextLayout:
         acc_anchor_x = anchor_x
         # GlyphBoxes (boxes) are collection of Glyphs/Inline Elements. A line can have multiple GlyphBoxes.
         for box in boxes:
-            box.place(self, i, self._x, self._y, self._z, line_x, line_y, self._rotation, self._visible, acc_anchor_x,
+            place_anchor_x = round(acc_anchor_x) if self._rotation == 0 else acc_anchor_x
+            box.place(self, i, self._x, self._y, self._z, line_x, line_y, self._rotation, self._visible, place_anchor_x,
                       anchor_y, context)
             i += box.length
             acc_anchor_x += box.advance

--- a/pyglet/text/layout/incremental.py
+++ b/pyglet/text/layout/incremental.py
@@ -617,10 +617,11 @@ class IncrementalTextLayout(TextLayout, EventDispatcher):
             # A line can have no vertex list if it's out of view OR is an empty row.
 
             # Accumulate the X accounting for multiple GlyphBoxes.
-            anchor_x = anchor_left
+            acc_anchor_x = anchor_left
             for box in line.boxes:
-                box.update_anchor(anchor_x, anchor_top)
-                anchor_x += box.advance
+                place_anchor_x = round(acc_anchor_x) if self._rotation == 0 else acc_anchor_x
+                box.update_anchor(place_anchor_x, anchor_top)
+                acc_anchor_x += box.advance
 
     def _get_bottom_anchor(self) -> float:
         """Returns the anchor for the Y axis from the bottom."""


### PR DESCRIPTION
I ran into a few issues regarding text placements in Windows.

Here is an example:
<img width="1174" height="244" alt="image" src="https://github.com/user-attachments/assets/bc029f4d-451f-4c05-8575-2f4244c781ff" />

With some fonts, the glyphs can get squished together and depending on the glyph run, the anchor offset can also distort the text. I traced these to issues regarding float accumulation errors.

With fonts, the advances can be float positions, and over time those imprecisions can add up causing it to undershoot or overshoot when placing these bitmap glyphs. This instead rounds the positions, same for the accumulated anchors of the glyph runs. I have opted to round them as well, as the accumulated errors can cause it to shift.

Before we were rounding all of the vertices after the fact, which could slightly distort/stretch the glyph texture by 1 or 2 pixels depending on where the positions ended up.

These changes have seemed to fix the errors:
<img width="1136" height="158" alt="image" src="https://github.com/user-attachments/assets/3c97002e-0953-4e1f-a837-890eed11d370" />

Lastly, this might a controversial change, but changing the default texture filtering for fonts to NEAREST. The glyphs are already rendered to a texture with anti-aliasing (depending on the font). By having it linearly, it can potentially "double filter" the labels in some scaling or float positions (see the last word in the first image "laborum", on how they can end up looking). Of course this will affect how labels get scaled in a framebuffer or appear when on a float position, but for me it gave a much better appearance. 

Would like if someone could test these changes on Linux/Mac.