### PR TITLE
Expanding clock behavior with event chaining

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.10' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.10' ]
 
     name: Python ${{ matrix.python-version }} Ubuntu
     steps:
@@ -78,7 +78,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
 
     name: Python ${{ matrix.python-version }} Windows
     steps:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -56,6 +56,7 @@ If you are migrating from an older version of pyglet, please read through
    programming_guide/rendering
    programming_guide/camera
    programming_guide/events
+   programming_guide/event_chains
    programming_guide/gui
    programming_guide/time
    programming_guide/context

--- a/doc/programming_guide/event_chains.rst
+++ b/doc/programming_guide/event_chains.rst
@@ -476,3 +476,81 @@ running::
         def destroy(self):
             self.chains.clear()
 
+
+Tweening values
+---------------
+
+Tweens update a value gradually over time. They are useful for visual changes
+such as fading, movement, scaling, or rotation, as well as audio levels,
+gameplay parameters, and any other state that changes smoothly. Yielding a
+tween keeps the update logic separate from the sequence that should continue
+after it finishes.
+
+:py:func:`~pyglet.clock.tween` drives an update callable with normalized
+progress over a duration. The callable receives one ``float`` argument. It
+can be a function, a lambda, a bound method, or any callable object. The tween
+returns a chain that can be yielded like any other child chain::
+
+    class FadeOut:
+        def __init__(self, target):
+            self.target = target
+            self.start_opacity = target.opacity
+
+        def update(self, progress):
+            self.target.opacity = self.start_opacity * (1.0 - progress)
+
+    @pyglet.clock.chain
+    def remove_sprite(sprite):
+        yield pyglet.clock.tween(0.5, FadeOut(sprite).update)
+        sprite.delete()
+
+For a one-off update, define a local function instead::
+
+    start_opacity = sprite.opacity
+
+    def update(progress):
+        sprite.opacity = start_opacity * (1.0 - progress)
+
+    yield pyglet.clock.tween(0.5, update)
+
+For a compact one-off update, a lambda works too. Capture the starting value
+before creating the lambda so that each update is based on the same value::
+
+    start_opacity = sprite.opacity
+    yield pyglet.clock.tween(
+        0.5,
+        lambda progress: setattr(sprite, 'opacity', start_opacity * (1.0 - progress)),
+    )
+
+With the default linear easing, the update callable receives ``0.0`` when the
+tween starts and ``1.0`` when it finishes. A zero-duration tween applies only
+the eased final value. Tweens are chains themselves, so they can be started
+directly or composed with :py:func:`~pyglet.clock.parallel` and
+:py:func:`~pyglet.clock.race`. They pause, resume, and stop like any other
+chain::
+
+    yield pyglet.clock.parallel(
+        pyglet.clock.tween(0.5, FadeOut(sprite).update),
+        pyglet.clock.tween(0.5, update_position),
+    )
+
+Pass an easing function to transform the linear progress. Easing functions
+receive a value from ``0.0`` through ``1.0``. Their result is not clamped,
+which permits curves that intentionally overshoot::
+
+    yield pyglet.clock.tween(
+        0.5,
+        FadeOut(sprite).update,
+        easing=pyglet.clock.ease_in_out,
+    )
+
+The built-in curves are :py:func:`~pyglet.clock.linear`,
+:py:func:`~pyglet.clock.ease_in`, :py:func:`~pyglet.clock.ease_out`,
+:py:func:`~pyglet.clock.ease_in_out`, and
+:py:func:`~pyglet.clock.smoothstep`. Any callable with the same ``float ->
+float`` shape can be supplied instead.
+
+Use :py:meth:`~pyglet.clock.Clock.tween` to bind the tween to a custom clock::
+
+    yield game_clock.tween(1.0, update_position, easing=my_easing)
+

--- a/doc/programming_guide/event_chains.rst
+++ b/doc/programming_guide/event_chains.rst
@@ -169,8 +169,8 @@ Error reporting
 Event chains do not silently hide uncaught exceptions. If a chain raises an
 exception, or if a yielded instruction calls ``fail(error)``, the error is
 thrown into the waiting chain. If your chain does not catch it, the chain stops,
-stores the exception on ``Chain.exception``, and calls any callbacks
-registered with :py:meth:`~pyglet.clock.Chain.add_callbacks`::
+stores the exception on ``Chain.exception``, finishes as failed, and calls any
+callbacks registered with :py:meth:`~pyglet.clock.Chain.add_callbacks`::
 
     @pyglet.clock.chain
     def failing_sequence():
@@ -205,6 +205,33 @@ small reusable event flows::
         profile = yield load_profile('Ada')
         print(profile['name'])
 
+
+Stopping child chains
+---------------------
+
+Calling :py:meth:`~pyglet.clock.Chain.stop` on a parent stops its active child
+chains as well. This is immediate cancellation: the parent generator is closed,
+its ``finally`` blocks run, and its ``on_stop`` callbacks are called.
+
+If a child is stopped independently while a parent is waiting for it, pyglet
+throws :py:exc:`~pyglet.clock.ChainStopped` at the parent's ``yield``. The
+parent can catch this signal and choose how to recover::
+
+    @pyglet.clock.chain
+    def load_scene():
+        try:
+            assets = yield download_assets()
+        except pyglet.clock.ChainStopped:
+            assets = load_cached_assets()
+
+        yield display_scene(assets)
+
+If the parent does not catch ``ChainStopped``, the parent stops too. It calls
+``on_stop``, not ``on_error``, and ``Chain.exception`` remains ``None``. This
+keeps cancellation separate from failure while still allowing a parent to
+handle child cancellation deliberately.
+
+
 Parallel work
 -------------
 
@@ -229,10 +256,13 @@ the same time and the parent should continue after all of them finish::
         )
         print(music, level)
 
-By default, if one child chain stops, the parallel group stops the remaining
-children and the parent receives an error. If a stopped child should be treated
-as missing work and the other children should continue, pass
-``continue_on_stop=True``. The stopped child contributes
+By default, if one child chain stops independently, the parallel group stops
+the remaining children and throws :py:exc:`~pyglet.clock.ChainStopped` at the
+parent's ``yield``. The parent may catch it; otherwise the parent stops as
+described above.
+
+If a stopped child should be treated as missing work and the other children
+should continue, pass ``continue_on_stop=True``. The stopped child contributes
 :py:data:`~pyglet.clock.STOPPED` to the result tuple, which keeps cancellation
 separate from a child that completed with ``return`` or ``return None``::
 
@@ -252,6 +282,11 @@ Race and timeout
 :py:func:`~pyglet.clock.race` resumes when the first child chain completes. It
 returns ``(index, result)``, where ``index`` is the winning child position. The
 remaining children are stopped.
+
+If a race child stops independently before there is a winner, the other
+children are stopped and the parent receives
+:py:exc:`~pyglet.clock.ChainStopped`. As with a directly yielded child, the
+parent may catch the signal; otherwise it stops.
 
 :py:func:`~pyglet.clock.timeout` is a small chain that completes after a delay.
 It is most useful when combined with ``race`` to bound how long a flow can wait
@@ -311,6 +346,9 @@ important because completed chains cannot be restarted::
 
     # Run until a condition becomes true.
     yield pyglet.clock.repeat_until(blink_once, lambda: game_over)
+
+    # Run until this chain is stopped.
+    yield pyglet.clock.repeat_forever(blink_once)
 
     # Run for a fixed duration.
     yield pyglet.clock.repeat_duration(blink_once, 3.0)

--- a/doc/programming_guide/event_chains.rst
+++ b/doc/programming_guide/event_chains.rst
@@ -316,38 +316,6 @@ important because completed chains cannot be restarted::
     yield pyglet.clock.repeat_duration(blink_once, 3.0)
 
 
-Chain lifecycle events
-----------------------
-
-``Chain`` is an :py:class:`~pyglet.event.EventDispatcher`. It dispatches
-``on_complete(result)``, ``on_stop()``, ``on_pause()``, ``on_resume()``, and
-``on_error(error)`` when its lifecycle changes. This allows chains to use the
-same handler APIs as other pyglet event sources like a Window::
-
-    sequence.add_callbacks(
-        on_complete=lambda result: print('finished:', result),
-        on_error=lambda error: print('failed:', error),
-    )
-
-
-Because lifecycle changes are ordinary events, another chain can wait for one.
-For example, this performs follow-up work only after an independently started
-fade completes::
-
-    fade = fade_out().start()
-
-    @pyglet.clock.chain
-    def destroy_after_fade():
-        yield pyglet.clock.wait_for_event(fade, 'on_complete')
-        sprite.delete()
-
-    destroy_after_fade().start()
-
-Lifecycle event handlers follow normal pyglet dispatch rules. In particular,
-returning ``EVENT_HANDLED`` prevents lower-priority handlers from receiving the
-same lifecycle event.
-
-
 Waiting for events and callbacks
 --------------------------------
 

--- a/doc/programming_guide/event_chains.rst
+++ b/doc/programming_guide/event_chains.rst
@@ -1,0 +1,510 @@
+.. _guide_event_chains:
+
+Event chains
+============
+
+Event chains are generator-based coroutines that run on pyglet's clock. They are
+useful when an event flow has several timed or callback-driven steps, but you do
+not want to split the logic across several scheduled functions.
+
+Event chains live in :py:mod:`pyglet.clock` because they are scheduled work.
+They can still wait for dispatcher events through
+:py:func:`pyglet.clock.wait_for_event`.
+
+Why event chains
+----------------
+
+Normal scheduling via :py:func:`pyglet.clock.schedule_interval` and
+:py:func:`pyglet.clock.schedule_once` are simple and easy to use for periodic
+updates and simple one-shot callbacks. However, some workflows become awkward
+when written only with :py:func:`pyglet.clock.schedule_once`,
+:py:func:`pyglet.clock.schedule`, and temporary event handlers:
+
+* A timed sequence needs multiple named callbacks or nested functions.
+* Cancellation requires tracking every scheduled callback and temporary event
+  handler manually.
+* Repeating a multi-step flow requires recreating the whole sequence manually.
+* Waiting for an event or callback in the middle of a timed flow splits the
+  logic across unrelated handlers.
+* No pause or resume behavior.
+* Running several flows together, or racing an event against a timeout, requires
+  custom bookkeeping.
+* Error handling is easy to lose when failures happen inside later scheduled
+  callbacks.
+
+Event chains add a small coordination layer over pyglet's existing clock and
+event system. They let you write the flow in the order it happens while still
+using pyglet's normal single-threaded event loop.
+
+Event chains are not ``asyncio`` coroutines. They do not require ``async`` or
+``await`` and they do not run on an asyncio event loop. Instead, a function
+decorated with :py:func:`~pyglet.clock.chain` returns a
+:py:class:`~pyglet.clock.Chain`, and the chain advances when pyglet's clock
+ticks or when a yielded event or callback instruction completes.
+
+The basic rule is that a chain yields one of the following:
+
+* A number (float or int) to wait that many seconds.
+* ``None``, to resume on the next clock tick.
+* Another :py:class:`~pyglet.clock.Chain` to wait for that child chain.
+* A yield instruction created with :py:func:`~pyglet.clock.wait_for_event`,
+  :py:func:`~pyglet.clock.yielding_callback`, or
+  :py:func:`~pyglet.clock.from_callback`.
+
+A sequence without event chains
+-------------------------------
+
+The following example shows a small title flow: fade in, show a title, fade out,
+then notify that the sequence is done. With only ``schedule_once``, each step
+must be split into a separate function, and the caller needs to track pending
+callbacks if the flow should be cancellable::
+
+    import pyglet
+
+    pending_callbacks = []
+
+    def schedule_step(callback, delay):
+        pending_callbacks.append(callback)
+        pyglet.clock.schedule_once(callback, delay)
+
+    def cancel_title_sequence():
+        for callback in pending_callbacks:
+            pyglet.clock.unschedule(callback)
+        pending_callbacks.clear()
+        print('cancelled')
+
+    def start_title_sequence():
+        print('fade in')
+        schedule_step(show_title, 0.5)
+
+    def show_title(dt):
+        pending_callbacks.remove(show_title)
+        print('show title')
+        schedule_step(fade_out, 2.0)
+
+    def fade_out(dt):
+        pending_callbacks.remove(fade_out)
+        print('fade out')
+        schedule_step(finished, 0.5)
+
+    def finished(dt):
+        pending_callbacks.remove(finished)
+        print('done')
+
+    start_title_sequence()
+    pyglet.app.run()
+
+This is manageable for three steps, but becomes harder to maintain as soon as
+the sequence waits for user input, repeats, runs alongside another sequence, or
+needs consistent error handling.
+
+The same sequence with event chains
+-----------------------------------
+
+With an event chain, the flow is written as one function in the order it
+happens::
+
+    import pyglet
+
+    @pyglet.clock.chain
+    def title_sequence():
+        print('fade in')
+        yield 0.5
+        print('show title')
+        yield 2.0
+        print('fade out')
+        yield 0.5
+        return 'done'
+
+    sequence = title_sequence()
+    sequence.add_callbacks(
+        on_complete=print,
+        on_stop=lambda: print('cancelled'),
+    )
+    sequence.start()
+
+    pyglet.app.run()
+
+The returned :py:class:`~pyglet.clock.Chain` can be stopped, paused,
+resumed, and observed::
+
+    sequence.pause()
+    sequence.resume()
+    sequence.stop()
+
+
+Separate clock instances
+------------------------
+
+By default, chains use :py:func:`pyglet.clock.get_default` when the chain object
+is created::
+
+    @pyglet.clock.chain
+    def spawn_wave():
+        yield 1.0
+        print('spawn')
+
+    spawn_wave().start()
+
+To bind chains to a specific :py:class:`~pyglet.clock.Clock`, decorate from the
+clock instance itself::
+
+    game_clock = pyglet.clock.Clock()
+
+    @game_clock.chain
+    def spawn_wave():
+        yield 1.0
+        print('spawn')
+
+    spawn_wave().start()
+
+This is useful when a game has separate clocks for gameplay, UI, or editor
+tools. Pausing can be as simple as not ticking the gameplay clock while the UI
+clock continues to tick.
+
+
+Error reporting
+---------------
+
+Event chains do not silently hide uncaught exceptions. If a chain raises an
+exception, or if a yielded instruction calls ``fail(error)``, the error is
+thrown into the waiting chain. If your chain does not catch it, the chain stops,
+stores the exception on ``Chain.exception``, and calls any callbacks
+registered with :py:meth:`~pyglet.clock.Chain.add_callbacks`::
+
+    @pyglet.clock.chain
+    def failing_sequence():
+        yield 0.5
+        raise RuntimeError('failed')
+
+    failing_sequence().add_callbacks(on_error=lambda error: print('handled:', error)).start()
+
+If no error callback is registered, pyglet prints the traceback with
+``traceback.print_exception`` and still stores the exception on the chain::
+
+    active = failing_sequence().start()
+
+    # After the failure:
+    # active.done is True
+    # active.exception is the RuntimeError instance
+
+
+Returning values
+----------------
+
+A child chain can return a value to its parent. This makes it possible to write
+small reusable event flows::
+
+    @pyglet.clock.chain
+    def load_profile(name):
+        yield 0.1
+        return {'name': name}
+
+    @pyglet.clock.chain
+    def show_profile():
+        profile = yield load_profile('Ada')
+        print(profile['name'])
+
+Parallel work
+-------------
+
+Use :py:func:`~pyglet.clock.parallel` when several child chains should run at
+the same time and the parent should continue after all of them finish::
+
+    @pyglet.clock.chain
+    def prepare_music():
+        yield 1.0
+        return 'music'
+
+    @pyglet.clock.chain
+    def prepare_level():
+        yield 2.0
+        return 'level'
+
+    @pyglet.clock.chain
+    def prepare_game():
+        music, level = yield pyglet.clock.parallel(
+            prepare_music(),
+            prepare_level(),
+        )
+        print(music, level)
+
+By default, if one child chain stops, the parallel group stops the remaining
+children and the parent receives an error. If a stopped child should be treated
+as missing work and the other children should continue, pass
+``continue_on_stop=True``. The stopped child contributes
+:py:data:`~pyglet.clock.STOPPED` to the result tuple, which keeps cancellation
+separate from a child that completed with ``return`` or ``return None``::
+
+    results = yield pyglet.clock.parallel(
+        prepare_music(),
+        prepare_level(),
+        continue_on_stop=True,
+    )
+
+    if results[0] is pyglet.clock.STOPPED:
+        print('music preparation was stopped')
+
+
+Race and timeout
+----------------
+
+:py:func:`~pyglet.clock.race` resumes when the first child chain completes. It
+returns ``(index, result)``, where ``index`` is the winning child position. The
+remaining children are stopped.
+
+:py:func:`~pyglet.clock.timeout` is a small chain that completes after a delay.
+It is most useful when combined with ``race`` to bound how long a flow can wait
+for an external event. This keeps prompts, network waits, menu flows, and other
+event-driven steps from waiting forever::
+
+    @pyglet.clock.chain
+    def wait_for_space():
+        symbol, modifiers = yield pyglet.clock.wait_for_event(
+            window,
+            'on_key_press',
+            condition=lambda symbol, modifiers: symbol == key.SPACE,
+        )
+        return symbol
+
+    @pyglet.clock.chain
+    def wait_or_timeout():
+        winner, result = yield pyglet.clock.race(
+            wait_for_space(),
+            pyglet.clock.timeout(5.0),
+        )
+
+        if winner == 0:
+            print('user responded')
+        else:
+            print('timed out')
+
+Timeouts can also be used without input events. For example, a status message
+can clear itself after a short delay::
+
+    @pyglet.clock.chain
+    def show_status(message):
+        status_label.text = message
+        yield pyglet.clock.timeout(2.0)
+        status_label.text = ''
+
+When ``timeout`` wins a race, the other child chains are stopped. If one of
+those child chains is waiting on a callback instruction, its cancellation
+callback is called during that stop.
+
+
+Repeating chains
+----------------
+
+Repeat helpers accept a factory that creates a fresh chain each time. This is
+important because completed chains cannot be restarted::
+
+    @pyglet.clock.chain
+    def blink_once():
+        print('on')
+        yield 0.25
+        print('off')
+        yield 0.25
+
+    # Run exactly three times.
+    yield pyglet.clock.repeat(blink_once, 3)
+
+    # Run until a condition becomes true.
+    yield pyglet.clock.repeat_until(blink_once, lambda: game_over)
+
+    # Run for a fixed duration.
+    yield pyglet.clock.repeat_duration(blink_once, 3.0)
+
+
+Chain lifecycle events
+----------------------
+
+``Chain`` is an :py:class:`~pyglet.event.EventDispatcher`. It dispatches
+``on_complete(result)``, ``on_stop()``, ``on_pause()``, ``on_resume()``, and
+``on_error(error)`` when its lifecycle changes. This allows chains to use the
+same handler APIs as other pyglet event sources like a Window::
+
+    sequence.add_callbacks(
+        on_complete=lambda result: print('finished:', result),
+        on_error=lambda error: print('failed:', error),
+    )
+
+
+Because lifecycle changes are ordinary events, another chain can wait for one.
+For example, this performs follow-up work only after an independently started
+fade completes::
+
+    fade = fade_out().start()
+
+    @pyglet.clock.chain
+    def destroy_after_fade():
+        yield pyglet.clock.wait_for_event(fade, 'on_complete')
+        sprite.delete()
+
+    destroy_after_fade().start()
+
+Lifecycle event handlers follow normal pyglet dispatch rules. In particular,
+returning ``EVENT_HANDLED`` prevents lower-priority handlers from receiving the
+same lifecycle event.
+
+
+Waiting for events and callbacks
+--------------------------------
+
+Most pyglet objects that produce events are
+:py:class:`~pyglet.event.EventDispatcher` instances. Use
+:py:func:`~pyglet.clock.wait_for_event` to suspend a chain until a dispatcher
+emits a matching event. The helper registers and removes the temporary handler
+for you::
+
+    from pyglet.window import key
+
+    window = pyglet.window.Window()
+
+    @pyglet.clock.chain
+    def prompt():
+        print('press Space')
+        symbol, modifiers = yield pyglet.clock.wait_for_event(
+            window,
+            'on_key_press',
+            condition=lambda symbol, modifiers: symbol == key.SPACE,
+        )
+        print('pressed', symbol)
+
+The optional ``condition`` lets you ignore events until the desired one arrives.
+The matching event arguments are sent back into the chain. Destructure them the
+same way you would in a normal event handler::
+
+    x, y, button, modifiers = yield pyglet.clock.wait_for_event(window, 'on_mouse_press')
+
+``wait_for_event`` is useful for custom dispatchers too. This example does not
+depend on windows or graphics::
+
+    class JobQueue(pyglet.event.EventDispatcher):
+        def finish_job(self, job_id, status):
+            self.dispatch_event('on_job_finished', job_id, status)
+
+    JobQueue.register_event_type('on_job_finished')
+
+    jobs = JobQueue()
+
+    @pyglet.clock.chain
+    def wait_for_export():
+        job_id, status = yield pyglet.clock.wait_for_event(
+            jobs,
+            'on_job_finished',
+            condition=lambda job_id, status: job_id == 'export',
+        )
+        print(job_id, 'finished:', status)
+
+Callback-based APIs that are not event dispatchers can be adapted into yield
+instructions with :py:func:`~pyglet.clock.yielding_callback`. The decorated
+function receives ``complete`` and ``fail`` callbacks and may return a cancellation
+callback. Call ``complete(value)`` when the external operation succeeds; that
+``value`` becomes the result of ``yield`` in the waiting chain. Call
+``fail(error)`` with a :py:class:`BaseException` instance when the external
+operation fails; the error is thrown into the waiting chain, and is reported to
+the chain's error callbacks if it is not caught. If the starter function raises
+an exception before returning, that exception is handled like ``fail(error)``.
+For most asynchronous APIs, the starter function only registers callbacks and
+returns; ``complete`` or ``fail`` is called later by the external operation::
+
+    class NetworkRequest:
+        def send(self, on_success, on_error):
+            ...
+
+        def cancel(self):
+            ...
+
+    @pyglet.clock.yielding_callback
+    def wait_for_network_reply(
+        complete: pyglet.clock.CompleteCallback,
+        fail: pyglet.clock.ErrorCallback,
+        request: NetworkRequest,
+    ) -> pyglet.clock.CancelCallback | None:
+        request.send(
+            on_success=complete,
+            on_error=fail,
+        )
+        return request.cancel
+
+    @pyglet.clock.chain
+    def fetch_profile(request):
+        try:
+            reply = yield wait_for_network_reply(request)
+        except OSError as error:
+            print('request failed:', error)
+            return None
+
+        return reply.json()
+
+    active_request = fetch_profile(NetworkRequest()).start()
+
+If ``fetch_profile`` is stopped before the network request finishes, the cancel
+callback returned by ``wait_for_network_reply`` is called. If the external API
+calls ``fail(error)``, the ``yield`` raises that error inside ``fetch_profile``.
+Errors that are not caught inside the chain are passed to callbacks registered
+with :py:meth:`~pyglet.clock.Chain.add_callbacks`::
+
+    fetch_profile(NetworkRequest()).add_callbacks(on_error=print).start()
+
+
+Chain groups
+------------
+
+:py:class:`~pyglet.clock.ChainGroup` tracks related chains so they can be
+paused, resumed, or stopped together. A group is not a scheduler; the
+:py:class:`~pyglet.clock.Clock` still owns time. The group owns lifecycle.
+Adding a chain to a group does not change the clock the chain was created with.
+
+This is useful when an entity starts several independent chains and all of them
+must stop when that entity is destroyed::
+
+    class Enemy:
+        def __init__(self, game_clock):
+            self.chains = pyglet.clock.ChainGroup(clock=game_clock)
+
+        def destroy(self):
+            self.chains.clear()
+            self.delete_sprites()
+
+        def flash(self):
+            self.chains.start(flash_sprite(self.sprite), tag='flash')
+
+Groups can be nested. For example, a scene can own a world group, and the world
+group can own entity groups. Clearing the scene group stops every descendant
+chain::
+
+    scene_chains = pyglet.clock.ChainGroup(clock=game_clock)
+    world_chains = scene_chains.create_group()
+
+    enemy = Enemy(game_clock)
+    world_chains.add_group(enemy.chains)
+
+    # Changing scenes:
+    scene_chains.clear()
+
+Tags let a group stop one category of work without touching the rest. This is
+useful for mutually exclusive flows such as fading in while a fade-out is still
+running::
+
+    class Actor:
+        def __init__(self, game_clock):
+            self.chains = pyglet.clock.ChainGroup(clock=game_clock)
+            self.sprites = []
+
+        def fade_in(self):
+            self.chains.clear(tag='fade')
+            self.chains.start(fade_sprites(self.sprites, target_alpha=255), tag='fade')
+
+        def fade_out_then_destroy(self):
+            self.chains.clear(tag='fade')
+            chain = self.chains.start(
+                fade_sprites(self.sprites, target_alpha=0),
+                tag='fade',
+            )
+            chain.add_callbacks(on_complete=lambda _result: self.destroy())
+
+        def destroy(self):
+            self.chains.clear()
+

--- a/doc/programming_guide/events.rst
+++ b/doc/programming_guide/events.rst
@@ -208,7 +208,7 @@ The steps for creating an event dispatcher are:
 1. Subclass :py:class:`~pyglet.event.EventDispatcher`
 2. Call the :py:meth:`~pyglet.event.EventDispatcher.register_event_type`
    class method on your subclass for each event your subclass will recognise.
-3. Call :py:meth:`~pyglet.event.EventDispatcher. dispatch_event` to create and
+3. Call :py:meth:`~pyglet.event.EventDispatcher.dispatch_event` to create and
    dispatch an event as needed.
 
 In the following example, a hypothetical GUI widget provides several events::
@@ -300,3 +300,7 @@ The two clock objects will be notified whenever the timer is "ticked", though
 neither the timer nor the clocks needed prior knowledge of the other.  During
 object construction any relationships between subjects and observers can be
 created.
+
+
+Event chains provide a higher-level way to write timed and callback-driven
+event flows. See :doc:`event_chains` for details and examples.

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -367,17 +367,28 @@ ChainTag: TypeAlias = str
 _MISSING = object()
 
 
-class Chain(EventDispatcher):
+class Chain:
     """Run generator-based sequences on a pyglet clock.
 
     Chains yield delays, child chains, callback operations, or ``None``. They can
-    be stopped as a group, and they expose callbacks for completion, stop, and
-    error handling.
+    be stopped as a group and exposes callbacks.
     """
+    _callback_names = frozenset(('on_complete', 'on_stop', 'on_pause', 'on_resume', 'on_error'))
+    on_complete: Callable[[Any], Any] | None
+    on_stop: Callable[[], Any] | None
+    on_pause: Callable[[], Any] | None
+    on_resume: Callable[[], Any] | None
+    on_error: Callable[[BaseException], Any] | None
+
+    _callbacks: dict[str, list[Callable[..., Any]]]
+
     def __init__(self, generator: ChainGenerator[Any], clock: Clock | None = None) -> None:
         """Initialize the chain with a generator."""
         self._generator = generator
         self._clock: Clock = clock or _default
+        self._callbacks = {
+            name: [] for name in self._callback_names
+        }
         self._running = False
         self._paused = False
         self._finished = False
@@ -610,7 +621,7 @@ class Chain(EventDispatcher):
             cancel()
 
         self._generator.close()
-        self.dispatch_event('on_stop')
+        self._dispatch_callbacks('on_stop')
 
     def pause(self) -> Chain:
         """Pauses the chain, with the intention to either resume or stop in the future.
@@ -630,7 +641,7 @@ class Chain(EventDispatcher):
         elif self._operation is not None and hasattr(self._operation, 'pause'):
             self._operation.pause()
 
-        self.dispatch_event('on_pause')
+        self._dispatch_callbacks('on_pause')
 
         return self
 
@@ -655,7 +666,7 @@ class Chain(EventDispatcher):
         elif self._scheduled_callback is not None:
             self._clock.schedule(self._scheduled_callback)
 
-        self.dispatch_event('on_resume')
+        self._dispatch_callbacks('on_resume')
 
         return self
 
@@ -664,33 +675,44 @@ class Chain(EventDispatcher):
         self._paused = False
         self._finished = True
         self.result = result
-        self.dispatch_event('on_complete', result)
+        self._dispatch_callbacks('on_complete', result)
 
     def _fail(self, error: BaseException) -> None:
         self._running = False
         self._paused = False
         self._finished = True
         self.exception = error
-        if self.dispatch_event('on_error', error) is False:
+        if not self._dispatch_callbacks('on_error', error):
             traceback.print_exception(error)
 
     def add_callbacks(self, **callbacks: Callable[..., Any]) -> Chain:
-        """Register lifecycle event handlers and return this chain.
-
-        Mostly an alias for ``push_handlers''.
+        """Register strongly referenced callbacks and return this chain.
 
         Accepted names are ``on_complete``, ``on_stop``, ``on_pause``,
         ``on_resume``, and ``on_error``.
         """
-        self.push_handlers(**callbacks)
+        for name, callback in callbacks.items():
+            if name not in self._callback_names:
+                msg = f"Unknown chain callback {name!r}"
+                raise ValueError(msg)
+            if not callable(callback):
+                msg = f"Chain callback {name!r} must be callable"
+                raise TypeError(msg)
+            self._callbacks[name].append(callback)
+
         return self
 
+    def _dispatch_callbacks(self, name: str, *args: Any) -> bool:
+        """Invoke registered callbacks and an optional directly assigned callback.
 
-Chain.register_event_type('on_complete')
-Chain.register_event_type('on_stop')
-Chain.register_event_type('on_pause')
-Chain.register_event_type('on_resume')
-Chain.register_event_type('on_error')
+        Returns:
+            True if callback was called.
+        """
+        invoked = False
+        for callback in tuple(self._callbacks[name]):
+            invoked = True
+            callback(*args)
+        return invoked
 
 
 class ChainGroup:

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -84,6 +84,35 @@ T = TypeVar('T')
 CancelCallback: TypeAlias = Callable[[], None]
 CompleteCallback: TypeAlias = Callable[[Any], None]
 ErrorCallback: TypeAlias = Callable[[BaseException], None]
+EasingFunction: TypeAlias = Callable[[float], float]
+TweenUpdateFunction: TypeAlias = Callable[[float], Any]
+
+
+def linear(progress: float) -> float:
+    """Return unchanged progress for constant-speed interpolation."""
+    return progress
+
+
+def ease_in(progress: float) -> float:
+    """Accelerate from rest using quadratic easing."""
+    return progress * progress
+
+
+def ease_out(progress: float) -> float:
+    """Decelerate to rest using quadratic easing."""
+    return 1.0 - (1.0 - progress) ** 2
+
+
+def ease_in_out(progress: float) -> float:
+    """Accelerate and then decelerate using quadratic easing."""
+    if progress < 0.5:
+        return 2.0 * progress * progress
+    return 1.0 - ((-2.0 * progress + 2.0) ** 2) / 2.0
+
+
+def smoothstep(progress: float) -> float:
+    """Interpolate with zero first derivatives at both endpoints."""
+    return progress * progress * (3.0 - 2.0 * progress)
 
 
 class _StoppedResult:
@@ -307,6 +336,159 @@ class _RaceOperation(_ChainOperation):
             return None
 
         return self.stop
+
+
+class _TweenManager:
+    """Update every tween on one clock from a single scheduled callback.
+
+    This is mostly for improved performance, since unscheduling rebuilds
+    the scheduler list.
+    """
+
+    def __init__(self, clock: Clock) -> None:
+        self._clock = clock
+        self._operations: dict[_TweenOperation, None] = {}
+
+    def add(self, operation: _TweenOperation) -> None:
+        if not self._operations:
+            self._clock.schedule(self._tick)
+        self._operations[operation] = None
+
+    def remove(self, operation: _TweenOperation) -> None:
+        self._operations.pop(operation, None)
+        if not self._operations:
+            self._clock.unschedule(self._tick)
+
+    def _tick(self, _dt: float) -> None:
+        now = self._clock.time()
+        for operation in tuple(self._operations):
+            operation._tick(now)  # noqa: SLF001
+
+
+class _TweenOperation:
+    """Drive an update callback with eased progress over a duration."""
+
+    def __init__(
+        self,
+        duration: float,
+        update: TweenUpdateFunction,
+        *,
+        easing: EasingFunction = linear,
+        clock: Clock | None = None,
+    ) -> None:
+        """Initialize a tween with its duration, update, easing, and clock."""
+        if duration < 0:
+            raise ValueError("Tween duration cannot be negative.")
+        if not callable(update):
+            raise TypeError("Tween update must be callable.")
+        if not callable(easing):
+            raise TypeError("Tween easing must be callable.")
+
+        self.duration = float(duration)
+        self.update = update
+        self.easing = easing
+        self._clock: Clock = clock or _default
+        self._manager = self._clock._get_tween_manager()  # noqa: SLF001
+        self._elapsed = 0.0
+        self._last_time: float | None = None
+        self._running = False
+        self._paused = False
+        self._finished = False
+        self._complete: CompleteCallback | None = None
+        self._fail: ErrorCallback | None = None
+
+    def start(
+        self,
+        complete: CompleteCallback,
+        fail: ErrorCallback,
+    ) -> CancelCallback | None:
+        """Start updating and return a callback that cancels the tween."""
+        if self._running or self._finished:
+            raise RuntimeError("A tween operation can only be started once.")
+
+        self._running = True
+        self._complete = complete
+        self._fail = fail
+
+        if self.duration == 0.0:
+            if self._apply(1.0):
+                self._finish()
+            return None
+
+        if not self._apply(0.0):
+            return None
+
+        self._last_time = self._clock.time()
+        self._manager.add(self)
+        return self.stop
+
+    def _tick(self, now: float) -> None:
+        if not self._running or self._paused or self._last_time is None:
+            return
+
+        self._elapsed += max(now - self._last_time, 0.0)
+        self._last_time = now
+        progress = min(self._elapsed / self.duration, 1.0)
+        if not self._apply(progress):
+            return
+        if progress >= 1.0:
+            self._finish()
+
+    def _apply(self, progress: float) -> bool:
+        try:
+            self.update(self.easing(progress))
+        except Exception as exc:  # noqa: BLE001
+            self._finish(exc)
+            return False
+        return True
+
+    def _finish(self, error: BaseException | None = None) -> None:
+        self._manager.remove(self)
+        self._running = False
+        self._paused = False
+        self._finished = True
+        self._last_time = None
+
+        complete, fail = self._complete, self._fail
+        self._complete = None
+        self._fail = None
+        if error is None:
+            if complete is not None:
+                complete(None)
+        elif fail is not None:
+            fail(error)
+
+    def stop(self) -> None:
+        """Cancel the tween without completing its waiting chain."""
+        if not self._running:
+            return
+
+        self._manager.remove(self)
+        self._running = False
+        self._paused = False
+        self._finished = True
+        self._last_time = None
+        self._complete = None
+        self._fail = None
+
+    def pause(self) -> None:
+        """Pause the tween without consuming clock time."""
+        if not self._running or self._paused:
+            return
+
+        self._paused = True
+        self._last_time = None
+        self._manager.remove(self)
+
+    def resume(self) -> None:
+        """Resume a paused tween from its current progress."""
+        if not self._running or not self._paused:
+            return
+
+        self._paused = False
+        self._last_time = self._clock.time()
+        self._manager.add(self)
+
 
 def from_callback(
     starter: Callable[
@@ -918,6 +1100,23 @@ def chain(
     return wrapper
 
 
+def tween(
+    duration: float,
+    update: TweenUpdateFunction,
+    *,
+    easing: EasingFunction = linear,
+    clock: Clock | None = None,
+) -> Chain:
+    """Create a tween chain that updates eased progress over a duration."""
+    bound_clock = clock or _default
+    operation = _TweenOperation(duration, update, easing=easing, clock=bound_clock)
+
+    def _tween() -> ChainGenerator[None]:
+        yield operation
+
+    return Chain(_tween(), clock=bound_clock)
+
+
 def yielding_callback(
     function: Callable[..., CancelCallback | None],
 ) -> Callable[..., YieldInstruction]:
@@ -1061,6 +1260,7 @@ class Clock:
         self._schedule_items = []
         self._schedule_interval_items = []
         self._current_interval_item = None
+        self._tween_manager: _TweenManager | None = None
 
     def chain(self, function: Callable[..., ChainGenerator[T]]) -> Callable[..., Chain]:
         """Decorate a generator function so returned chains use this clock."""
@@ -1089,6 +1289,21 @@ class Clock:
     def repeat_duration(self, factory: Callable[[], Chain], duration: float) -> Chain:
         """Create a duration-limited repeat chain on this clock."""
         return repeat_duration(factory, duration, clock=self)
+
+    def tween(
+        self,
+        duration: float,
+        update: TweenUpdateFunction,
+        *,
+        easing: EasingFunction = linear,
+    ) -> Chain:
+        """Create a tween chain driven by this clock."""
+        return tween(duration, update, easing=easing, clock=self)
+
+    def _get_tween_manager(self) -> _TweenManager:
+        if self._tween_manager is None:
+            self._tween_manager = _TweenManager(self)
+        return self._tween_manager
 
     def create_group(self) -> ChainGroup:
         """Create a chain group bound to this clock."""

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -126,6 +126,10 @@ STOPPED = _StoppedResult()
 """Used when something continues after a stop."""
 
 
+class ChainStopped(Exception):  # noqa: N818
+    """Raised in a waiting chain when one of its child chains stops."""
+
+
 class YieldingOperation(Protocol):
     """A yield instruction that can wake a suspended chain."""
 
@@ -261,7 +265,7 @@ class _ParallelOperation(_ChainOperation):
             if self._continue_on_stop:
                 finish_child(idx, STOPPED)
             else:
-                fail_child(RuntimeError("A parallel child chain stopped."))
+                fail_child(ChainStopped("A parallel child chain stopped."))
 
         for child_index, child in enumerate(self._chains):
             child.add_callbacks(
@@ -271,8 +275,13 @@ class _ParallelOperation(_ChainOperation):
             )
 
         try:
-            for child in self._chains:
-                child.start()
+            for child_index, child in enumerate(self._chains):
+                if child.stopped:
+                    stop_child(child_index)
+                else:
+                    child.start()
+                if not self._running:
+                    break
         except Exception as exc:  # noqa: BLE001
             fail_child(exc)
 
@@ -317,7 +326,7 @@ class _RaceOperation(_ChainOperation):
 
         def stop_child() -> None:
             if self._running:
-                fail_child(RuntimeError("A race child chain stopped"))
+                fail_child(ChainStopped("A race child chain stopped."))
 
         for child_idx, child in enumerate(self._chains):
             child.add_callbacks(
@@ -328,7 +337,12 @@ class _RaceOperation(_ChainOperation):
 
         try:
             for child in self._chains:
-                child.start()
+                if child.stopped:
+                    stop_child()
+                else:
+                    child.start()
+                if not self._running:
+                    break
         except Exception as exc:  # noqa: BLE001
             fail_child(exc)
 
@@ -656,6 +670,9 @@ class Chain:
         except StopIteration as completed:
             self._finish(completed.value)
             return
+        except ChainStopped:
+            self.stop()
+            return
         except Exception as exc:  # noqa: BLE001
             self._fail(exc)
             return
@@ -685,13 +702,21 @@ class Chain:
         self._child = child
         token = self._new_wait_token()
 
-        # A child is a dependency and its result resumes this chain,
-        # its error is thrown here, and stopping it also stops its waiting parent.
+        # Child results and errors resume this chain. A stopped child throws a
+        # catchable ChainStopped signal into the generator; if it remains
+        # unhandled, _advance stops this waiting parent.
         child.add_callbacks(
             on_complete=lambda result: self._resume_if_current(token, value=result),
             on_error=lambda error: self._resume_if_current(token, error=error),
-            on_stop=lambda: self.stop() if self._wait_token is token else None,
+            on_stop=lambda: self._resume_if_current(
+                token,
+                error=ChainStopped("A child chain stopped."),
+            ),
         )
+
+        if child.stopped:
+            self._resume_if_current(token, error=ChainStopped("A child chain stopped."))
+            return
 
         try:
             child.start()
@@ -1177,21 +1202,24 @@ def repeat_until(
     return chain(_repeat_until, clock=clock)()
 
 
-def repeat_duration(factory: Callable[[], Chain], duration: float, *, clock: Clock | None = None) -> Chain:
-    """Create a chain that repeats child chains until ``duration`` elapses.
-
-    If duration is 0, it repeats until stopped.
-    """
-    if duration < 0:
-        raise ValueError("Repeat duration cannot be negative.")
+def repeat_forever(factory: Callable[[], Chain], *, clock: Clock | None = None) -> Chain:
+    """Create a chain that repeats child chains until stopped."""
 
     def _repeat_forever() -> ChainGenerator[None]:
         while True:
             yield factory()
 
+    return chain(_repeat_forever, clock=clock)()
+
+
+def repeat_duration(factory: Callable[[], Chain], duration: float, *, clock: Clock | None = None) -> Chain:
+    """Create a chain that repeats child chains until ``duration`` elapses."""
+    if duration < 0:
+        raise ValueError("Repeat duration cannot be negative.")
+
     def _repeat_duration() -> ChainGenerator[Any]:
         winner_index, result = yield race(
-            chain(_repeat_forever, clock=clock)(),
+            repeat_forever(factory, clock=clock),
             timeout(duration, clock=clock),
         )
         return result if winner_index == 0 else None
@@ -1285,6 +1313,10 @@ class Clock:
     def repeat_until(self, factory: Callable[[], Chain], condition: Callable[[], bool]) -> Chain:
         """Create a repeat-until chain on this clock."""
         return repeat_until(factory, condition, clock=self)
+
+    def repeat_forever(self, factory: Callable[[], Chain]) -> Chain:
+        """Create an indefinite repeat chain on this clock."""
+        return repeat_forever(factory, clock=self)
 
     def repeat_duration(self, factory: Callable[[], Chain], duration: float) -> Chain:
         """Create a duration-limited repeat chain on this clock."""

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -398,6 +398,7 @@ class Chain:
         self._cancel_operation: CancelCallback | None = None
         self._scheduled_callback: Callable[[float], None] | None = None
         self._scheduled_remaining: float | None = None
+        self._scheduled_started_at: float | None = None
         self._pending_advance: tuple[Any, BaseException | None] | None = None
 
         # Stale guard prevents old callbacks from resuming.
@@ -453,6 +454,7 @@ class Chain:
 
         self._scheduled_callback = None
         self._scheduled_remaining = None
+        self._scheduled_started_at = None
         self._wait_token = None
 
         if self._paused:
@@ -574,25 +576,21 @@ class Chain:
             if not self._running:
                 return
 
-            remaining = self._scheduled_remaining
-            if remaining is not None:
-                # Count down using this clock's ticks rather than sampling a
-                # wall-clock timestamp or schedule_interval. Keeps custom clocks and pauses
-                # accurate, and leaves the unscheduled remainder intact.
-                # Not sure if there is a better way?
-                remaining -= dt
-                self._scheduled_remaining = remaining
-                if remaining > 1e-12:
-                    return
-
-            self._clock.unschedule(callback)
+            # Zero-delay advances use ``schedule`` to preserve next-tick
+            # behavior, so they must remove themselves. Positive delays are
+            # one-shot items and have already been removed by the scheduler.
+            if self._scheduled_started_at is None:
+                self._clock.unschedule(callback)
             self._advance(dt, value, error)
 
         self._scheduled_callback = callback
-        # Schedule on every tick so pause can unschedule this exact callback
-        # and resume can continue with the accumulated remaining duration.
         self._scheduled_remaining = delay
-        self._clock.schedule(callback)
+        if delay > 0.0:
+            self._scheduled_started_at = self._clock.time()
+            self._clock.schedule_once(callback, delay)
+        else:
+            self._scheduled_started_at = None
+            self._clock.schedule(callback)
 
     def stop(self) -> None:
         """Stops the chain from running."""
@@ -610,6 +608,7 @@ class Chain:
             self._clock.unschedule(self._scheduled_callback)
             self._scheduled_callback = None
             self._scheduled_remaining = None
+            self._scheduled_started_at = None
 
         if self._child is not None:
             child, self._child = self._child, None
@@ -634,7 +633,12 @@ class Chain:
         self._paused = True
 
         if self._scheduled_callback is not None:
+            # Calculate remaining for when unpausing.
+            if self._scheduled_started_at is not None and self._scheduled_remaining is not None:
+                elapsed = max(self._clock.time() - self._scheduled_started_at, 0.0)
+                self._scheduled_remaining = max(self._scheduled_remaining - elapsed, 0.0)
             self._clock.unschedule(self._scheduled_callback)
+            self._scheduled_started_at = None
 
         if self._child is not None:
             self._child.pause()
@@ -664,7 +668,12 @@ class Chain:
             self._pending_advance = None
             self._schedule_advance(0.0, value=value, error=error)
         elif self._scheduled_callback is not None:
-            self._clock.schedule(self._scheduled_callback)
+            remaining = self._scheduled_remaining or 0.0
+            if remaining > 0.0:
+                self._scheduled_started_at = self._clock.time()
+                self._clock.schedule_once(self._scheduled_callback, remaining)
+            else:
+                self._clock.schedule(self._scheduled_callback)
 
         self._dispatch_callbacks('on_resume')
 

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -1006,8 +1006,11 @@ class ChainGroup:
         tag: ChainTag | None = None,
         tags: Iterable[ChainTag] = (),
     ) -> Chain:
-        """Track and start a chain."""
+        """Track and start a chain, or return it unchanged if already done."""
         self.add(chain, tag=tag, tags=tags)
+        if chain.done:
+            return chain
+
         chain.start()
         if self._paused and chain.running:
             chain.pause()

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -65,8 +65,12 @@ of the system clock.
 from __future__ import annotations
 
 import time as _time
+import inspect
+import traceback
 
-from typing import Any, Callable
+from collections.abc import Generator, Iterable
+from functools import wraps
+from typing import Any, Callable, Protocol, TypeAlias, TypeVar, cast
 
 from heapq import heappop as _heappop
 from heapq import heappush as _heappush
@@ -74,9 +78,899 @@ from heapq import heappushpop as _heappushpop
 from operator import attrgetter as _attrgetter
 from collections import deque as _deque
 
+from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED, EventDispatcher
+
+T = TypeVar('T')
+CancelCallback: TypeAlias = Callable[[], None]
+CompleteCallback: TypeAlias = Callable[[Any], None]
+ErrorCallback: TypeAlias = Callable[[BaseException], None]
+
+
+class _StoppedResult:
+    """Sentinel returned by composition helpers for a stopped child chain."""
+
+    def __repr__(self) -> str:
+        return 'STOPPED'
+
+
+STOPPED = _StoppedResult()
+"""Used when something continues after a stop."""
+
+
+class YieldingOperation(Protocol):
+    """A yield instruction that can wake a suspended chain."""
+
+    def start(
+        self,
+        complete: CompleteCallback,
+        fail: ErrorCallback,
+    ) -> CancelCallback | None:
+        ...
+
+
+class YieldInstruction:
+    """Adapt a callback-driven API into a yield instruction."""
+
+    def __init__(
+        self,
+        starter: Callable[
+            [CompleteCallback, ErrorCallback],
+            CancelCallback | None,
+        ],
+    ) -> None:
+        """Initialize the operation with a callback starter."""
+        self._starter = starter
+
+    def start(
+        self,
+        complete: CompleteCallback,
+        fail: ErrorCallback,
+    ) -> CancelCallback | None:
+        return self._starter(complete, fail)
+
+
+class _ChainOperation:
+    """Shared lifecycle behavior for operations composed of child chains."""
+    _finished: bool
+    _running: bool
+    _clock: Clock
+    _chains: tuple[Chain, ...]
+
+    def __init__(
+        self,
+        chains: tuple[Chain, ...],
+        *,
+        clock: Clock | None = None,
+    ) -> None:
+        self._chains = chains
+        self._clock: Clock = clock or _default
+        self._running = False
+        self._finished = False
+
+    def stop(self) -> None:
+        if not self._running:
+            return
+
+        self._running = False
+        for child in self._chains:
+            if not child.done:
+                child.stop()
+
+    def pause(self) -> None:
+        if not self._running:
+            return
+
+        for child in self._chains:
+            child.pause()
+
+    def resume(self) -> None:
+        if not self._running:
+            return
+
+        for child in self._chains:
+            child.resume()
+
+
+class _ParallelOperation(_ChainOperation):
+    """Run several chains concurrently and complete when all are done."""
+    _continue_on_stop: bool
+
+    def __init__(
+        self,
+        chains: tuple[Chain, ...],
+        *,
+        continue_on_stop: bool = False,
+        clock: Clock | None = None,
+    ) -> None:
+        """Initialize the operation with child chains."""
+        super().__init__(chains, clock=clock)
+        self._continue_on_stop = continue_on_stop
+
+    def start(
+        self,
+        complete: CompleteCallback,
+        fail: ErrorCallback,
+    ) -> CancelCallback | None:
+        self._running = True
+        if not self._chains:
+            complete(())
+            self._finished = True
+            self._running = False
+            return None
+
+        remaining = len(self._chains)
+        results: list[Any] = [None] * remaining
+
+        def finish_child(idx: int, result: Any) -> None:
+            nonlocal remaining
+            if not self._running:
+                return
+
+            results[idx] = result
+            remaining -= 1
+            if remaining:
+                return
+
+            self._finished = True
+            self._running = False
+            complete(tuple(results))
+
+        def fail_child(error: BaseException) -> None:
+            if not self._running:
+                return
+
+            # A parallel operation has one failure outcome.  Stop unfinished
+            # siblings before reporting it so they cannot keep changing state.
+            self.stop()
+            self._finished = True
+            fail(error)
+
+        def stop_child(idx: int) -> None:
+            if not self._running:
+                return
+
+            if self._continue_on_stop:
+                finish_child(idx, STOPPED)
+            else:
+                fail_child(RuntimeError("A parallel child chain stopped."))
+
+        for child_index, child in enumerate(self._chains):
+            child.add_callbacks(
+                on_complete=lambda result, current_index=child_index: finish_child(current_index, result),
+                on_error=fail_child,
+                on_stop=lambda current_index=child_index: stop_child(current_index),
+            )
+
+        try:
+            for child in self._chains:
+                child.start()
+        except Exception as exc:  # noqa: BLE001
+            fail_child(exc)
+
+        if self._finished:
+            return None
+
+        return self.stop
+
+class _RaceOperation(_ChainOperation):
+    """Run several chains concurrently and complete with the first result."""
+    def __init__(self, chains: tuple[Chain, ...], *, clock: Clock | None = None) -> None:
+        """Initialize the operation with child chains."""
+        if not chains:
+            raise ValueError("race requires at least one child chain")
+        super().__init__(chains, clock=clock)
+
+    def start(
+        self,
+        complete: CompleteCallback,
+        fail: ErrorCallback,
+    ) -> CancelCallback | None:
+        self._running = True
+        def finish_child(idx: int, result: Any) -> None:
+            if not self._running:
+                return
+
+            self._finished = True
+            self._running = False
+            # A race consumes the first completion, then cancels all others.
+            for child_chain in self._chains:
+                if not child_chain.done:
+                    child_chain.stop()
+            complete((idx, result))
+
+        def fail_child(error: BaseException) -> None:
+            if not self._running:
+                return
+
+            self.stop()
+            self._finished = True
+            fail(error)
+
+        def stop_child() -> None:
+            if self._running:
+                fail_child(RuntimeError("A race child chain stopped"))
+
+        for child_idx, child in enumerate(self._chains):
+            child.add_callbacks(
+                on_complete=lambda result, current_idx=child_idx: finish_child(current_idx, result),
+                on_error=fail_child,
+                on_stop=stop_child,
+            )
+
+        try:
+            for child in self._chains:
+                child.start()
+        except Exception as exc:  # noqa: BLE001
+            fail_child(exc)
+
+        if self._finished:
+            return None
+
+        return self.stop
+
+def from_callback(
+    starter: Callable[
+        [CompleteCallback, ErrorCallback],
+        CancelCallback | None,
+    ],
+) -> YieldInstruction:
+    """Create a yield instruction from a callback-based function."""
+    return YieldInstruction(starter)
+
+
+def wait_for_event(
+    dispatcher: EventDispatcher,
+    event_type: str,
+    *,
+    condition: Callable[..., bool] | None = None,
+    consume: bool = False,
+) -> YieldInstruction:
+    """Create a yield instruction that completes on a dispatcher event.
+
+    The temporary handler is removed when the event matches or when the
+    waiting chain is stopped.
+    """
+    def starter(complete: CompleteCallback, _fail: ErrorCallback) -> CancelCallback:
+        def handler(*args: Any) -> bool | None:
+            if condition is not None and not condition(*args):
+                return EVENT_UNHANDLED
+
+            dispatcher.remove_handlers(**{event_type: handler})
+            if not args:
+                complete(None)
+            elif len(args) == 1:
+                complete(args[0])
+            else:
+                complete(args)
+
+            return EVENT_HANDLED if consume else EVENT_UNHANDLED
+
+        dispatcher.push_handlers(**{event_type: handler})
+        return lambda: dispatcher.remove_handlers(**{event_type: handler})
+
+    return from_callback(starter)
+
+
+def parallel(*chains: Chain, continue_on_stop: bool = False) -> _ParallelOperation:
+    """Run child chains concurrently and resume with their ordered results."""
+    return _ParallelOperation(chains, continue_on_stop=continue_on_stop)
+
+
+def race(*chains: Chain) -> _RaceOperation:
+    """Run child chains concurrently and resume with the first result."""
+    return _RaceOperation(chains)
+
+
+YieldValue: TypeAlias = 'float | int | Chain | YieldingOperation | None'
+ChainGenerator: TypeAlias = Generator[YieldValue, Any, T]
+ChainTag: TypeAlias = str
+_MISSING = object()
+
+
+class Chain(EventDispatcher):
+    """Run generator-based sequences on a pyglet clock.
+
+    Chains yield delays, child chains, callback operations, or ``None``. They can
+    be stopped as a group, and they expose callbacks for completion, stop, and
+    error handling.
+    """
+    def __init__(self, generator: ChainGenerator[Any], clock: Clock | None = None) -> None:
+        """Initialize the chain with a generator."""
+        self._generator = generator
+        self._clock: Clock = clock or _default
+        self._running = False
+        self._paused = False
+        self._finished = False
+        self._stopped = False
+        self._child: Chain | None = None
+        self._operation: YieldingOperation | None = None
+        self._cancel_operation: CancelCallback | None = None
+        self._scheduled_callback: Callable[[float], None] | None = None
+        self._scheduled_remaining: float | None = None
+        self._pending_advance: tuple[Any, BaseException | None] | None = None
+
+        # Stale guard prevents old callbacks from resuming.
+        self._wait_token: object | None = None
+
+        self.result: Any = None
+        self.exception: BaseException | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._running and not self._paused
+
+    @property
+    def paused(self) -> bool:
+        return self._paused
+
+    @property
+    def done(self) -> bool:
+        return self._finished
+
+    @property
+    def completed(self) -> bool:
+        return self._finished and not self._stopped and self.exception is None
+
+    @property
+    def stopped(self) -> bool:
+        return self._stopped
+
+    @property
+    def failed(self) -> bool:
+        return self.exception is not None
+
+    @property
+    def clock(self) -> Clock:
+        return self._clock
+
+    def start(self) -> Chain:
+        if self._finished:
+            raise RuntimeError("A completed or stopped chain cannot be restarted")
+        if not self._running:
+            self._running = True
+            self._advance(0.0)
+        return self
+
+    def _advance(
+        self,
+        _dt: float,
+        value: Any = _MISSING,
+        error: BaseException | None = None,
+    ) -> None:
+        if not self._running:
+            return
+
+        self._scheduled_callback = None
+        self._scheduled_remaining = None
+        self._wait_token = None
+
+        if self._paused:
+            self._pending_advance = (value, error)
+            return
+
+        try:
+            # Resume the generator using the outcome of its previous yield:
+            # a yielded child or operation sends a value, while its failure is
+            # thrown back into the generator for ordinary try/except handling.
+            if error is not None:
+                yielded = self._generator.throw(error)
+            elif value is _MISSING:
+                yielded = next(self._generator)
+            else:
+                yielded = self._generator.send(value)
+        except StopIteration as completed:
+            self._finish(completed.value)
+            return
+        except Exception as exc:  # noqa: BLE001
+            self._fail(exc)
+            return
+
+        if isinstance(yielded, Chain):
+            self._wait_for_child(yielded)
+        elif isinstance(yielded, (int, float)):
+            delay = float(yielded)
+            if delay < 0:
+                self._fail(ValueError("A chain cannot yield a negative delay"))
+            else:
+                self._schedule_advance(delay)
+        elif yielded is None:
+            self._schedule_advance(0.0)
+        elif hasattr(yielded, "start") and callable(yielded.start):
+            self._wait_for_operation(cast("YieldingOperation", yielded))
+        else:
+            self._fail(
+                TypeError(
+                    "A chain must yield a delay, another Chain, "
+                    "a callback operation, or None; "
+                    f"received {yielded}",
+                ),
+            )
+
+    def _wait_for_child(self, child: Chain) -> None:
+        self._child = child
+        token = self._new_wait_token()
+
+        # A child is a dependency and its result resumes this chain,
+        # its error is thrown here, and stopping it also stops its waiting parent.
+        child.add_callbacks(
+            on_complete=lambda result: self._resume_if_current(token, value=result),
+            on_error=lambda error: self._resume_if_current(token, error=error),
+            on_stop=lambda: self.stop() if self._wait_token is token else None,
+        )
+
+        try:
+            child.start()
+        except Exception as exc:  # noqa: BLE001
+            self._resume_if_current(token, error=exc)
+
+    def _wait_for_operation(self, operation: YieldingOperation) -> None:
+        token = self._new_wait_token()
+
+        def complete(result: Any = None) -> None:
+            self._resume_if_current(token, value=result)
+
+        def fail(error: BaseException) -> None:
+            self._resume_if_current(token, error=error)
+
+        try:
+            cancel = operation.start(complete, fail)
+            # A starter may call complete or fail before returning.  Only keep
+            # its cancellation callback if this is still the active wait.
+            if self._wait_token is token:
+                self._operation = operation
+                self._cancel_operation = cancel
+        except Exception as exc:  # noqa: BLE001
+            fail(exc)
+
+    def _new_wait_token(self) -> object:
+        # Callback-based operations can complete after cancellation.
+        # Gives each wait a distinct identity so a late callback cannot resume a chain
+        # that has already advanced, stopped, or started another wait.
+        token = object()
+        self._wait_token = token
+        return token
+
+    def _resume_if_current(
+        self,
+        token: object,
+        *,
+        value: Any = _MISSING,
+        error: BaseException | None = None,
+    ) -> None:
+        # This is the single gate used by child and callback-operation results.
+        if not self._running or self._wait_token is not token:
+            return
+        self._wait_token = None
+        self._cancel_operation = None
+        self._operation = None
+        self._child = None
+        if self._paused:
+            self._pending_advance = (value, error)
+            return
+        self._schedule_advance(0.0, value=value, error=error)
+
+    def _schedule_advance(
+        self,
+        delay: float,
+        *,
+        value: Any = _MISSING,
+        error: BaseException | None = None,
+    ) -> None:
+        if not self._running:
+            return
+
+        def callback(dt: float) -> None:
+            if not self._running:
+                return
+
+            remaining = self._scheduled_remaining
+            if remaining is not None:
+                # Count down using this clock's ticks rather than sampling a
+                # wall-clock timestamp or schedule_interval. Keeps custom clocks and pauses
+                # accurate, and leaves the unscheduled remainder intact.
+                # Not sure if there is a better way?
+                remaining -= dt
+                self._scheduled_remaining = remaining
+                if remaining > 1e-12:
+                    return
+
+            self._clock.unschedule(callback)
+            self._advance(dt, value, error)
+
+        self._scheduled_callback = callback
+        # Schedule on every tick so pause can unschedule this exact callback
+        # and resume can continue with the accumulated remaining duration.
+        self._scheduled_remaining = delay
+        self._clock.schedule(callback)
+
+    def stop(self) -> None:
+        """Stops the chain from running."""
+        if not self._running:
+            return
+
+        self._running = False
+        self._paused = False
+        self._finished = True
+        self._stopped = True
+        self._pending_advance = None
+        self._wait_token = None
+
+        if self._scheduled_callback is not None:
+            self._clock.unschedule(self._scheduled_callback)
+            self._scheduled_callback = None
+            self._scheduled_remaining = None
+
+        if self._child is not None:
+            child, self._child = self._child, None
+            child.stop()
+
+        if self._cancel_operation is not None:
+            cancel, self._cancel_operation = self._cancel_operation, None
+            self._operation = None
+            cancel()
+
+        self._generator.close()
+        self.dispatch_event('on_stop')
+
+    def pause(self) -> Chain:
+        """Pauses the chain, with the intention to either resume or stop in the future.
+
+        Cannot resume if chain was stopped.
+        """
+        if not self._running or self._paused or self._finished:
+            return self
+
+        self._paused = True
+
+        if self._scheduled_callback is not None:
+            self._clock.unschedule(self._scheduled_callback)
+
+        if self._child is not None:
+            self._child.pause()
+        elif self._operation is not None and hasattr(self._operation, 'pause'):
+            self._operation.pause()
+
+        self.dispatch_event('on_pause')
+
+        return self
+
+    def resume(self) -> Chain:
+        """Resumes the chain if it was paused.
+
+        Cannot resume if chain was stopped.
+        """
+        if not self._running or not self._paused or self._finished:
+            return self
+
+        self._paused = False
+
+        if self._child is not None:
+            self._child.resume()
+        elif self._operation is not None and hasattr(self._operation, 'resume'):
+            self._operation.resume()
+        elif self._pending_advance is not None:
+            value, error = self._pending_advance
+            self._pending_advance = None
+            self._schedule_advance(0.0, value=value, error=error)
+        elif self._scheduled_callback is not None:
+            self._clock.schedule(self._scheduled_callback)
+
+        self.dispatch_event('on_resume')
+
+        return self
+
+    def _finish(self, result: Any) -> None:
+        self._running = False
+        self._paused = False
+        self._finished = True
+        self.result = result
+        self.dispatch_event('on_complete', result)
+
+    def _fail(self, error: BaseException) -> None:
+        self._running = False
+        self._paused = False
+        self._finished = True
+        self.exception = error
+        if self.dispatch_event('on_error', error) is False:
+            traceback.print_exception(error)
+
+    def add_callbacks(self, **callbacks: Callable[..., Any]) -> Chain:
+        """Register lifecycle event handlers and return this chain.
+
+        Mostly an alias for ``push_handlers''.
+
+        Accepted names are ``on_complete``, ``on_stop``, ``on_pause``,
+        ``on_resume``, and ``on_error``.
+        """
+        self.push_handlers(**callbacks)
+        return self
+
+
+Chain.register_event_type('on_complete')
+Chain.register_event_type('on_stop')
+Chain.register_event_type('on_pause')
+Chain.register_event_type('on_resume')
+Chain.register_event_type('on_error')
+
+
+class ChainGroup:
+    """Track related chains and child groups for lifecycle control."""
+
+    def __init__(self, clock: Clock | None = None) -> None:
+        """Initialize the group with an optional clock for unbound chains."""
+        self._clock: Clock = clock or _default
+        self._chains: dict[Chain, frozenset[ChainTag]] = {}
+        self._groups: set[ChainGroup] = set()
+        self._paused = False
+
+    @property
+    def clock(self) -> Clock:
+        return self._clock
+
+    @property
+    def paused(self) -> bool:
+        return self._paused
+
+    @property
+    def chains(self) -> tuple[Chain, ...]:
+        return tuple(self._chains)
+
+    @property
+    def groups(self) -> tuple[ChainGroup, ...]:
+        return tuple(self._groups)
+
+    def add_group(self, group: ChainGroup) -> ChainGroup:
+        """Add an existing child group and return it."""
+        if group is self:
+            raise ValueError("A chain group cannot contain itself")
+
+        self._groups.add(group)
+        if self._paused:
+            group.pause()
+        return group
+
+    def create_group(self, clock: Clock | None = None) -> ChainGroup:
+        """Create, add, and return a child group."""
+        return self.add_group(ChainGroup(clock=clock or self._clock))
+
+    def add(
+        self,
+        chain: Chain,
+        *,
+        tag: ChainTag | None = None,
+        tags: Iterable[ChainTag] = (),
+    ) -> Chain:
+        """Track a chain without starting it."""
+        if chain.done:
+            return chain
+
+        chain_tags = self._normalize_tags(tag, tags)
+        self._chains[chain] = chain_tags
+
+        def remove_chain(_result: Any = None) -> None:
+            self._chains.pop(chain, None)
+
+        chain.add_callbacks(
+            on_complete=remove_chain,
+            on_stop=remove_chain,
+            on_error=remove_chain,
+        )
+
+        if self._paused and chain.running:
+            chain.pause()
+
+        return chain
+
+    def start(
+        self,
+        chain: Chain,
+        *,
+        tag: ChainTag | None = None,
+        tags: Iterable[ChainTag] = (),
+    ) -> Chain:
+        """Track and start a chain."""
+        self.add(chain, tag=tag, tags=tags)
+        chain.start()
+        if self._paused and chain.running:
+            chain.pause()
+        return chain
+
+    def clear(
+        self,
+        *,
+        tag: ChainTag | None = None,
+        tags: Iterable[ChainTag] = (),
+    ) -> ChainGroup:
+        """Stop and forget tracked chains, optionally filtered by tag."""
+        tag_filter = self._normalize_tags(tag, tags)
+
+        # Groups form a lifecycle tree.  Apply the same filter to children
+        # before removing this group's unfiltered child-group references.
+        for child_group in tuple(self._groups):
+            child_group.clear(tags=tag_filter)
+
+        for chain, chain_tags in tuple(self._chains.items()):
+            if tag_filter and chain_tags.isdisjoint(tag_filter):
+                continue
+
+            self._chains.pop(chain, None)
+            chain.stop()
+
+        if not tag_filter:
+            self._groups.clear()
+
+        return self
+
+    def stop(
+        self,
+        *,
+        tag: ChainTag | None = None,
+        tags: Iterable[ChainTag] = (),
+    ) -> ChainGroup:
+        """Alias for :py:meth:`clear`."""
+        return self.clear(tag=tag, tags=tags)
+
+    def pause(
+        self,
+        *,
+        tag: ChainTag | None = None,
+        tags: Iterable[ChainTag] = (),
+    ) -> ChainGroup:
+        """Pause tracked chains and child groups, optionally filtered by tag."""
+        tag_filter = self._normalize_tags(tag, tags)
+
+        if not tag_filter:
+            self._paused = True
+
+        for child_group in tuple(self._groups):
+            child_group.pause(tags=tag_filter)
+
+        for chain, chain_tags in tuple(self._chains.items()):
+            if tag_filter and chain_tags.isdisjoint(tag_filter):
+                continue
+            chain.pause()
+
+        return self
+
+    def resume(
+        self,
+        *,
+        tag: ChainTag | None = None,
+        tags: Iterable[ChainTag] = (),
+    ) -> ChainGroup:
+        """Resume tracked chains and child groups, optionally filtered by tag."""
+        tag_filter = self._normalize_tags(tag, tags)
+
+        if not tag_filter:
+            self._paused = False
+
+        for child_group in tuple(self._groups):
+            child_group.resume(tags=tag_filter)
+
+        for chain, chain_tags in tuple(self._chains.items()):
+            if tag_filter and chain_tags.isdisjoint(tag_filter):
+                continue
+            chain.resume()
+
+        return self
+
+    @staticmethod
+    def _normalize_tags(
+        tag: ChainTag | None,
+        tags: Iterable[ChainTag],
+    ) -> frozenset[ChainTag]:
+        normalized = set(tags)
+        if tag is not None:
+            normalized.add(tag)
+        return frozenset(normalized)
+
+def chain(
+    function: Callable[..., ChainGenerator[T]],
+    *,
+    clock: Clock | None = None,
+) -> Callable[..., Chain]:
+    """Decorate a generator function so it returns a ``Chain``."""
+
+    @wraps(function)
+    def wrapper(*args: Any, **kwargs: Any) -> Chain:
+        generator = function(*args, **kwargs)
+        if not inspect.isgenerator(generator):
+            msg = (
+                f"{function.__qualname__} must be a generator function "
+                "and contain at least one yield"
+            )
+            raise TypeError(
+                msg,
+            )
+        return Chain(generator, clock=clock)
+
+    return wrapper
+
+
+def yielding_callback(
+    function: Callable[..., CancelCallback | None],
+) -> Callable[..., YieldInstruction]:
+    """Decorate a callback starter so it can be yielded from a chain."""
+
+    @wraps(function)
+    def wrapper(*args: Any, **kwargs: Any) -> YieldInstruction:
+        def start(
+            complete: CompleteCallback,
+            fail: ErrorCallback,
+        ) -> CancelCallback | None:
+            return function(complete, fail, *args, **kwargs)
+
+        return YieldInstruction(start)
+
+    return wrapper
+
+
+def timeout(delay: float, *, clock: Clock | None = None) -> Chain:
+    """Create a chain that completes after ``delay`` seconds."""
+    if delay < 0:
+        raise ValueError("Timeout delay cannot be negative.")
+
+    def _timeout() -> ChainGenerator[None]:
+        yield delay
+
+    return chain(_timeout, clock=clock)()
+
+
+def repeat(factory: Callable[[], Chain], count: int, *, clock: Clock | None = None) -> Chain:
+    """Create a chain that runs a child-chain factory ``count`` times."""
+    if count < 0:
+        raise ValueError("Repeat count cannot be negative.")
+
+    def _repeat() -> ChainGenerator[tuple[Any, ...]]:
+        results = []
+        for _ in range(count):
+            results.append((yield factory()))  # noqa: PERF401
+        return tuple(results)
+
+    return chain(_repeat, clock=clock)()
+
+
+def repeat_until(
+    factory: Callable[[], Chain],
+    condition: Callable[[], bool],
+    *,
+    clock: Clock | None = None,
+) -> Chain:
+    """Create a chain that repeats child chains until ``condition`` is true."""
+
+    def _repeat_until() -> ChainGenerator[tuple[Any, ...]]:
+        results = []
+        while not condition():
+            results.append((yield factory()))
+        return tuple(results)
+
+    return chain(_repeat_until, clock=clock)()
+
+
+def repeat_duration(factory: Callable[[], Chain], duration: float, *, clock: Clock | None = None) -> Chain:
+    """Create a chain that repeats child chains until ``duration`` elapses.
+
+    If duration is 0, it repeats until stopped.
+    """
+    if duration < 0:
+        raise ValueError("Repeat duration cannot be negative.")
+
+    def _repeat_forever() -> ChainGenerator[None]:
+        while True:
+            yield factory()
+
+    def _repeat_duration() -> ChainGenerator[Any]:
+        winner_index, result = yield race(
+            chain(_repeat_forever, clock=clock)(),
+            timeout(duration, clock=clock),
+        )
+        return result if winner_index == 0 else None
+
+    return chain(_repeat_duration, clock=clock)()
+
 
 class _ScheduledItem:
-    __slots__ = ['func', 'args', 'kwargs']
+    __slots__ = ['args', 'func', 'kwargs']
 
     def __init__(self, func: Callable, args: Any, kwargs: Any) -> None:
         self.func = func
@@ -85,7 +979,7 @@ class _ScheduledItem:
 
 
 class _ScheduledIntervalItem:
-    __slots__ = ['func', 'interval', 'last_ts', 'next_ts', 'args', 'kwargs']
+    __slots__ = ['args', 'func', 'interval', 'kwargs', 'last_ts', 'next_ts']
 
     def __init__(self, func: Callable, interval: float, last_ts: float, next_ts: float, args: Any, kwargs: Any) -> None:
         self.func = func
@@ -100,6 +994,12 @@ class _ScheduledIntervalItem:
 
 
 class Clock:
+    """Schedule callbacks and chains against a single time source.
+
+    Each clock maintains its own scheduled callbacks, chain state, and
+    frequency measurements. Custom clocks can be ticked independently to
+    separate gameplay time, UI time, or other application timelines.
+    """
 
     # List of functions to call every tick.
     _schedule_items: list
@@ -111,7 +1011,7 @@ class Clock:
     _force_sleep: bool = False
 
     def __init__(self, time_function: Callable = _time.perf_counter) -> None:
-        """Initialise a Clock, with optional custom time function.
+        """Initialize a Clock, with optional custom time function.
 
         You can provide a custom time function to return the elapsed
         time of the application, in seconds. Defaults to ``time.perf_counter``,
@@ -130,6 +1030,38 @@ class Clock:
         self._schedule_items = []
         self._schedule_interval_items = []
         self._current_interval_item = None
+
+    def chain(self, function: Callable[..., ChainGenerator[T]]) -> Callable[..., Chain]:
+        """Decorate a generator function so returned chains use this clock."""
+        return chain(function, clock=self)
+
+    def timeout(self, delay: float) -> Chain:
+        """Create a chain on this clock that completes after ``delay`` seconds."""
+        return timeout(delay, clock=self)
+
+    def parallel(self, *chains: Chain, continue_on_stop: bool = False) -> _ParallelOperation:
+        """Run child chains on this clock and resume with their ordered results."""
+        return _ParallelOperation(chains, continue_on_stop=continue_on_stop, clock=self)
+
+    def race(self, *chains: Chain) -> _RaceOperation:
+        """Run child chains on this clock and resume with the first result."""
+        return _RaceOperation(chains, clock=self)
+
+    def repeat(self, factory: Callable[[], Chain], count: int) -> Chain:
+        """Create a repeat chain on this clock."""
+        return repeat(factory, count, clock=self)
+
+    def repeat_until(self, factory: Callable[[], Chain], condition: Callable[[], bool]) -> Chain:
+        """Create a repeat-until chain on this clock."""
+        return repeat_until(factory, condition, clock=self)
+
+    def repeat_duration(self, factory: Callable[[], Chain], duration: float) -> Chain:
+        """Create a duration-limited repeat chain on this clock."""
+        return repeat_duration(factory, duration, clock=self)
+
+    def create_group(self) -> ChainGroup:
+        """Create a chain group bound to this clock."""
+        return ChainGroup(clock=self)
 
     @staticmethod
     def sleep(microseconds: float) -> None:

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -68,6 +68,7 @@ import time as _time
 import inspect
 import traceback
 
+from bisect import bisect_left as _bisect_left
 from collections.abc import Generator, Iterable
 from functools import wraps
 from typing import Any, Callable, Protocol, TypeAlias, TypeVar, cast
@@ -75,7 +76,6 @@ from typing import Any, Callable, Protocol, TypeAlias, TypeVar, cast
 from heapq import heappop as _heappop
 from heapq import heappush as _heappush
 from heapq import heappushpop as _heappushpop
-from operator import attrgetter as _attrgetter
 from collections import deque as _deque
 
 from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED, EventDispatcher
@@ -1255,25 +1255,17 @@ class Clock:
         return last_ts
 
     def _get_soft_next_ts(self, last_ts: float, interval: float) -> float:
+        # ``taken`` is evaluated repeatedly below.  Prior to this, it sorted the
+        # scheduler heap in place, then scanned it for every query.
+        # Keep the heap untouched and use this sorted timestamp snapshot so
+        # each range check can use a binary search instead. Generally 30% faster.
+        timestamps = sorted(item.next_ts for item in self._schedule_interval_items)
 
         def taken(ts: float, e: float) -> bool:
             """Check if `ts` has already got an item scheduled nearby."""
-            # TODO this function is slow and called very often.
-            # Optimise it, maybe?
-            for item in self._schedule_interval_items:
-                if abs(item.next_ts - ts) <= e:
-                    return True
-                elif item.next_ts > ts + e:
-                    return False
-
-            return False
-
-        # sorted list is required to produce expected results
-        # taken() will iterate through the heap, expecting it to be sorted
-        # and will not always catch the smallest value, so sort here.
-        # do not remove the sort key...it is faster than relaying comparisons
-        # NOTE: do not rewrite as popping from heap, as that is super slow!
-        self._schedule_interval_items.sort(key=_attrgetter('next_ts'))
+            # The first timestamp >= ts - e is in range when it is <= ts + e.
+            index = _bisect_left(timestamps, ts - e)
+            return index < len(timestamps) and timestamps[index] <= ts + e
 
         # Binary division over interval:
         #

--- a/pyglet/clock.py
+++ b/pyglet/clock.py
@@ -68,7 +68,6 @@ import time as _time
 import inspect
 import traceback
 
-from bisect import bisect_left as _bisect_left
 from collections.abc import Generator, Iterable
 from functools import wraps
 from typing import Any, Callable, Protocol, TypeAlias, TypeVar, cast
@@ -76,6 +75,7 @@ from typing import Any, Callable, Protocol, TypeAlias, TypeVar, cast
 from heapq import heappop as _heappop
 from heapq import heappush as _heappush
 from heapq import heappushpop as _heappushpop
+from operator import attrgetter as _attrgetter
 from collections import deque as _deque
 
 from pyglet.event import EVENT_HANDLED, EVENT_UNHANDLED, EventDispatcher
@@ -1536,17 +1536,25 @@ class Clock:
         return last_ts
 
     def _get_soft_next_ts(self, last_ts: float, interval: float) -> float:
-        # ``taken`` is evaluated repeatedly below.  Prior to this, it sorted the
-        # scheduler heap in place, then scanned it for every query.
-        # Keep the heap untouched and use this sorted timestamp snapshot so
-        # each range check can use a binary search instead. Generally 30% faster.
-        timestamps = sorted(item.next_ts for item in self._schedule_interval_items)
 
         def taken(ts: float, e: float) -> bool:
             """Check if `ts` has already got an item scheduled nearby."""
-            # The first timestamp >= ts - e is in range when it is <= ts + e.
-            index = _bisect_left(timestamps, ts - e)
-            return index < len(timestamps) and timestamps[index] <= ts + e
+            # TODO this function is slow and called very often.
+            # Optimise it, maybe?
+            for item in self._schedule_interval_items:
+                if abs(item.next_ts - ts) <= e:
+                    return True
+                elif item.next_ts > ts + e:
+                    return False
+
+            return False
+
+        # sorted list is required to produce expected results
+        # taken() will iterate through the heap, expecting it to be sorted
+        # and will not always catch the smallest value, so sort here.
+        # do not remove the sort key...it is faster than relaying comparisons
+        # NOTE: do not rewrite as popping from heap, as that is super slow!
+        self._schedule_interval_items.sort(key=_attrgetter('next_ts'))
 
         # Binary division over interval:
         #

--- a/pyglet/event.py
+++ b/pyglet/event.py
@@ -121,13 +121,13 @@ from __future__ import annotations
 import inspect
 import os.path
 
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 from weakref import WeakMethod
 
 import pyglet
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Generator
+    from collections.abc import Callable, Generator
 
 
 EVENT_HANDLED = True
@@ -437,10 +437,10 @@ class EventDispatcher:
     def _dump_handlers(self) -> None:
 
         for level, handlers in enumerate(self._event_stack):
-            print(f"level: {level}")
+            print(f"level: {level}")  # noqa: T201
 
             for event_type, handler in handlers.items():
-                print(f" - '{event_type}': {handler}")
+                print(f" - '{event_type}': {handler}")  # noqa: T201
 
     # Decorator
 

--- a/pyglet/event.py
+++ b/pyglet/event.py
@@ -102,10 +102,10 @@ the particular class documentation.
 .. note::
 
     In order to prevent issues with garbage collection, the
-    :py:class:`~pyglet.event.EventDispatcher` class only holds weak
-    references to pushed event handlers. That means the following example
-    will not work, because the pushed object will fall out of scope and be
-    collected::
+    :py:class:`~pyglet.event.EventDispatcher` class holds weak references to
+    pushed bound methods when their instance supports weak references. That
+    means the following example will not work, because the pushed object will
+    fall out of scope and be collected::
 
         dispatcher.push_handlers(MyHandlerClass())
 
@@ -114,6 +114,9 @@ the particular class documentation.
 
         my_handler_instance = MyHandlerClass()
         dispatcher.push_handlers(my_handler_instance)
+
+    Bound methods whose instance cannot be weakly referenced, such as
+    ``list.append``, are retained strongly instead.
 
 """
 from __future__ import annotations
@@ -184,6 +187,16 @@ class EventDispatcher:
 
     def _get_handlers(self, args: list, kwargs: dict) -> Generator[tuple[str, Callable], None, None]:
         """Implement handler matching on arguments for set_handlers and remove_handlers."""
+        def weak_method_or_handler(handler: Callable) -> Callable:
+            try:
+                return WeakMethod(handler)
+            except TypeError:
+                # PyPy work around.
+                # It considers some built-in methods (list.append)
+                # to be bound methods even when their instance cannot be weakly
+                # referenced. Keep those handlers strongly instead.
+                return handler
+
         for obj in args:
             if inspect.isroutine(obj):
                 # Single magically named function
@@ -192,7 +205,7 @@ class EventDispatcher:
                     msg = f'Unknown event "{name}"'
                     raise EventException(msg)
                 if inspect.ismethod(obj):
-                    yield name, WeakMethod(obj)
+                    yield name, weak_method_or_handler(obj)
                 else:
                     yield name, obj
             else:
@@ -200,7 +213,7 @@ class EventDispatcher:
                 for name in dir(obj):
                     if name in self.event_types:
                         meth = getattr(obj, name)
-                        yield name, WeakMethod(meth)
+                        yield name, weak_method_or_handler(meth)
 
         for name, handler in kwargs.items():
             # Function for handling given event (no magic)
@@ -208,7 +221,7 @@ class EventDispatcher:
                 msg = f'Unknown event "{name}"'
                 raise EventException(msg)
             if inspect.ismethod(handler):
-                yield name, WeakMethod(handler)
+                yield name, weak_method_or_handler(handler)
             else:
                 yield name, handler
 

--- a/pyglet/event.py
+++ b/pyglet/event.py
@@ -102,10 +102,10 @@ the particular class documentation.
 .. note::
 
     In order to prevent issues with garbage collection, the
-    :py:class:`~pyglet.event.EventDispatcher` class holds weak references to
-    pushed bound methods when their instance supports weak references. That
-    means the following example will not work, because the pushed object will
-    fall out of scope and be collected::
+    :py:class:`~pyglet.event.EventDispatcher` class only holds weak
+    references to pushed event handlers. That means the following example
+    will not work, because the pushed object will fall out of scope and be
+    collected::
 
         dispatcher.push_handlers(MyHandlerClass())
 
@@ -114,9 +114,6 @@ the particular class documentation.
 
         my_handler_instance = MyHandlerClass()
         dispatcher.push_handlers(my_handler_instance)
-
-    Bound methods whose instance cannot be weakly referenced, such as
-    ``list.append``, are retained strongly instead.
 
 """
 from __future__ import annotations
@@ -187,16 +184,6 @@ class EventDispatcher:
 
     def _get_handlers(self, args: list, kwargs: dict) -> Generator[tuple[str, Callable], None, None]:
         """Implement handler matching on arguments for set_handlers and remove_handlers."""
-        def weak_method_or_handler(handler: Callable) -> Callable:
-            try:
-                return WeakMethod(handler)
-            except TypeError:
-                # PyPy work around.
-                # It considers some built-in methods (list.append)
-                # to be bound methods even when their instance cannot be weakly
-                # referenced. Keep those handlers strongly instead.
-                return handler
-
         for obj in args:
             if inspect.isroutine(obj):
                 # Single magically named function
@@ -205,7 +192,7 @@ class EventDispatcher:
                     msg = f'Unknown event "{name}"'
                     raise EventException(msg)
                 if inspect.ismethod(obj):
-                    yield name, weak_method_or_handler(obj)
+                    yield name, WeakMethod(obj)
                 else:
                     yield name, obj
             else:
@@ -213,7 +200,7 @@ class EventDispatcher:
                 for name in dir(obj):
                     if name in self.event_types:
                         meth = getattr(obj, name)
-                        yield name, weak_method_or_handler(meth)
+                        yield name, WeakMethod(meth)
 
         for name, handler in kwargs.items():
             # Function for handling given event (no magic)
@@ -221,7 +208,7 @@ class EventDispatcher:
                 msg = f'Unknown event "{name}"'
                 raise EventException(msg)
             if inspect.ismethod(handler):
-                yield name, weak_method_or_handler(handler)
+                yield name, WeakMethod(handler)
             else:
                 yield name, handler
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('pyglet/__init__.py') as f:
             break
 
 
-setup_info = dict(
+setup_info = dict(  # noqa: C408
     name='pyglet',
     version=info['version'],
     author='Alex Holkner',
@@ -38,19 +38,20 @@ setup_info = dict(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Games/Entertainment',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-
     # Package info
     packages=['pyglet'] + ['pyglet.' + pkg for pkg in find_packages('pyglet')],
-
     # Add _ prefix to the names of temporary build dirs
-    options={'build': {'build_base': '_build'}, },
+    options={
+        'build': {'build_base': '_build'},
+    },
     zip_safe=True,
 )
 

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 import unittest
+
+import pytest
+
 from tests import mock
+
 import pyglet.clock
 
 
@@ -351,3 +357,244 @@ class ClockTestCase(unittest.TestCase):
         items = sorted(i.next_ts for i in self.clock._schedule_interval_items)
 
         self.assertEqual(items, expected)
+
+
+@pytest.fixture
+def tween_clock():
+    now = [0.0]
+    instance = pyglet.clock.Clock(lambda: now[0])
+    instance.tick(poll=True)
+    return instance, now
+
+
+def test_easing_functions():
+    assert pyglet.clock.linear(0.25) == pytest.approx(0.25)
+    assert pyglet.clock.ease_in(0.5) == pytest.approx(0.25)
+    assert pyglet.clock.ease_out(0.5) == pytest.approx(0.75)
+    assert pyglet.clock.ease_in_out(0.25) == pytest.approx(0.125)
+    assert pyglet.clock.ease_in_out(0.75) == pytest.approx(0.875)
+    assert pyglet.clock.smoothstep(0.0) == pytest.approx(0.0)
+    assert pyglet.clock.smoothstep(0.5) == pytest.approx(0.5)
+    assert pyglet.clock.smoothstep(1.0) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'exception'),
+    [
+        ({'duration': -1.0, 'update': lambda _progress: None}, ValueError),
+        ({'duration': 1.0, 'update': None}, TypeError),
+        ({'duration': 1.0, 'update': lambda _progress: None, 'easing': None}, TypeError),
+    ],
+)
+def test_tween_validates_arguments(kwargs, exception):
+    with pytest.raises(exception):
+        pyglet.clock.tween(**kwargs)
+
+
+def test_tween_updates_from_zero_to_one_and_completes(tween_clock):
+    instance, now = tween_clock
+    values = []
+    completed = []
+
+    tween = instance.tween(1.0, values.append)
+    tween.add_callbacks(on_complete=completed.append, on_error=pytest.fail).start()
+
+    assert values == [0.0]
+
+    now[0] = 0.25
+    instance.tick(poll=True)
+    now[0] = 1.0
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+
+    assert values == [0.0, 0.25, 1.0]
+    assert completed == [None]
+    assert instance.get_sleep_time(True) is None
+
+
+def test_zero_duration_tween_completes_immediately(tween_clock):
+    instance, _now = tween_clock
+    values = []
+    completed = []
+
+    tween = instance.tween(0.0, values.append)
+    tween.add_callbacks(on_complete=completed.append, on_error=pytest.fail).start()
+
+    assert values == [1.0]
+    instance.tick(poll=True)
+    assert completed == [None]
+    assert instance.get_sleep_time(True) is None
+
+
+def test_tween_pause_excludes_paused_time(tween_clock):
+    instance, now = tween_clock
+    values = []
+    tween = instance.tween(1.0, values.append).start()
+
+    now[0] = 0.25
+    instance.tick(poll=True)
+    tween.pause()
+
+    now[0] = 10.0
+    instance.tick(poll=True)
+    assert values == [0.0, 0.25]
+
+    tween.resume()
+    now[0] = 10.25
+    instance.tick(poll=True)
+    assert values == [0.0, 0.25, 0.5]
+
+
+def test_tween_failure_is_reported(tween_clock):
+    instance, now = tween_clock
+    error = RuntimeError('update failed')
+    failures = []
+
+    def update(progress):
+        if progress:
+            raise error
+
+    tween = instance.tween(1.0, update)
+    tween.add_callbacks(
+        on_complete=lambda _result: pytest.fail('completed unexpectedly'),
+        on_error=failures.append,
+    ).start()
+
+    now[0] = 0.5
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+
+    assert failures == [error]
+    assert instance.get_sleep_time(True) is None
+
+
+def test_chain_can_yield_module_clock_tween(tween_clock):
+    instance, now = tween_clock
+    default = pyglet.clock.get_default()
+    pyglet.clock.set_default(instance)
+
+    class Sprite:
+        opacity = 255.0
+        deleted = False
+
+        def delete(self):
+            self.deleted = True
+
+    class FadeOut:
+        def __init__(self, target):
+            self.target = target
+            self.start_opacity = target.opacity
+
+        def __call__(self, progress):
+            self.target.opacity = self.start_opacity * (1.0 - progress)
+
+    @pyglet.clock.chain
+    def remove_sprite(sprite):
+        yield pyglet.clock.tween(0.5, FadeOut(sprite))
+        sprite.delete()
+
+    try:
+        sprite = Sprite()
+        chain = remove_sprite(sprite).start()
+        now[0] = 0.25
+        instance.tick(poll=True)
+        assert sprite.opacity == pytest.approx(127.5)
+        assert not sprite.deleted
+
+        now[0] = 0.5
+        instance.tick(poll=True)
+        instance.tick(poll=True)
+        instance.tick(poll=True)
+    finally:
+        pyglet.clock.set_default(default)
+
+    assert chain.done
+    assert sprite.opacity == pytest.approx(0.0)
+    assert sprite.deleted
+
+
+def test_tweens_can_run_in_parallel(tween_clock):
+    instance, now = tween_clock
+    first_values = []
+    second_values = []
+
+    @instance.chain
+    def sequence():
+        return (
+            yield instance.parallel(
+                instance.tween(0.5, first_values.append),
+                instance.tween(1.0, second_values.append),
+            )
+        )
+
+    chain = sequence().start()
+    now[0] = 0.5
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+    now[0] = 1.0
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+
+    assert chain.done
+    assert chain.result == (None, None)
+    assert first_values[-1] == pytest.approx(1.0)
+    assert second_values[-1] == pytest.approx(1.0)
+
+
+def test_tweens_can_race(tween_clock):
+    instance, now = tween_clock
+    slow_values = []
+
+    @instance.chain
+    def sequence():
+        return (
+            yield instance.race(
+                instance.tween(0.5, lambda _progress: None),
+                instance.tween(1.0, slow_values.append),
+            )
+        )
+
+    chain = sequence().start()
+    now[0] = 0.5
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+    instance.tick(poll=True)
+
+    assert chain.done
+    assert chain.result == (0, None)
+    assert slow_values[-1] == pytest.approx(0.5)
+    assert instance.get_sleep_time(True) is None
+
+
+def test_stopping_chain_cancels_its_tween(tween_clock):
+    instance, now = tween_clock
+    values = []
+
+    @instance.chain
+    def sequence():
+        yield instance.tween(1.0, values.append)
+
+    chain = sequence().start()
+    now[0] = 0.25
+    instance.tick(poll=True)
+    chain.stop()
+
+    now[0] = 1.0
+    instance.tick(poll=True)
+    assert values == [0.0, 0.25]
+    assert instance.get_sleep_time(True) is None
+
+
+def test_clock_uses_one_scheduled_callback_for_multiple_tweens(tween_clock):
+    instance, _now = tween_clock
+
+    first = instance.tween(1.0, lambda _progress: None).start()
+    second = instance.tween(1.0, lambda _progress: None).start()
+
+    assert len(instance._schedule_items) == 1  # noqa: SLF001
+
+    first.stop()
+    second.stop()
+    assert instance.get_sleep_time(True) is None

--- a/tests/unit/test_event_chain.py
+++ b/tests/unit/test_event_chain.py
@@ -8,25 +8,39 @@ import pyglet.event
 
 class FakeClock:
     def __init__(self):
+        self.now = 0.0
         self.scheduled = []
         self.scheduled_once = []
 
     def schedule_once(self, func, delay):
-        self.scheduled_once.append((func, delay))
+        self.scheduled_once.append([func, delay])
 
     def schedule(self, func):
         self.scheduled.append(func)
 
     def unschedule(self, func):
         self.scheduled = [callback for callback in self.scheduled if callback != func]
-        self.scheduled_once = [(callback, delay) for callback, delay in self.scheduled_once if callback != func]
+        self.scheduled_once = [item for item in self.scheduled_once if item[0] != func]
+
+    def time(self):
+        return self.now
 
     def tick(self, dt=0.0):
+        pending_once = list(self.scheduled_once)
+        self.now += dt
         for callback in list(self.scheduled):
             callback(dt)
+        for item in pending_once:
+            if item not in self.scheduled_once:
+                continue
+            item[1] -= dt
+            if item[1] <= 1e-12:
+                self.scheduled_once.remove(item)
+                item[0](dt)
 
     def run_once(self):
         callback, delay = self.scheduled_once.pop(0)
+        self.now += delay
         callback(delay)
 
 
@@ -57,6 +71,8 @@ def test_chain_yields_delay_and_completes(fake_clock):
     assert chain.running
     assert not chain.done
     assert events == ['started']
+    assert fake_clock.scheduled == []
+    assert len(fake_clock.scheduled_once) == 1
 
     fake_clock.tick(0.24)
 
@@ -400,6 +416,26 @@ def test_chain_yields_none_to_resume_on_next_clock_tick(fake_clock):
     assert events == ['started', 'resumed']
 
 
+def test_consecutive_zero_delays_each_resume_on_a_separate_tick(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        events.append(0)
+        yield None
+        events.append(1)
+        yield 0
+        events.append(2)
+
+    sequence().start()
+
+    fake_clock.tick()
+    assert events == [0, 1]
+
+    fake_clock.tick()
+    assert events == [0, 1, 2]
+
+
 def test_chain_stop_unschedules_pending_work_and_closes_generator(fake_clock):
     events = []
 
@@ -531,8 +567,11 @@ def test_chain_pause_unschedules_and_resume_continues_remaining_delay(fake_clock
     assert chain.paused
     assert not chain.running
     assert fake_clock.scheduled == []
+    assert fake_clock.scheduled_once == []
     assert events == ['started', 'paused']
 
+    # Time spent paused must not consume the delay.
+    fake_clock.tick(5.0)
     chain.resume()
 
     assert chain.running

--- a/tests/unit/test_event_chain.py
+++ b/tests/unit/test_event_chain.py
@@ -73,7 +73,22 @@ def test_chain_yields_delay_and_completes(fake_clock):
     assert events == ['started', 'finished', 'done']
 
 
-def test_chain_dispatches_lifecycle_events(fake_clock):
+def test_chain_callbacks_support_builtin_bound_methods(fake_clock):
+    # Should pass on normal pythons to may pypy happy.
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        yield 0
+        return 'done'
+
+    sequence().add_callbacks(on_complete=events.append).start()
+    fake_clock.tick()
+
+    assert events == ['done']
+
+
+def test_chain_invokes_lifecycle_callbacks(fake_clock):
     events = []
 
     @pyglet.clock.chain
@@ -82,7 +97,7 @@ def test_chain_dispatches_lifecycle_events(fake_clock):
         return 'done'
 
     chain = sequence()
-    chain.push_handlers(
+    chain.add_callbacks(
         on_pause=lambda: events.append('paused'),
         on_resume=lambda: events.append('resumed'),
         on_complete=lambda result: events.append(result),
@@ -93,6 +108,28 @@ def test_chain_dispatches_lifecycle_events(fake_clock):
     fake_clock.tick(0.5)
 
     assert events == ['paused', 'resumed', 'done']
+
+
+def test_chain_invokes_all_completion_callbacks_in_registration_order(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        yield 0
+        return 'done'
+
+    def first(result):
+        events.append(('first', result))
+        return True
+
+    chain = sequence()
+    chain.add_callbacks(on_complete=first)
+    chain.add_callbacks(on_complete=lambda result: events.append(('second', result)))
+    chain.on_complete = lambda result: events.append(('assigned', result))
+    chain.start()
+    fake_clock.tick()
+
+    assert events == [('first', 'done'), ('second', 'done'), ('assigned', 'done')]
 
 
 def test_chain_allows_default_lifecycle_event_handlers(fake_clock):
@@ -109,25 +146,6 @@ def test_chain_allows_default_lifecycle_event_handlers(fake_clock):
     fake_clock.tick(0.5)
 
     assert events == ['done']
-
-
-def test_chain_lifecycle_event_can_be_waited_for(fake_clock):
-    @pyglet.clock.chain
-    def child():
-        yield 0.5
-        return 'child result'
-
-    child_chain = child().start()
-
-    @pyglet.clock.chain
-    def observer():
-        return (yield pyglet.clock.wait_for_event(child_chain, 'on_complete'))
-
-    observer_chain = observer().start()
-    fake_clock.tick(0.5)
-    fake_clock.tick()
-
-    assert observer_chain.result == 'child result'
 
 
 def test_chain_can_be_created_for_explicit_clock(fake_clock):

--- a/tests/unit/test_event_chain.py
+++ b/tests/unit/test_event_chain.py
@@ -257,6 +257,29 @@ def test_chain_group_tracks_and_removes_completed_chains(fake_clock):
     assert events == ['finished']
 
 
+def test_chain_group_start_ignores_already_done_chains(fake_clock):
+    group = pyglet.clock.ChainGroup()
+
+    @pyglet.clock.chain
+    def completes_immediately():
+        if False:
+            yield
+
+    @pyglet.clock.chain
+    def waits():
+        yield 1.0
+
+    completed = completes_immediately().start()
+    stopped = waits().start()
+    stopped.stop()
+
+    assert group.start(completed) is completed
+    assert group.start(stopped) is stopped
+    assert group.chains == ()
+    assert fake_clock.scheduled == []
+    assert fake_clock.scheduled_once == []
+
+
 def test_chain_group_clear_stops_tracked_chains(fake_clock):
     events = []
     group = pyglet.clock.ChainGroup()

--- a/tests/unit/test_event_chain.py
+++ b/tests/unit/test_event_chain.py
@@ -125,11 +125,10 @@ def test_chain_invokes_all_completion_callbacks_in_registration_order(fake_clock
     chain = sequence()
     chain.add_callbacks(on_complete=first)
     chain.add_callbacks(on_complete=lambda result: events.append(('second', result)))
-    chain.on_complete = lambda result: events.append(('assigned', result))
     chain.start()
     fake_clock.tick()
 
-    assert events == [('first', 'done'), ('second', 'done'), ('assigned', 'done')]
+    assert events == [('first', 'done'), ('second', 'done')]
 
 
 def test_chain_allows_default_lifecycle_event_handlers(fake_clock):
@@ -141,7 +140,7 @@ def test_chain_allows_default_lifecycle_event_handlers(fake_clock):
         return 'done'
 
     chain = sequence()
-    chain.on_complete = events.append
+    chain.add_callbacks(on_complete=events.append)
     chain.start()
     fake_clock.tick(0.5)
 

--- a/tests/unit/test_event_chain.py
+++ b/tests/unit/test_event_chain.py
@@ -639,6 +639,78 @@ def test_chain_waits_for_child_chain_result(fake_clock):
     assert chain.result == 42
 
 
+def test_stopped_child_stops_waiting_parent(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        yield 1.0
+
+    child_chain = child()
+
+    @pyglet.clock.chain
+    def parent():
+        yield child_chain
+
+    chain = parent().add_callbacks(on_stop=lambda: events.append('parent stopped')).start()
+
+    child_chain.stop()
+    fake_clock.tick()
+
+    assert chain.stopped
+    assert not chain.failed
+    assert events == ['parent stopped']
+
+
+def test_parent_can_catch_stopped_child(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        yield 1.0
+
+    child_chain = child()
+
+    @pyglet.clock.chain
+    def parent():
+        try:
+            yield child_chain
+        except pyglet.clock.ChainStopped as exc:
+            events.append(str(exc))
+        return 'recovered'
+
+    chain = parent().start()
+
+    child_chain.stop()
+    fake_clock.tick()
+
+    assert chain.completed
+    assert chain.result == 'recovered'
+    assert events == ['A child chain stopped.']
+
+
+def test_parent_can_catch_child_stopped_before_yield(fake_clock):
+    @pyglet.clock.chain
+    def child():
+        yield 1.0
+
+    child_chain = child().start()
+    child_chain.stop()
+
+    @pyglet.clock.chain
+    def parent():
+        try:
+            yield child_chain
+        except pyglet.clock.ChainStopped:
+            return 'recovered'
+
+    chain = parent().start()
+    fake_clock.tick()
+
+    assert chain.completed
+    assert chain.result == 'recovered'
+
+
 def test_pause_and_resume_propagates_to_child_chain(fake_clock):
     events = []
 
@@ -732,9 +804,8 @@ def test_parallel_stop_stops_running_child_chains(fake_clock):
     assert events == ['first stopped', 'second stopped']
 
 
-def test_parallel_child_stop_stops_remaining_children_by_default(fake_clock):
+def test_parallel_child_stop_stops_remaining_children_and_parent_by_default(fake_clock):
     events = []
-    captured = []
 
     @pyglet.clock.chain
     def child(name):
@@ -750,7 +821,7 @@ def test_parallel_child_stop_stops_remaining_children_by_default(fake_clock):
     def parent():
         yield pyglet.clock.parallel(first, second)
 
-    chain = parent().add_callbacks(on_error=captured.append).start()
+    chain = parent().add_callbacks(on_stop=lambda: events.append('parent stopped')).start()
 
     first.stop()
 
@@ -759,10 +830,41 @@ def test_parallel_child_stop_stops_remaining_children_by_default(fake_clock):
     fake_clock.tick()
 
     assert chain.done
-    assert isinstance(chain.exception, RuntimeError)
-    assert captured == [chain.exception]
+    assert chain.stopped
+    assert not chain.failed
     assert fake_clock.scheduled == []
-    assert events == ['first stopped', 'second stopped']
+    assert events == ['first stopped', 'second stopped', 'parent stopped']
+
+
+def test_parallel_child_stop_can_be_caught_by_parent(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child(name):
+        try:
+            yield 1.0
+        finally:
+            events.append(f'{name} stopped')
+
+    first = child('first')
+    second = child('second')
+
+    @pyglet.clock.chain
+    def parent():
+        try:
+            yield pyglet.clock.parallel(first, second)
+        except pyglet.clock.ChainStopped:
+            events.append('recovered')
+        return 'done'
+
+    chain = parent().start()
+
+    first.stop()
+    fake_clock.tick()
+
+    assert chain.completed
+    assert chain.result == 'done'
+    assert events == ['first stopped', 'second stopped', 'recovered']
 
 
 def test_parallel_can_continue_when_child_chain_stops(fake_clock):
@@ -901,6 +1003,34 @@ def test_race_completes_with_first_child_result_and_stops_losers(fake_clock):
     assert events == ['first stopped', 'second stopped', (0, 'first')]
 
 
+def test_race_child_stop_stops_remaining_children_and_parent(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child(name):
+        try:
+            yield 1.0
+        finally:
+            events.append(f'{name} stopped')
+
+    first = child('first')
+    second = child('second')
+
+    @pyglet.clock.chain
+    def parent():
+        yield pyglet.clock.race(first, second)
+
+    chain = parent().add_callbacks(on_stop=lambda: events.append('parent stopped')).start()
+
+    first.stop()
+    fake_clock.tick()
+
+    assert chain.stopped
+    assert not chain.failed
+    assert fake_clock.scheduled == []
+    assert events == ['first stopped', 'second stopped', 'parent stopped']
+
+
 def test_race_child_error_stops_losers_and_errors_parent(fake_clock):
     error = ValueError('race failed')
     events = []
@@ -989,6 +1119,47 @@ def test_repeat_until_runs_until_condition_is_true(fake_clock):
     assert chain.result == (1, 2)
 
 
+def test_repeat_forever_runs_until_stopped(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        try:
+            events.append('started')
+            yield 0.1
+            events.append('finished')
+        finally:
+            events.append('stopped')
+
+    chain = pyglet.clock.repeat_forever(child).start()
+
+    for _ in range(3):
+        fake_clock.tick(0.1)
+        fake_clock.tick()
+
+    chain.stop()
+
+    assert chain.stopped
+    assert events == [
+        'started', 'finished', 'stopped',
+        'started', 'finished', 'stopped',
+        'started', 'finished', 'stopped',
+        'started', 'stopped',
+    ]
+
+
+def test_clock_repeat_forever_uses_clock_instance():
+    clock = pyglet.clock.Clock(time_function=lambda: 0.0)
+
+    @clock.chain
+    def child():
+        yield 0.1
+
+    chain = clock.repeat_forever(child)
+
+    assert chain.clock is clock
+
+
 def test_repeat_duration_stops_repeating_when_duration_elapses(fake_clock):
     events = []
 
@@ -1012,6 +1183,23 @@ def test_repeat_duration_stops_repeating_when_duration_elapses(fake_clock):
 
     assert chain.done
     assert events == ['started', 'finished', 'stopped', 'started', 'finished', 'stopped', 'started', 'stopped']
+
+
+def test_repeat_duration_zero_completes_without_repeating(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        events.append('started')
+        yield 0.1
+
+    chain = pyglet.clock.repeat_duration(child, 0).start()
+
+    fake_clock.tick()
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == ['started']
 
 
 def test_chain_waits_for_callback_operation(fake_clock):

--- a/tests/unit/test_event_chain.py
+++ b/tests/unit/test_event_chain.py
@@ -1,0 +1,1038 @@
+from __future__ import annotations
+
+import pytest
+
+import pyglet.clock
+import pyglet.event
+
+
+class FakeClock:
+    def __init__(self):
+        self.scheduled = []
+        self.scheduled_once = []
+
+    def schedule_once(self, func, delay):
+        self.scheduled_once.append((func, delay))
+
+    def schedule(self, func):
+        self.scheduled.append(func)
+
+    def unschedule(self, func):
+        self.scheduled = [callback for callback in self.scheduled if callback != func]
+        self.scheduled_once = [(callback, delay) for callback, delay in self.scheduled_once if callback != func]
+
+    def tick(self, dt=0.0):
+        for callback in list(self.scheduled):
+            callback(dt)
+
+    def run_once(self):
+        callback, delay = self.scheduled_once.pop(0)
+        callback(delay)
+
+
+@pytest.fixture
+def fake_clock():
+    clock = FakeClock()
+    default_clock = pyglet.clock.get_default()
+    pyglet.clock.set_default(clock)
+    try:
+        yield clock
+    finally:
+        pyglet.clock.set_default(default_clock)
+
+
+def test_chain_yields_delay_and_completes(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        events.append('started')
+        yield 0.25
+        events.append('finished')
+        return 'done'
+
+    chain = sequence().add_callbacks(on_complete=events.append).start()
+
+    assert chain.clock is fake_clock
+    assert chain.running
+    assert not chain.done
+    assert events == ['started']
+
+    fake_clock.tick(0.24)
+
+    assert not chain.done
+
+    fake_clock.tick(0.01)
+
+    assert not chain.running
+    assert chain.done
+    assert chain.completed
+    assert not chain.stopped
+    assert not chain.failed
+    assert chain.result == 'done'
+    assert events == ['started', 'finished', 'done']
+
+
+def test_chain_dispatches_lifecycle_events(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        yield 0.5
+        return 'done'
+
+    chain = sequence()
+    chain.push_handlers(
+        on_pause=lambda: events.append('paused'),
+        on_resume=lambda: events.append('resumed'),
+        on_complete=lambda result: events.append(result),
+    )
+    chain.start()
+    chain.pause()
+    chain.resume()
+    fake_clock.tick(0.5)
+
+    assert events == ['paused', 'resumed', 'done']
+
+
+def test_chain_allows_default_lifecycle_event_handlers(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        yield 0.5
+        return 'done'
+
+    chain = sequence()
+    chain.on_complete = events.append
+    chain.start()
+    fake_clock.tick(0.5)
+
+    assert events == ['done']
+
+
+def test_chain_lifecycle_event_can_be_waited_for(fake_clock):
+    @pyglet.clock.chain
+    def child():
+        yield 0.5
+        return 'child result'
+
+    child_chain = child().start()
+
+    @pyglet.clock.chain
+    def observer():
+        return (yield pyglet.clock.wait_for_event(child_chain, 'on_complete'))
+
+    observer_chain = observer().start()
+    fake_clock.tick(0.5)
+    fake_clock.tick()
+
+    assert observer_chain.result == 'child result'
+
+
+def test_chain_can_be_created_for_explicit_clock(fake_clock):
+    events = []
+    game_time = [0.0]
+    game_clock = pyglet.clock.Clock(lambda: game_time[0])
+
+    @game_clock.chain
+    def sequence():
+        yield 0.5
+        events.append('game clock')
+
+    chain = sequence().start()
+
+    assert chain.clock is game_clock
+    assert fake_clock.scheduled == []
+
+    game_clock.tick(poll=True)
+    game_time[0] = 0.5
+    game_clock.tick(poll=True)
+
+    assert events == ['game clock']
+
+
+def test_clock_instance_chain_binds_to_that_clock(fake_clock):
+    events = []
+    game_time = [0.0]
+    game_clock = pyglet.clock.Clock(lambda: game_time[0])
+
+    @game_clock.chain
+    def sequence():
+        yield 0.5
+        events.append('bound clock')
+
+    chain = sequence().start()
+
+    assert chain.clock is game_clock
+    assert fake_clock.scheduled == []
+
+    game_clock.tick(poll=True)
+    game_time[0] = 0.5
+    game_clock.tick(poll=True)
+
+    assert events == ['bound clock']
+
+
+def test_clock_instance_parallel_binds_children_to_that_clock(fake_clock):
+    events = []
+    game_time = [0.0]
+    game_clock = pyglet.clock.Clock(lambda: game_time[0])
+
+    @game_clock.chain
+    def child(name):
+        yield 0.5
+        return name
+
+    @game_clock.chain
+    def parent():
+        results = yield game_clock.parallel(child('first'), child('second'))
+        events.append(results)
+
+    parent().start()
+
+    assert fake_clock.scheduled == []
+
+    game_clock.tick(poll=True)
+    game_time[0] = 0.5
+    game_clock.tick(poll=True)
+    game_clock.tick(poll=True)
+
+    assert events == [('first', 'second')]
+
+
+def test_chain_group_tracks_and_removes_completed_chains(fake_clock):
+    events = []
+    group = pyglet.clock.ChainGroup()
+
+    assert group.clock is fake_clock
+
+    @pyglet.clock.chain
+    def sequence():
+        yield 0.1
+        events.append('finished')
+        return 'done'
+
+    chain = group.start(sequence(), tag='fade')
+
+    assert group.chains == (chain,)
+
+    fake_clock.tick(0.1)
+
+    assert group.chains == ()
+    assert chain.completed
+    assert events == ['finished']
+
+
+def test_chain_group_clear_stops_tracked_chains(fake_clock):
+    events = []
+    group = pyglet.clock.ChainGroup()
+
+    @pyglet.clock.chain
+    def sequence(name):
+        try:
+            yield 1.0
+        finally:
+            events.append(f'{name} stopped')
+
+    group.start(sequence('fade'), tag='fade')
+    group.start(sequence('move'), tag='move')
+
+    group.clear()
+
+    assert group.chains == ()
+    assert fake_clock.scheduled == []
+    assert events == ['fade stopped', 'move stopped']
+
+
+def test_chain_group_clear_can_filter_by_tag(fake_clock):
+    events = []
+    group = pyglet.clock.ChainGroup()
+
+    @pyglet.clock.chain
+    def sequence(name):
+        try:
+            yield 1.0
+            events.append(f'{name} finished')
+        finally:
+            events.append(f'{name} stopped')
+
+    fade = group.start(sequence('fade'), tag='fade')
+    move = group.start(sequence('move'), tag='move')
+
+    group.clear(tag='fade')
+
+    assert group.chains == (move,)
+    assert fade.stopped
+    assert not move.done
+    assert events == ['fade stopped']
+
+    fake_clock.tick(1.0)
+
+    assert group.chains == ()
+    assert events == ['fade stopped', 'move finished', 'move stopped']
+
+
+def test_chain_group_clear_recurses_into_child_groups(fake_clock):
+    events = []
+    scene_group = pyglet.clock.ChainGroup()
+    entity_group = scene_group.create_group()
+
+    @pyglet.clock.chain
+    def sequence():
+        try:
+            yield 1.0
+        finally:
+            events.append('entity stopped')
+
+    entity_group.start(sequence(), tag='fade')
+
+    scene_group.clear()
+
+    assert scene_group.groups == ()
+    assert entity_group.chains == ()
+    assert fake_clock.scheduled == []
+    assert events == ['entity stopped']
+
+
+def test_chain_group_tagged_clear_recurses_without_removing_child_groups(fake_clock):
+    events = []
+    scene_group = pyglet.clock.ChainGroup()
+    entity_group = scene_group.create_group()
+
+    @pyglet.clock.chain
+    def sequence(name):
+        try:
+            yield 1.0
+        finally:
+            events.append(f'{name} stopped')
+
+    fade = entity_group.start(sequence('fade'), tag='fade')
+    move = entity_group.start(sequence('move'), tag='move')
+
+    scene_group.clear(tag='fade')
+
+    assert scene_group.groups == (entity_group,)
+    assert entity_group.chains == (move,)
+    assert fade.stopped
+    assert not move.done
+    assert events == ['fade stopped']
+
+
+def test_chain_group_pause_and_resume(fake_clock):
+    events = []
+    group = pyglet.clock.ChainGroup()
+
+    @pyglet.clock.chain
+    def sequence():
+        yield 1.0
+        events.append('finished')
+
+    group.start(sequence())
+    group.pause()
+
+    fake_clock.tick(1.0)
+
+    assert events == []
+
+    group.resume()
+    fake_clock.tick(1.0)
+
+    assert events == ['finished']
+
+
+def test_clock_create_group_binds_started_chains_to_that_clock(fake_clock):
+    events = []
+    game_time = [0.0]
+    game_clock = pyglet.clock.Clock(lambda: game_time[0])
+    group = game_clock.create_group()
+
+    @game_clock.chain
+    def sequence():
+        yield 0.5
+        events.append('game clock')
+
+    chain = group.start(sequence())
+
+    assert chain.clock is game_clock
+    assert fake_clock.scheduled == []
+
+    game_clock.tick(poll=True)
+    game_time[0] = 0.5
+    game_clock.tick(poll=True)
+
+    assert events == ['game clock']
+
+
+def test_chain_yields_none_to_resume_on_next_clock_tick(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        events.append('started')
+        yield None
+        events.append('resumed')
+
+    sequence().start()
+
+    assert events == ['started']
+    assert len(fake_clock.scheduled) == 1
+
+    fake_clock.tick()
+
+    assert events == ['started', 'resumed']
+
+
+def test_chain_stop_unschedules_pending_work_and_closes_generator(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        try:
+            yield 5.0
+        finally:
+            events.append('closed')
+
+    chain = sequence().add_callbacks(on_stop=lambda: events.append('stopped')).start()
+
+    chain.stop()
+
+    assert chain.done
+    assert not chain.completed
+    assert chain.stopped
+    assert not chain.failed
+    assert not chain.running
+    assert fake_clock.scheduled == []
+    assert events == ['closed', 'stopped']
+
+
+def test_wait_for_event_completes_on_dispatcher_event(fake_clock):
+    class Dispatcher(pyglet.event.EventDispatcher):
+        pass
+
+    Dispatcher.register_event_type('on_value')
+    dispatcher = Dispatcher()
+
+    @pyglet.clock.chain
+    def sequence():
+        value = yield pyglet.clock.wait_for_event(dispatcher, 'on_value')
+        return value
+
+    chain = sequence().start()
+
+    dispatcher.dispatch_event('on_value', 42)
+    fake_clock.tick()
+
+    assert chain.done
+    assert chain.result == 42
+    assert dispatcher.dispatch_event('on_value', 99) is False
+
+
+def test_wait_for_event_can_filter_with_condition(fake_clock):
+    class Dispatcher(pyglet.event.EventDispatcher):
+        pass
+
+    Dispatcher.register_event_type('on_value')
+    dispatcher = Dispatcher()
+
+    @pyglet.clock.chain
+    def sequence():
+        value = yield pyglet.clock.wait_for_event(
+            dispatcher,
+            'on_value',
+            condition=lambda value: value > 1,
+        )
+        return value
+
+    chain = sequence().start()
+
+    dispatcher.dispatch_event('on_value', 1)
+    fake_clock.tick()
+
+    assert not chain.done
+
+    dispatcher.dispatch_event('on_value', 2)
+    fake_clock.tick()
+
+    assert chain.done
+    assert chain.result == 2
+
+
+def test_wait_for_event_can_consume_matching_event(fake_clock):
+    class Dispatcher(pyglet.event.EventDispatcher):
+        pass
+
+    Dispatcher.register_event_type('on_value')
+    dispatcher = Dispatcher()
+
+    @pyglet.clock.chain
+    def sequence():
+        yield pyglet.clock.wait_for_event(dispatcher, 'on_value', consume=True)
+
+    sequence().start()
+
+    assert dispatcher.dispatch_event('on_value') == pyglet.event.EVENT_HANDLED
+
+
+def test_wait_for_event_stop_removes_handler(fake_clock):
+    class Dispatcher(pyglet.event.EventDispatcher):
+        pass
+
+    Dispatcher.register_event_type('on_value')
+    dispatcher = Dispatcher()
+
+    @pyglet.clock.chain
+    def sequence():
+        yield pyglet.clock.wait_for_event(dispatcher, 'on_value')
+
+    chain = sequence().start()
+
+    chain.stop()
+
+    assert dispatcher.dispatch_event('on_value') is False
+
+
+def test_chain_pause_unschedules_and_resume_continues_remaining_delay(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def sequence():
+        events.append('started')
+        yield 1.0
+        events.append('finished')
+
+    chain = sequence()
+    chain.add_callbacks(
+        on_pause=lambda: events.append('paused'),
+        on_resume=lambda: events.append('resumed'),
+    )
+    chain.start()
+
+    fake_clock.tick(0.4)
+    chain.pause()
+
+    assert chain.paused
+    assert not chain.running
+    assert fake_clock.scheduled == []
+    assert events == ['started', 'paused']
+
+    chain.resume()
+
+    assert chain.running
+    assert not chain.paused
+    assert events == ['started', 'paused', 'resumed']
+
+    fake_clock.tick(0.59)
+
+    assert not chain.done
+
+    fake_clock.tick(0.01)
+
+    assert chain.done
+    assert events == ['started', 'paused', 'resumed', 'finished']
+
+
+def test_paused_chain_defers_callback_operation_completion(fake_clock):
+    complete_callback = None
+    events = []
+
+    @pyglet.clock.yielding_callback
+    def wait_for_message(complete, fail):
+        nonlocal complete_callback
+        complete_callback = complete
+
+    @pyglet.clock.chain
+    def sequence():
+        events.append('waiting')
+        message = yield wait_for_message()
+        events.append(message)
+
+    chain = sequence().start()
+    chain.pause()
+
+    assert complete_callback is not None
+    complete_callback('arrived')
+
+    assert fake_clock.scheduled == []
+    assert events == ['waiting']
+
+    chain.resume()
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == ['waiting', 'arrived']
+
+
+def test_chain_waits_for_child_chain_result(fake_clock):
+    @pyglet.clock.chain
+    def child():
+        yield 0.1
+        return 21
+
+    @pyglet.clock.chain
+    def parent():
+        result = yield child()
+        return result * 2
+
+    chain = parent().start()
+
+    fake_clock.tick(0.1)
+    fake_clock.tick()
+
+    assert chain.done
+    assert chain.result == 42
+
+
+def test_pause_and_resume_propagates_to_child_chain(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        events.append('child started')
+        yield 1.0
+        events.append('child finished')
+        return 'child result'
+
+    @pyglet.clock.chain
+    def parent():
+        result = yield child()
+        events.append(result)
+
+    chain = parent().start()
+
+    fake_clock.tick(0.25)
+    chain.pause()
+
+    assert chain.paused
+    assert fake_clock.scheduled == []
+
+    chain.resume()
+
+    fake_clock.tick(0.74)
+
+    assert not chain.done
+
+    fake_clock.tick(0.01)
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == ['child started', 'child finished', 'child result']
+
+
+def test_parallel_runs_child_chains_together_and_returns_ordered_results(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child(name, delay):
+        events.append(f'{name} started')
+        yield delay
+        events.append(f'{name} finished')
+        return name
+
+    @pyglet.clock.chain
+    def parent():
+        results = yield pyglet.clock.parallel(
+            child('first', 0.2),
+            child('second', 0.4),
+        )
+        events.append(results)
+
+    chain = parent().start()
+
+    assert events == ['first started', 'second started']
+
+    fake_clock.tick(0.2)
+
+    assert not chain.done
+    assert events == ['first started', 'second started', 'first finished']
+
+    fake_clock.tick(0.2)
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == ['first started', 'second started', 'first finished', 'second finished', ('first', 'second')]
+
+
+def test_parallel_stop_stops_running_child_chains(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child(name):
+        try:
+            yield 1.0
+        finally:
+            events.append(f'{name} stopped')
+
+    @pyglet.clock.chain
+    def parent():
+        yield pyglet.clock.parallel(child('first'), child('second'))
+
+    chain = parent().start()
+
+    chain.stop()
+
+    assert chain.done
+    assert fake_clock.scheduled == []
+    assert events == ['first stopped', 'second stopped']
+
+
+def test_parallel_child_stop_stops_remaining_children_by_default(fake_clock):
+    events = []
+    captured = []
+
+    @pyglet.clock.chain
+    def child(name):
+        try:
+            yield 1.0
+        finally:
+            events.append(f'{name} stopped')
+
+    first = child('first')
+    second = child('second')
+
+    @pyglet.clock.chain
+    def parent():
+        yield pyglet.clock.parallel(first, second)
+
+    chain = parent().add_callbacks(on_error=captured.append).start()
+
+    first.stop()
+
+    assert not chain.done
+
+    fake_clock.tick()
+
+    assert chain.done
+    assert isinstance(chain.exception, RuntimeError)
+    assert captured == [chain.exception]
+    assert fake_clock.scheduled == []
+    assert events == ['first stopped', 'second stopped']
+
+
+def test_parallel_can_continue_when_child_chain_stops(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child(name):
+        try:
+            yield 1.0
+            events.append(f'{name} finished')
+            return name
+        finally:
+            events.append(f'{name} stopped')
+
+    first = child('first')
+    second = child('second')
+
+    @pyglet.clock.chain
+    def parent():
+        results = yield pyglet.clock.parallel(first, second, continue_on_stop=True)
+        events.append(results)
+
+    chain = parent().start()
+
+    first.stop()
+
+    assert not chain.done
+    assert events == ['first stopped']
+
+    fake_clock.tick(1.0)
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == [
+        'first stopped',
+        'second finished',
+        'second stopped',
+        (pyglet.clock.STOPPED, 'second'),
+    ]
+
+
+def test_parallel_pause_and_resume_propagates_to_children(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child(name):
+        yield 1.0
+        events.append(f'{name} finished')
+        return name
+
+    @pyglet.clock.chain
+    def parent():
+        results = yield pyglet.clock.parallel(child('first'), child('second'))
+        events.append(results)
+
+    chain = parent().start()
+
+    fake_clock.tick(0.3)
+    chain.pause()
+
+    assert chain.paused
+    assert fake_clock.scheduled == []
+
+    chain.resume()
+    fake_clock.tick(0.69)
+
+    assert not chain.done
+
+    fake_clock.tick(0.01)
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == ['first finished', 'second finished', ('first', 'second')]
+
+
+def test_parallel_child_error_stops_remaining_children(fake_clock):
+    error = ValueError('failed child')
+    events = []
+    captured = []
+
+    @pyglet.clock.chain
+    def failing_child():
+        yield 0.2
+        raise error
+
+    @pyglet.clock.chain
+    def long_child():
+        try:
+            yield 1.0
+        finally:
+            events.append('long child stopped')
+
+    @pyglet.clock.chain
+    def parent():
+        yield pyglet.clock.parallel(failing_child(), long_child())
+
+    chain = parent().add_callbacks(on_error=captured.append).start()
+
+    fake_clock.tick(0.2)
+    fake_clock.tick()
+
+    assert chain.done
+    assert not chain.completed
+    assert not chain.stopped
+    assert chain.failed
+    assert chain.exception is error
+    assert captured == [error]
+    assert events == ['long child stopped']
+
+
+def test_race_completes_with_first_child_result_and_stops_losers(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child(name, delay):
+        try:
+            yield delay
+            return name
+        finally:
+            events.append(f'{name} stopped')
+
+    @pyglet.clock.chain
+    def parent():
+        result = yield pyglet.clock.race(
+            child('first', 0.2),
+            child('second', 0.5),
+        )
+        events.append(result)
+
+    chain = parent().start()
+
+    fake_clock.tick(0.2)
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == ['first stopped', 'second stopped', (0, 'first')]
+
+
+def test_race_child_error_stops_losers_and_errors_parent(fake_clock):
+    error = ValueError('race failed')
+    events = []
+    captured = []
+
+    @pyglet.clock.chain
+    def failing_child():
+        yield 0.2
+        raise error
+
+    @pyglet.clock.chain
+    def long_child():
+        try:
+            yield 1.0
+        finally:
+            events.append('long child stopped')
+
+    @pyglet.clock.chain
+    def parent():
+        yield pyglet.clock.race(failing_child(), long_child())
+
+    chain = parent().add_callbacks(on_error=captured.append).start()
+
+    fake_clock.tick(0.2)
+    fake_clock.tick()
+
+    assert chain.done
+    assert not chain.completed
+    assert not chain.stopped
+    assert chain.failed
+    assert chain.exception is error
+    assert captured == [error]
+    assert events == ['long child stopped']
+
+
+def test_timeout_completes_after_delay(fake_clock):
+    events = []
+
+    pyglet.clock.timeout(0.5).add_callbacks(on_complete=lambda result: events.append(result)).start()
+
+    fake_clock.tick(0.49)
+
+    assert events == []
+
+    fake_clock.tick(0.01)
+
+    assert events == [None]
+
+
+def test_repeat_runs_factory_count_times(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        events.append('started')
+        yield 0.1
+        return len(events)
+
+    chain = pyglet.clock.repeat(child, 3).start()
+
+    for _ in range(3):
+        fake_clock.tick(0.1)
+        fake_clock.tick()
+
+    assert chain.done
+    assert chain.result == (1, 2, 3)
+    assert events == ['started', 'started', 'started']
+
+
+def test_repeat_until_runs_until_condition_is_true(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        events.append('started')
+        yield 0.1
+        return len(events)
+
+    chain = pyglet.clock.repeat_until(child, lambda: len(events) == 2).start()
+
+    for _ in range(2):
+        fake_clock.tick(0.1)
+        fake_clock.tick()
+
+    assert chain.done
+    assert chain.result == (1, 2)
+
+
+def test_repeat_duration_stops_repeating_when_duration_elapses(fake_clock):
+    events = []
+
+    @pyglet.clock.chain
+    def child():
+        try:
+            events.append('started')
+            yield 0.3
+            events.append('finished')
+        finally:
+            events.append('stopped')
+
+    chain = pyglet.clock.repeat_duration(child, 0.75).start()
+
+    fake_clock.tick(0.3)
+    fake_clock.tick()
+    fake_clock.tick(0.3)
+    fake_clock.tick()
+    fake_clock.tick(0.15)
+    fake_clock.tick()
+
+    assert chain.done
+    assert events == ['started', 'finished', 'stopped', 'started', 'finished', 'stopped', 'started', 'stopped']
+
+
+def test_chain_waits_for_callback_operation(fake_clock):
+    complete_callback = None
+
+    @pyglet.clock.yielding_callback
+    def wait_for_message(complete, fail):
+        nonlocal complete_callback
+        complete_callback = complete
+
+    @pyglet.clock.chain
+    def sequence():
+        message = yield wait_for_message()
+        return message.upper()
+
+    chain = sequence().start()
+
+    assert complete_callback is not None
+    complete_callback('arrived')
+    fake_clock.tick()
+
+    assert chain.done
+    assert chain.result == 'ARRIVED'
+
+
+def test_chain_stop_cancels_callback_operation(fake_clock):
+    events = []
+
+    @pyglet.clock.yielding_callback
+    def wait_forever(complete, fail):
+        return lambda: events.append('cancelled')
+
+    @pyglet.clock.chain
+    def sequence():
+        yield wait_forever()
+
+    chain = sequence().add_callbacks(on_stop=lambda: events.append('stopped')).start()
+
+    chain.stop()
+
+    assert events == ['cancelled', 'stopped']
+
+
+def test_chain_reports_operation_errors(fake_clock):
+    error = ValueError('bad event')
+    captured = []
+
+    @pyglet.clock.yielding_callback
+    def fail_later(complete, fail):
+        fail(error)
+
+    @pyglet.clock.chain
+    def sequence():
+        yield fail_later()
+
+    chain = sequence().add_callbacks(on_error=captured.append).start()
+
+    fake_clock.tick()
+
+    assert chain.done
+    assert not chain.completed
+    assert not chain.stopped
+    assert chain.failed
+    assert chain.exception is error
+    assert captured == [error]
+
+
+def test_chain_rejects_negative_delay(fake_clock):
+    captured = []
+
+    @pyglet.clock.chain
+    def sequence():
+        yield -1
+
+    chain = sequence().add_callbacks(on_error=captured.append).start()
+
+    assert chain.done
+    assert isinstance(chain.exception, ValueError)
+    assert captured == [chain.exception]
+

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -90,19 +90,6 @@ def test_push_handlers_kwargs(dispatcher, mock_handler):
     assert mock_handler.called
 
 
-def test_push_handlers_accepts_non_weakrefable_bound_methods(dispatcher):
-    dispatcher.register_event_type('mock_event')
-    values = []
-
-    dispatcher.push_handlers(mock_event=values.append)
-
-    assert dispatcher.dispatch_event('mock_event', 42) is None
-    assert values == [42]
-
-    dispatcher.remove_handlers(mock_event=values.append)
-    assert dispatcher.dispatch_event('mock_event', 99) is False
-
-
 def test_push_handlers_instance(dispatcher, class_instance_handler):
     dispatcher.register_event_type('mock_event')
     dispatcher.push_handlers(class_instance_handler)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -90,6 +90,19 @@ def test_push_handlers_kwargs(dispatcher, mock_handler):
     assert mock_handler.called
 
 
+def test_push_handlers_accepts_non_weakrefable_bound_methods(dispatcher):
+    dispatcher.register_event_type('mock_event')
+    values = []
+
+    dispatcher.push_handlers(mock_event=values.append)
+
+    assert dispatcher.dispatch_event('mock_event', 42) is None
+    assert values == [42]
+
+    dispatcher.remove_handlers(mock_event=values.append)
+    assert dispatcher.dispatch_event('mock_event', 99) is False
+
+
 def test_push_handlers_instance(dispatcher, class_instance_handler):
     dispatcher.register_event_type('mock_event')
     dispatcher.push_handlers(class_instance_handler)


### PR DESCRIPTION
This PR is to expand the clock module a bit to add generator-based event chaining to pyglet.clock, similar to async implementations that other event loop systems provide.

It's intended to make scheduling multi-step flows easier to manage, as well as, allow cancel, pause, and resume. Also to help remove a lot of boilerplate and frustration with trying to manage multiple `schedule_once` calls to chain together things.

Something like this:
```py
def part2(dt):
    print("part2")

def part1(dt):
    print("part1")
    pyglet.clock.schedule_once(part2, 0.5)

print("starting")
pyglet.clock.schedule_once(part1, 1.0)
```

Would become:
```py
@pyglet.clock.chain
def part_chain():
    print("starting")
    yield 1.0
    print("part 1")
    yield 0.5
    print("part 2")

chain = part_chain()
chain.start()
```


As you can see it can easily be created with a decorator and is much easier to understand the flow. You can even yield from another chain creating little pieces that can be re-used.


You can also create a chain without the decorator: `chain = pyglet.clock.Chain(part_chain())`

Cancel it with `chain.cancel()` or pause and resume via `chain.pause()`/`chain.resume()`.

It has lots of different helper functions for looping chains, parallel runs, race, timeouts, and integrating with other yielding return functions. 

There are also ChainGroups which help control life cycle. For example, you might have a character that has multiple chains being run on it. Maybe size changes, color changes, waits for actions being done, but then suddenly that character dies, you would want an easy way to stop those. That is where the group comes in. Furthermore you can create an inheritance of ChainGroups as well. For example, maybe you have a scene chain, and a ui chain. This way you can stop all of your scene chains during transitions or other features while keeping your UI separate.

Chains can also be used for separate clock instances as well. For example you can use the default clock as your game clock, but maybe you have a separate clock called UI clock. That way you can directly target chain control by different pieces of your application.

This could also be used for various animation features in the future.

At this point it might seem just easier to implement something like asyncio and then we could have features like that built in, but it would require a larger rewrite and would still be separate from the clock. 

Read the docs for more examples and explanations.

Looking for any input for improvements, or oversights, and just discussion on it.