### PR TITLE
Cleanup Uniform Buffer Object creation

### DIFF
--- a/examples/graphics/uniform_buffer_object.py
+++ b/examples/graphics/uniform_buffer_object.py
@@ -1,0 +1,152 @@
+"""Uniform Buffer Object region example.
+
+This example uses one shader program with three material UBO regions. Each
+group binds a different region before its shape is drawn.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pyglet
+from pyglet.enums import GeometryMode, GraphicsAPI
+
+
+if pyglet.options.backend != GraphicsAPI.OPENGL:
+    raise RuntimeError("This example uses OpenGL 3.3 shader syntax. Run it with the OpenGL backend.")
+
+
+window = pyglet.window.Window(width=720, height=480, caption="Uniform Buffer Object", resizable=True)
+batch = pyglet.graphics.Batch()
+
+
+vertex_source = """#version 330 core
+    in vec2 position;
+
+    uniform WindowBlock
+    {
+        mat4 projection;
+        mat4 view;
+    } window;
+
+    layout(std140) uniform MaterialBlock
+    {
+        vec4 color;
+        vec4 offset_scale;
+    } material;
+
+    out vec4 vertex_color;
+
+    void main()
+    {
+        vec2 scaled_position = position * material.offset_scale.zw;
+        vec2 world_position = scaled_position + material.offset_scale.xy;
+        gl_Position = window.projection * window.view * vec4(world_position, 0.0, 1.0);
+        vertex_color = material.color;
+    }
+"""
+
+fragment_source = """#version 330 core
+    in vec4 vertex_color;
+    out vec4 final_color;
+
+    void main()
+    {
+        final_color = vertex_color;
+    }
+"""
+
+program = pyglet.graphics.ShaderProgram(
+    pyglet.graphics.Shader(vertex_source, "vertex"),
+    pyglet.graphics.Shader(fragment_source, "fragment"),
+)
+
+material_block = program.uniform_blocks["MaterialBlock"]
+
+
+def create_material(color: tuple[float, float, float, float],
+                    offset_scale: tuple[float, float, float, float]):
+    region = material_block.create_ubo_region()
+    # When creating the material, ensure it has some initial data.
+    with region as material_region:
+        material_region.color[:] = color
+        material_region.offset_scale[:] = offset_scale
+    return region
+
+
+triangle_vertices = (
+    -0.6, -0.5,
+     0.6, -0.5,
+     0.0,  0.6,
+)
+
+quad_vertices = (
+    -0.5, -0.5,
+     0.5, -0.5,
+     0.5,  0.5,
+    -0.5,  0.5,
+)
+
+materials = [
+    create_material((0.95, 0.30, 0.22, 1.0), (160.0, 240.0, 100.0, 100.0)),
+    create_material((0.18, 0.64, 0.96, 1.0), (360.0, 240.0, 120.0, 120.0)),
+    create_material((0.90, 0.82, 0.28, 1.0), (560.0, 240.0, 90.0, 90.0)),
+]
+elapsed_time = 0.0
+
+groups = []
+# Give each separate material its own group, so the dirty regions can be committed during draw.
+for material in materials:
+    group = pyglet.graphics.ShaderGroup(program)
+    group.set_uniform_buffer(material)
+    groups.append(group)
+
+triangle_1 = program.vertex_list(
+    3,
+    GeometryMode.TRIANGLES,
+    batch=batch,
+    group=groups[0],
+    position=("f", triangle_vertices),
+)
+triangle_2 = program.vertex_list_indexed(
+    4,
+    GeometryMode.TRIANGLES,
+    indices=(0, 1, 2, 0, 2, 3),
+    batch=batch,
+    group=groups[1],
+    position=("f", quad_vertices),
+)
+triangle_3 = program.vertex_list(
+    3,
+    GeometryMode.TRIANGLES,
+    batch=batch,
+    group=groups[2],
+    position=("f", triangle_vertices),
+)
+
+
+def update_materials(dt: float) -> None:
+    global elapsed_time
+    elapsed_time += dt
+
+    for index, region in enumerate(materials):
+        angle = elapsed_time * 1.6 + index * 2.1
+        center_x = 360.0 + math.cos(angle) * (120.0 + index * 18.0)
+        center_y = 240.0 + math.sin(angle * 0.8) * (70.0 + index * 12.0)
+
+        with region as material_region:
+            material_region.offset_scale[0] = center_x
+            material_region.offset_scale[1] = center_y
+
+
+@window.event
+def on_draw() -> None:
+    window.clear()
+    batch.draw()
+
+
+pyglet.clock.schedule_interval(update_materials, 1 / 60)
+
+
+if __name__ == "__main__":
+    pyglet.app.run()

--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from pyglet.graphics.shader import Shader, ShaderProgram, ComputeShaderProgram, TransformFeedbackShaderProgram  # noqa: F401
     from pyglet.graphics.state import State  # noqa: F401
     from pyglet.graphics.shader import get_default_shader  # noqa: F401
+    from pyglet.graphics.buffer import UniformBufferRegion  # noqa: F401
     from pyglet.graphics.draw import get_default_batch  # noqa: F401
     from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
     from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas  # noqa: F401
@@ -53,6 +54,7 @@ else:
     )
     from pyglet.graphics.state import State  # noqa: F401
     from pyglet.graphics.api import core  # noqa: F401
+    from pyglet.graphics.buffer import UniformBufferRegion  # noqa: F401
     from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
     from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas  # noqa: F401
     from pyglet.graphics.framebuffer import Framebuffer, Renderbuffer  # noqa: F401

--- a/pyglet/graphics/api/gl/state.py
+++ b/pyglet/graphics/api/gl/state.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from pyglet.customtypes import ScissorProtocol
     from pyglet.graphics.draw import DrawContext
     from pyglet.graphics.api.gl.shader import ShaderProgram
+    from pyglet.graphics.buffer import UniformBufferRegion
     from pyglet.graphics.texture import Texture
 
 
@@ -227,8 +228,13 @@ class ViewportState(_BaseViewportState):
 
 @dataclass(frozen=True)
 class UniformBufferState(State):
-    name: str
-    binding: int
+    region: UniformBufferRegion
+    binding_index: int | None = None
+
+    sets_state: bool = True
+
+    def set_state(self, ctx: DrawContext) -> None:
+        self.region.bind(binding_index=self.binding_index)
 
 
 @dataclass(frozen=True)

--- a/pyglet/graphics/api/gl2/state.py
+++ b/pyglet/graphics/api/gl2/state.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pyglet.graphics.state import State
 from typing import TYPE_CHECKING
 from pyglet.graphics.api.gl.state import (TextureState, MultiTextureSamplerState, BlendState, ShaderUniformState,   # noqa: F401
-                                          DepthBufferComparison, ScissorState, ViewportState)
+                                          DepthBufferComparison, ScissorState, UniformBufferState, ViewportState)
 
 
 if TYPE_CHECKING:
@@ -24,6 +24,6 @@ class ShaderProgramState(State):
         ctx.active_shader_program = self.program
 
         if ctx.active_camera and ctx.active_camera.view.storage:
-            ctx.active_camera.view.storage.bind(ctx)
+            ctx.active_camera.view.storage.bind_camera(ctx)
 
 

--- a/pyglet/graphics/api/webgl/state.py
+++ b/pyglet/graphics/api/webgl/state.py
@@ -10,6 +10,7 @@ from pyglet.graphics.state import State, _BaseScissorState, _BaseViewportState
 
 if TYPE_CHECKING:
     from pyglet.customtypes import ScissorProtocol
+    from pyglet.graphics.buffer import UniformBufferRegion
     from pyglet.graphics.api.webgl.shader import ShaderProgram
     from pyglet.graphics.draw import DrawContext
     from pyglet.graphics.texture import Texture
@@ -216,8 +217,13 @@ class ViewportState(_BaseViewportState):
 
 @dataclass(frozen=True)
 class UniformBufferState(State):
-    name: str
-    binding: int
+    region: UniformBufferRegion
+    binding_index: int | None = None
+
+    sets_state: bool = True
+
+    def set_state(self, ctx: DrawContext) -> None:
+        self.region.bind(binding_index=self.binding_index)
 
 
 @dataclass(frozen=True)

--- a/pyglet/graphics/buffer.py
+++ b/pyglet/graphics/buffer.py
@@ -464,6 +464,89 @@ class UniformBufferObject(RingBuffer):
         )
 
 
+class UniformBufferRegion:
+    """UBO region that uploads through a ring-buffered ``UniformBufferObject``.
+
+    The region owns one CPU-side data structure and a set of GPU ranges.
+
+    General practice is to update the data structure, mark it dirty, and then commit when you are done updating
+    for that frame.
+
+    .. warning:: Do not make the CPU-side data dirty after binding/committing during the same frame (for example,
+                 during the ``on_draw`` call), or GPU stalls may occur.
+
+    .. versionadded:: 3.0
+    """
+
+    __slots__ = (
+        "_current_binding",
+        "_current_range",
+        "_dirty",
+        "_next_range_index",
+        "_ranges",
+        "_ubo",
+        "data",
+    )
+
+    def __init__(
+        self,
+        ubo: UniformBufferObject,
+        *,
+        copies_per_resource: int | None = None,
+    ) -> None:
+        self._ubo = ubo
+        self.data = ubo.get_data_structure()
+        self._current_binding: BufferBindingSlice | None = None
+        self._current_range: BufferRange | None = None
+        self._ranges = ubo.reserve_resource_range(copies_per_resource=copies_per_resource)
+        self._next_range_index = 0
+        self._dirty = True
+
+    @property
+    def ubo(self) -> UniformBufferObject:
+        """The underlying ``UniformBufferObject``."""
+        return self._ubo
+
+    @property
+    def dirty(self) -> bool:
+        """Whether the CPU-side data needs to be uploaded before drawing."""
+        return self._dirty
+
+    def __enter__(self) -> ctypes.Structure:
+        return self.data
+
+    def __exit__(self, _exc_type: Any, _exc_val: Any, _exc_tb: Any) -> None:
+        self.mark_dirty()
+
+    def mark_dirty(self) -> None:
+        """Mark the CPU-side data for upload on the next ``bind`` call."""
+        self._dirty = True
+
+    def commit(self) -> None:
+        """Upload dirty CPU-side data to the next writable GPU range."""
+        if not self._dirty:
+            return
+
+        self._current_binding, self._current_range, self._next_range_index = (
+            self._ubo.upload_to_available_binding_from_ranges(
+                self.data,
+                self._ranges,
+                self._next_range_index,
+            )
+        )
+        self._dirty = False
+
+    def bind(self, *, binding_index: int | None = None) -> None:
+        """Upload dirty data if needed, then bind the current GPU range."""
+        self.commit()
+
+        if self._current_binding is None or self._current_range is None:
+            return
+
+        self._ubo.use_range(self._current_range)
+        self._ubo.bind_slice(self._current_binding, binding_index=binding_index)
+
+
 class MappedBufferObject(AbstractBuffer):
     """A GPU buffer that supports map/unmap and range mapping."""
 

--- a/pyglet/graphics/draw.py
+++ b/pyglet/graphics/draw.py
@@ -23,10 +23,12 @@ from pyglet.graphics.state import (
     ShaderUniformState,
     State,
     TextureState,
+    UniformBufferState,
     ViewportState,
     _expand_states_in_order,
 )
 if TYPE_CHECKING:
+    from pyglet.graphics.buffer import UniformBufferRegion
     from pyglet.window.camera.base import BaseCamera, CameraScissor
     from pyglet.customtypes import ScissorProtocol
     from pyglet.graphics.shader import ShaderProgram
@@ -147,6 +149,18 @@ class Group:
 
     def set_shader_uniforms(self, program: ShaderProgram, uniforms: dict[str, Any]):
         self.set_state(ShaderUniformState(program, uniforms))
+
+    def set_uniform_buffer(self, region: UniformBufferRegion, binding_index: int | None = None) -> None:
+        """Set a Uniform Buffer Object region state.
+
+        Args:
+            region:
+                A region created by ``UniformBlock.create_ubo_region``.
+            binding_index:
+                Optional binding point override. By default, the region uses
+                the binding point assigned to its source uniform block.
+        """
+        self.set_state(UniformBufferState(region, binding_index))
 
     def set_texture(self, texture: Texture, texture_unit: int=0, set_id: int=0) -> None:
         """Set the texture state.

--- a/pyglet/graphics/shader.py
+++ b/pyglet/graphics/shader.py
@@ -9,20 +9,25 @@ import weakref
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Literal, Sequence, Any, TYPE_CHECKING, Callable, Protocol, overload
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol, Sequence, overload
 
 import pyglet
 from pyglet.enums import GraphicsAPI
+from pyglet.graphics.buffer import UniformBufferRegion
 
 if TYPE_CHECKING:
-    from pyglet.graphics.buffer import (
-        UniformBufferObject,
-    )
-    from pyglet.customtypes import DataTypes, CType
-    from pyglet.graphics.vertexdomain import IndexedVertexList, VertexList, InstanceIndexedVertexList, InstanceVertexList
-    from pyglet.graphics import Batch, Group
-    from pyglet.enums import GeometryMode
     from _weakref import CallableProxyType
+
+    from pyglet.customtypes import CType, DataTypes
+    from pyglet.enums import GeometryMode
+    from pyglet.graphics import Batch, Group
+    from pyglet.graphics.buffer import UniformBufferObject
+    from pyglet.graphics.vertexdomain import (
+        IndexedVertexList,
+        InstanceIndexedVertexList,
+        InstanceVertexList,
+        VertexList,
+    )
 
 
 class ShaderException(BaseException):
@@ -966,6 +971,22 @@ class UniformBlock:
             copies_per_resource,
             strict,
         )
+
+    def create_ubo_region(
+        self,
+        *,
+        copies_per_resource: int = 3,
+        alignment: int | None = None,
+        strict: bool = False,
+    ) -> UniformBufferRegion:
+        """Create a ring-buffered region for updating and binding this uniform block."""
+
+        ubo = self.create_ubo(
+            copies_per_resource=copies_per_resource,
+            alignment=alignment,
+            strict=strict,
+        )
+        return UniformBufferRegion(ubo, copies_per_resource=copies_per_resource)
 
     def set_binding(self, binding: int) -> None:
         """Rebind the Uniform Block to a new binding index number.

--- a/pyglet/graphics/state.py
+++ b/pyglet/graphics/state.py
@@ -8,8 +8,8 @@ import pyglet
 
 from pyglet.enums import GraphicsAPI
 
-
 if TYPE_CHECKING:
+    from pyglet.window.camera.base import _CameraViewBase
     from pyglet.customtypes import ScissorProtocol
     from pyglet.graphics.draw import DrawContext
     from pyglet.window.camera import ViewportType
@@ -62,6 +62,7 @@ class State:
 @runtime_checkable
 class CameraScopeProtocol(Protocol):
     """Protocol for camera objects used by camera scope states."""
+    view: _CameraViewBase
 
     @property
     def viewport(self) -> ViewportType:
@@ -180,6 +181,7 @@ MultiTextureSamplerState: type[State] = _backend_state.MultiTextureSamplerState
 ShaderProgramState: type[State] = _backend_state.ShaderProgramState
 BlendState: type[State] = _backend_state.BlendState
 ShaderUniformState: type[State] = _backend_state.ShaderUniformState
+UniformBufferState: type[State] = _backend_state.UniformBufferState
 DepthBufferComparison: type[State] = _backend_state.DepthBufferComparison
 ScissorState: type[State] = _backend_state.ScissorState
 ViewportState: type[State] = _backend_state.ViewportState

--- a/pyglet/window/camera/base.py
+++ b/pyglet/window/camera/base.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload, run
 
 import pyglet
 from pyglet.enums import GraphicsAPI
+from pyglet.graphics.buffer import UniformBufferRegion
 
 
 if TYPE_CHECKING:
     from pyglet.customtypes import ScissorProtocol
     from pyglet.graphics.draw import DrawContext
     from pyglet.math import Mat4
-    from pyglet.graphics.buffer import BufferBindingSlice, BufferRange, UniformBufferObject
+    from pyglet.graphics.buffer import UniformBufferObject
     from pyglet.graphics.shader import ShaderProgram, UniformBlock
     from pyglet.window import Window
 
@@ -61,7 +62,7 @@ class CameraViewStorage(Protocol):
     def commit(self, draw_context: DrawContext) -> None:
         """Commit staged camera data to GPU-visible state when drawing."""
 
-    def bind(self, draw_context: DrawContext) -> None:
+    def bind_camera(self, draw_context: DrawContext) -> None:
         """Bind or apply committed camera data for drawing."""
 
 
@@ -97,7 +98,7 @@ def _create_default_camera_ubo(
     return window_block.create_ubo(copies_per_resource=copies_per_resource)
 
 
-class UniformBufferCameraRegion:
+class UniformBufferCameraRegion(UniformBufferRegion):
     """Camera storage adapter for UBO-backed data uploads."""
 
     def __init__(
@@ -106,37 +107,20 @@ class UniformBufferCameraRegion:
         *,
         copies_per_resource: int | None = None,
     ) -> None:
-        self._ubo = ubo
+        super().__init__(ubo, copies_per_resource=copies_per_resource)
         self._copies_per_resource = copies_per_resource
-        self._ubo_data = ubo.get_data_structure()
-        self._current_binding: BufferBindingSlice | None = None
-        self._current_range: BufferRange | None = None
-        self._ranges = ubo.reserve_resource_range(copies_per_resource=self._copies_per_resource)
-        self._next_range_index = 0
         self._dirty = False
 
     def apply(self, projection: Mat4, view: Mat4) -> None:
-        self._ubo_data.projection[:] = projection
-        self._ubo_data.view[:] = view
-        self._dirty = True
+        self.data.projection[:] = projection
+        self.data.view[:] = view
+        self.mark_dirty()
 
-    def commit(self, _draw_context: DrawContext) -> None:
-        if not self._dirty:
-            return
+    def commit(self, _draw_context: DrawContext | None = None) -> None:
+        super().commit()
 
-        self._current_binding, self._current_range, self._next_range_index = (
-            self._ubo.upload_to_available_binding_from_ranges(
-                self._ubo_data,
-                self._ranges,
-                self._next_range_index,
-            )
-        )
-        self._dirty = False
-
-    def bind(self, _draw_context: DrawContext) -> None:
-        if self._current_binding is not None and self._current_range is not None:
-            self._ubo.use_range(self._current_range)
-            self._ubo.bind_slice(self._current_binding)
+    def bind_camera(self, _draw_context: DrawContext) -> None:
+        self.bind()
 
     def create_view_storage(self) -> UniformBufferCameraRegion:
         return UniformBufferCameraRegion(
@@ -197,7 +181,7 @@ class UniformSetCameraRegion:
     def commit(self, draw_context: DrawContext) -> None:
         self._dirty = False
 
-    def bind(self, draw_context: DrawContext) -> None:
+    def bind_camera(self, draw_context: DrawContext) -> None:
         if draw_context.active_shader_program is not None:
             self.apply_to_program(draw_context.active_shader_program)
 
@@ -436,7 +420,7 @@ class BaseCamera(Generic[ViewT]):
         self._window = weakref.proxy(window)
 
         if not isinstance(view_storage, CameraViewStorage):
-            msg = "Camera region must implement apply(projection, view) and commit(draw_context)."
+            msg = "Camera region must implement apply(projection, view), commit(draw_context), and bind_camera(draw_context)."
             raise TypeError(msg)
 
         self.view_storage = view_storage
@@ -644,7 +628,7 @@ class BaseCamera(Generic[ViewT]):
         if storage is not None and commit:
             storage.commit(draw_context)
         if storage is not None:
-            storage.bind(draw_context)
+            storage.bind_camera(draw_context)
         if changed:
             self._mark_cpu_data_applied(projection, view_matrix, target_view)
 

--- a/tests/integration/graphics/test_cameras.py
+++ b/tests/integration/graphics/test_cameras.py
@@ -28,7 +28,7 @@ class RecordingStorage:
         assert draw_context is not None
         self.commit_count += 1
 
-    def bind(self, draw_context) -> None:
+    def bind_camera(self, draw_context) -> None:
         assert draw_context is not None
         self.bind_count += 1
 

--- a/tests/interactive/graphics/group_ordering.py
+++ b/tests/interactive/graphics/group_ordering.py
@@ -13,7 +13,6 @@ A test to spot test camera scissors, views, and hierarchy views
 from __future__ import annotations
 
 import pyglet
-pyglet.options.backend = "gl2"
 from pyglet.window import key
 from pyglet.window.camera import Camera2D, CameraScissor
 


### PR DESCRIPTION
When creating the new UBO implementation to make the new Camera;s work, I didn't really consider it's use outside of it.  This is a cleanup and addition of an API so users can utilize their own UniformBlocks.

This PR creates a wrapper around the previous camera region and turns it into a generic use UniformBufferRegion.

Also created a small example for users to see how to utilize UniformBlocks and UBO regions with their applications. 