### PR TITLE
Fix Mat4.scale() to compose with self instead of only scaling the diagonal

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1256,11 +1256,7 @@ class Mat4(_typing.NamedTuple):
 
     def scale(self, vector: Vec3) -> Mat4:
         """Get a scale Matrix on x, y, or z axis."""
-        temp = list(self)
-        temp[0] *= vector[0]
-        temp[5] *= vector[1]
-        temp[10] *= vector[2]
-        return Mat4(*temp)
+        return self @ Mat4(vector[0], 0, 0, 0, 0, vector[1], 0, 0, 0, 0, vector[2], 0, 0, 0, 0, 1)
 
     def translate(self, vector: Vec3) -> Mat4:
         """Get a translation Matrix along x, y, and z axis."""

--- a/tests/unit/math/test_mat.py
+++ b/tests/unit/math/test_mat.py
@@ -147,6 +147,19 @@ def test_mat3_scale():
     assert result == Vec3(2, 3, 1)
 
 
+def test_mat4_scale():
+    # scale() must be equivalent to post-multiplying by a scale matrix, not just
+    # multiplying the diagonal of `self`. The two only agree when `self` is
+    # already diagonal, so use a rotated matrix to catch the difference.
+    matrix = Mat4().rotate(0.5, Vec3(0, 0, 1))
+    vector = Vec3(2, 3, 4)
+
+    scale_matrix = Mat4(vector.x, 0, 0, 0, 0, vector.y, 0, 0, 0, 0, vector.z, 0, 0, 0, 0, 1)
+    expected = matrix @ scale_matrix
+
+    assert round(matrix.scale(vector), 9) == round(expected, 9)
+
+
 def _invalid_matmul(first, second):
     return first @ second
 


### PR DESCRIPTION
`Mat4.scale()` just multiplies `temp[0]`, `temp[5]`, `temp[10]` (the three diagonal entries) and returns that. That's only the same as `self @ ScaleMatrix(v)` when `self` is already diagonal. As soon as `self` has anything off-diagonal in its first three columns, like after a `rotate()`, the scale lands on the wrong elements and most of it just gets dropped.

`Mat4.translate()` already does this the right way with `self @ Mat4(1,0,0,0, 0,1,0,0, 0,0,1,0, *vector, 1)`. Made `scale()` match that pattern instead of poking at individual indices.

Same root cause as #1460 basically: no test existed for `Mat4.scale()` on a non-identity matrix, so the identity-only case (where the two approaches happen to agree) never caught it.

Added `test_mat4_scale`, same idea as the `test_mat3_scale`/`test_mat3_translate` tests added in #1460: build a rotated matrix, scale it both ways, compare. Full `tests/unit/math/` suite passes locally (116 passed).

Fixes #1462
