### PR TITLE
Fix weakmethod callback errors on shutdown

### DIFF
--- a/pyglet/event.py
+++ b/pyglet/event.py
@@ -121,7 +121,6 @@ from __future__ import annotations
 import inspect
 import os.path
 
-from functools import partial
 from typing import TYPE_CHECKING, Literal, Union
 from weakref import WeakMethod
 
@@ -193,7 +192,7 @@ class EventDispatcher:
                     msg = f'Unknown event "{name}"'
                     raise EventException(msg)
                 if inspect.ismethod(obj):
-                    yield name, WeakMethod(obj, partial(self._remove_handler, name))
+                    yield name, WeakMethod(obj)
                 else:
                     yield name, obj
             else:
@@ -201,7 +200,7 @@ class EventDispatcher:
                 for name in dir(obj):
                     if name in self.event_types:
                         meth = getattr(obj, name)
-                        yield name, WeakMethod(meth, partial(self._remove_handler, name))
+                        yield name, WeakMethod(meth)
 
         for name, handler in kwargs.items():
             # Function for handling given event (no magic)
@@ -209,7 +208,7 @@ class EventDispatcher:
                 msg = f'Unknown event "{name}"'
                 raise EventException(msg)
             if inspect.ismethod(handler):
-                yield name, WeakMethod(handler, partial(self._remove_handler, name))
+                yield name, WeakMethod(handler)
             else:
                 yield name, handler
 
@@ -302,25 +301,6 @@ class EventDispatcher:
                     break
             except KeyError:
                 pass
-
-    def _remove_handler(self, name: str, handler: Callable) -> None:
-        """Used internally to remove all handler instances for the given event name.
-
-        This is normally called from a dead ``WeakMethod`` to remove itself from the
-        event stack.
-        """
-        # Iterate over a copy as we might mutate the list
-        for frame in list(self._event_stack):
-
-            if name in frame:
-                try:
-                    if frame[name] == handler:
-                        del frame[name]
-                        if not frame:
-                            self._event_stack.remove(frame)
-                except TypeError:
-                    # weakref is already dead
-                    pass
 
     def dispatch_event(self, event_type: str, *args: Any) -> bool | None:
         """Dispatch an event to the attached event handlers.

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -218,6 +218,29 @@ def test_weakref_to_instance(dispatcher):
     assert watcher.called
 
 
+@pytest.mark.parametrize(
+    ('push_handler', 'expected_callbacks'),
+    [
+        (lambda dispatcher, handler: dispatcher.push_handlers(handler.mock_event), 1),
+        (lambda dispatcher, handler: dispatcher.push_handlers(handler), 1),
+        (lambda dispatcher, handler: dispatcher.push_handlers(mock_event=handler.mock_event), 1),
+    ],
+)
+def test_weakref_handler_paths_have_no_removal_callbacks(dispatcher, monkeypatch, push_handler, expected_callbacks):
+    dispatcher.register_event_type('mock_event')
+    callbacks = []
+    weak_method = pyglet.event.WeakMethod
+
+    def track_callback(method, callback=None):
+        callbacks.append(callback)
+        return weak_method(method, callback)
+
+    monkeypatch.setattr(pyglet.event, 'WeakMethod', track_callback)
+    push_handler(dispatcher, DummyHandler())
+
+    assert callbacks == [None] * expected_callbacks
+
+
 def test_weakref_deleted_when_instance_is_deleted(dispatcher):
     dispatcher.register_event_type('mock_event')
     handler = DummyHandler()
@@ -238,3 +261,59 @@ def test_dispatch_event_ignores_dead_weak_method_handler(dispatcher):
     result = dispatcher.dispatch_event('mock_event')
     assert result is False
     assert not dispatcher._event_stack
+
+
+def test_remove_handlers_removes_weakref_to_instance_method(dispatcher):
+    dispatcher.register_event_type('mock_event')
+    handler = DummyHandler()
+    dispatcher.push_handlers(handler.mock_event)
+
+    dispatcher.remove_handlers(handler.mock_event)
+
+    result = dispatcher.dispatch_event('mock_event')
+    assert result is False
+
+
+def test_remove_handlers_removes_weakref_to_instance(dispatcher):
+    dispatcher.register_event_type('mock_event')
+    handler = DummyHandler()
+    dispatcher.push_handlers(handler)
+
+    dispatcher.remove_handlers(handler)
+
+    result = dispatcher.dispatch_event('mock_event')
+    assert result is False
+
+
+def test_dispatch_event_removes_dead_weak_handler_and_continues_to_lower_frame(dispatcher):
+    dispatcher.register_event_type('mock_event')
+    lower_handler = mock.Mock(spec=types.FunctionType)
+    lower_handler.__name__ = 'mock_event'
+    lower_handler.return_value = EVENT_HANDLED
+    weak_handler = DummyHandler()
+    dispatcher.push_handlers(lower_handler)
+    dispatcher.push_handlers(weak_handler.mock_event)
+    del weak_handler
+    gc.collect()
+
+    result = dispatcher.dispatch_event('mock_event')
+
+    assert result == EVENT_HANDLED
+    assert lower_handler.called
+    assert dispatcher._event_stack == [{'mock_event': lower_handler}]
+
+
+def test_dispatch_event_removes_dead_weak_handler_from_non_empty_frame(dispatcher):
+    dispatcher.register_event_type('mock_event')
+    dispatcher.register_event_type('mock_event2')
+    handler = ClassInstanceHandler()
+    dispatcher.push_handlers(handler)
+    del handler
+    gc.collect()
+
+    result = dispatcher.dispatch_event('mock_event')
+
+    assert result is False
+    assert len(dispatcher._event_stack) == 1
+    assert 'mock_event' not in dispatcher._event_stack[0]
+    assert 'mock_event2' in dispatcher._event_stack[0]


### PR DESCRIPTION
This fixes the weakref methods trying to call back the partial function internal remove handler function during interpreter shutdown when you have an instance that is being pushed as a handler.  The callback is no longer needed since we now cleanup dead weakrefs when they are dispatched.

Add tests to cover this too.