### PR TITLE
Remove check for Python < 3.2 in cocoapy's parse_type_encoding, add doc and return type

### DIFF
--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -835,8 +835,7 @@ cfunctype_table = {}
 def parse_type_encoding(encoding: bytes):
     """Takes a type encoding string and outputs a list of the separated type codes.
     Currently does not handle unions or bitfields and strips out any field width
-    specifiers or type specifiers from the encoding.  For Python 3.2+, encoding is
-    assumed to be a bytes object and not unicode.
+    specifiers or type specifiers from the encoding.
 
     Examples:
     parse_type_encoding('^v16@0:8') --> ['^v', '@', ':']
@@ -847,11 +846,6 @@ def parse_type_encoding(encoding: bytes):
     bracket_count = 0  # number of unclosed square brackets
     typecode = b''
     for c in encoding:
-        # In Python 3, c comes out as an integer in the range 0-255.  In Python 2, c is a single character string.
-        # To fix the disparity, we convert c to a bytes object if necessary.
-        if isinstance(c, int):
-            c = bytes([c])
-
         if c == b'{':
             # Check if this marked the end of previous type code.
             if typecode and typecode[-1:] != b'^' and brace_count == 0 and bracket_count == 0:

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -1748,3 +1748,4 @@ class ObjCBlock:
 
     def _wrapper(self, _block, *args):
         return self.func(*args)
+

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -38,7 +38,7 @@ from contextlib import contextmanager
 
 from ctypes import *
 from ctypes import util
-from typing import Type, TypeVar, Sequence, Any, Callable
+from typing import Type, TypeVar, Sequence, Any, Callable, List
 
 from .cocoatypes import *
 
@@ -832,7 +832,7 @@ def send_super(receiver, selName, *args, superclass_name=None, **kwargs):
 cfunctype_table = {}
 
 
-def parse_type_encoding(encoding: bytes):
+def parse_type_encoding(encoding: bytes) -> List[bytes]:
     """Takes a type encoding string and outputs a list of the separated type codes.
     Currently does not handle unions or bitfields and strips out any field width
     specifiers or type specifiers from the encoding.
@@ -841,7 +841,7 @@ def parse_type_encoding(encoding: bytes):
     parse_type_encoding('^v16@0:8') --> ['^v', '@', ':']
     parse_type_encoding('{CGSize=dd}40@0:8{CGSize=dd}16Q32') --> ['{CGSize=dd}', '@', ':', '{CGSize=dd}', 'Q']
     """
-    type_encodings = []
+    type_encodings: List[bytes] = []
     brace_count = 0  # number of unclosed curly braces
     bracket_count = 0  # number of unclosed square brackets
     typecode = b''

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -833,13 +833,31 @@ cfunctype_table = {}
 
 
 def parse_type_encoding(encoding: bytes) -> List[bytes]:
-    """Takes a type encoding string and outputs a list of the separated type codes.
-    Currently does not handle unions or bitfields and strips out any field width
-    specifiers or type specifiers from the encoding.
+    """Split the bytes of a limited subset of encodings into a list of type codes.
+
+    Type encodings are covered in the Objective-C Runtime Programming Guide:
+    https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+
+    Limitations include:
+
+    * No support for unions, e.g. `b'(value=^v*)'`
+    * No support for bitfields, e.g. `b'b8'` for an 8-bit bitfield
+    * Numerical field widths after a type encoding are removed
+    * Objective-C method encoding specifiers are removed
 
     Examples:
-    parse_type_encoding('^v16@0:8') --> ['^v', '@', ':']
-    parse_type_encoding('{CGSize=dd}40@0:8{CGSize=dd}16Q32') --> ['{CGSize=dd}', '@', ':', '{CGSize=dd}', 'Q']
+    .. code-block:: python
+
+        >>> parse_type_encoding(b'^v16@0:8')
+        [b'^v', b'@', b':']
+        >>> parse_type_encoding(b'{CGSize=dd}40@0:8{CGSize=dd}16Q32')
+        [b'{CGSize=dd}', b'@', b':', b'{CGSize=dd}', b'Q']
+
+    Args:
+        encoding: A bytes object with a type encoding.
+
+    Returns:
+        A list of type encodings stripped of unsupported dta (field widths, method encodings, etc).
     """
     type_encodings: List[bytes] = []
     brace_count = 0  # number of unclosed curly braces
@@ -875,7 +893,9 @@ def parse_type_encoding(encoding: bytes) -> List[bytes]:
             # Ignore field width specifiers for now.
             pass
         elif c in b'rnNoORV':
-            # Also ignore type specifiers.
+            # Also ignore Objective C method type specifiers.
+            # See Table 6-2 at the bottom of the Objective-C Runtime Programming Guide:
+            # https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
             pass
         elif c in b'^cislqCISLQfdBv*@#:b?':
             if typecode and typecode[-1:] == b'^':

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -838,14 +838,20 @@ def parse_type_encoding(encoding: bytes) -> List[bytes]:
     Type encodings are covered in the Objective-C Runtime Programming Guide:
     https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
 
-    Limitations include:
+    Limitations are numerous.
 
-    * No support for unions, e.g. `b'(value=^v*)'`
-    * No support for bitfields, e.g. `b'b8'` for an 8-bit bitfield
-    * Numerical field widths after a type encoding are removed
-    * Objective-C method encoding specifiers are removed
+    There is no support for:
+    * unions, e.g. ``b'(value=^v*)'`` for a union of:
+      * a void pointer
+      * a character string
+    * bitfields, e.g. `b'b8'` for an 8-bit bitfield
+
+    The following are removed:
+    * Numerical field widths (``'b'^v16'`` becomes ``[b'^v']``)
+    * Objective-C method encoding specifiers (any of ``b'rnNoORV'``)
 
     Examples:
+
     .. code-block:: python
 
         >>> parse_type_encoding(b'^v16@0:8')
@@ -857,7 +863,7 @@ def parse_type_encoding(encoding: bytes) -> List[bytes]:
         encoding: A bytes object with a type encoding.
 
     Returns:
-        A list of type encodings stripped of unsupported dta (field widths, method encodings, etc).
+        A list of type encodings stripped of unsupported data (field widths, method encodings, etc).
     """
     type_encodings: List[bytes] = []
     brace_count = 0  # number of unclosed curly braces
@@ -893,7 +899,7 @@ def parse_type_encoding(encoding: bytes) -> List[bytes]:
             # Ignore field width specifiers for now.
             pass
         elif c in b'rnNoORV':
-            # Also ignore Objective C method type specifiers.
+            # Also ignore Objective-C method type specifiers.
             # See Table 6-2 at the bottom of the Objective-C Runtime Programming Guide:
             # https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
             pass

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -869,7 +869,7 @@ def parse_type_encoding(encoding: bytes) -> List[bytes]:
     brace_count = 0  # number of unclosed curly braces
     bracket_count = 0  # number of unclosed square brackets
     typecode = b''
-    for c in encoding:
+    for c in (encoding[i:i+1] for i in range(len(encoding))):
         if c == b'{':
             # Check if this marked the end of previous type code.
             if typecode and typecode[-1:] != b'^' and brace_count == 0 and bracket_count == 0:


### PR DESCRIPTION
**TL;DR:** Type hint `parse_type_encoding`, explain what it does, remove check for Python < 3.2 strings

Practice toward an idea @Cleptomania had:
 
1. Add a return type annotation
2. Explain what the function does by adding:
    - What it doesn't support
    - Where the doc is buried in Apple's archives
    - better explanations of what a "type specifier" is (an Obj-C method type specifier)
3. Improve comments
4. Remove check for bytes