### PR TITLE
Fix Mat3.scale and Mat3.translate to match Mat4 conventions

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -976,10 +976,10 @@ class Mat3(_typing.NamedTuple):
     i: float = 1.0
 
     def scale(self, sx: float, sy: float) -> Mat3:
-        return self @ Mat3(1.0 / sx, 0.0, 0.0, 0.0, 1.0 / sy, 0.0, 0.0, 0.0, 1.0)
+        return self @ Mat3(sx, 0.0, 0.0, 0.0, sy, 0.0, 0.0, 0.0, 1.0)
 
     def translate(self, tx: float, ty: float) -> Mat3:
-        return self @ Mat3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, -tx, ty, 1.0)
+        return self @ Mat3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, tx, ty, 1.0)
 
     def rotate(self, phi: float) -> Mat3:
         s = _math.sin(_math.radians(phi))

--- a/tests/unit/math/test_mat.py
+++ b/tests/unit/math/test_mat.py
@@ -133,6 +133,20 @@ def test_mat3_associative_mul():
     assert v1 == v2 and abs(v1) != 0
 
 
+def test_mat3_translate():
+    # Translating the origin must move it by +(tx, ty), matching Mat4.translate.
+    result = Mat3().translate(10, 20) @ Vec3(0, 0, 1)
+    assert result == Vec3(10, 20, 1)
+    mat4_result = Mat4().translate(Vec3(10, 20, 0)) @ Vec4(0, 0, 0, 1)
+    assert (result.x, result.y) == (mat4_result.x, mat4_result.y)
+
+
+def test_mat3_scale():
+    # Scaling by (sx, sy) must multiply, matching Mat4.scale (not the reciprocal).
+    result = Mat3().scale(2, 3) @ Vec3(1, 1, 1)
+    assert result == Vec3(2, 3, 1)
+
+
 def _invalid_matmul(first, second):
     return first @ second
 


### PR DESCRIPTION
## Summary

`Mat3.scale` and `Mat3.translate` produce mathematically wrong results that disagree with their `Mat4` counterparts.

**`Mat3.scale`** builds the matrix from the *reciprocal* of the scale factors:

```python
def scale(self, sx, sy):
    return self @ Mat3(1.0 / sx, 0.0, 0.0, 0.0, 1.0 / sy, 0.0, 0.0, 0.0, 1.0)
```

so scaling *up* actually shrinks:

```python
>>> Mat3().scale(2, 3) @ Vec3(1, 1, 1)
Vec3(x=0.5, y=0.333..., z=1.0)      # expected (2, 3, 1)
```

**`Mat3.translate`** negates the x offset but not the y:

```python
def translate(self, tx, ty):
    return self @ Mat3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, -tx, ty, 1.0)
```

so translating the origin moves x the wrong way:

```python
>>> Mat3().translate(10, 20) @ Vec3(0, 0, 1)
Vec3(x=-10.0, y=20.0, z=1.0)        # expected (10, 20, 1)
```

The x/y asymmetry alone shows `translate` is a mistake regardless of any coordinate convention.

## Why this is the correct fix

`Mat4` is the well-used, tested sibling and defines the intended convention:

- `Mat4.scale` multiplies the diagonal by the factors (`temp[0] *= vector[0]`, …) — no reciprocal.
- `Mat4.translate` stores the offset positively (`Mat4(..., *vector, 1)`).

So `Mat3.scale` should use `sx, sy` and `Mat3.translate` should use `+tx`. After the fix:

```python
>>> Mat3().scale(2, 3) @ Vec3(1, 1, 1)
Vec3(x=2.0, y=3.0, z=1.0)
>>> Mat3().translate(10, 20) @ Vec3(0, 0, 1)
Vec3(x=10.0, y=20.0, z=1.0)
```

`Mat3.shear` was checked and is already correct (`x' = x + sx·y`, `y' = y + sy·x`), so it is left unchanged.

## Tests

Added `test_mat3_translate` and `test_mat3_scale` (there were none for these methods, which is why the bug went unnoticed). Both fail on the current code and pass with the fix; `test_mat3_translate` also cross-checks the offset against `Mat4.translate`. Full `tests/unit/math/` suite passes locally (115 passed).
