### PR TITLE
Fix Arc applying rotation twice, and implement Arc.__contains__

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -883,7 +883,7 @@ class Arc(ShapeBase):
         y = -self._anchor_y
         r = self._radius
         segment_radians = math.radians(self._angle) / self._segments
-        start_radians = math.radians(self._start_angle - self._rotation)
+        start_radians = math.radians(self._start_angle)
 
         # Calculate the outer points of the arc:
         points = [(x + (r * math.cos((i * segment_radians) + start_radians)),
@@ -968,6 +968,27 @@ class Arc(ShapeBase):
     def start_angle(self, angle: float) -> None:
         self._start_angle = angle
         self._update_vertices()
+
+    def __contains__(self, point: tuple[float, float]) -> bool:
+        assert len(point) == 2
+        point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
+        distance = math.dist((self._x - self._anchor_x, self._y - self._anchor_y), point)
+        if abs(distance - self._radius) > self._thickness / 2:
+            return False
+        angle = math.degrees(math.atan2(point[1] - self._y + self._anchor_y, point[0] - self._x + self._anchor_x))
+        angle = angle % 360
+        start_angle = self._start_angle % 360
+        end_angle = (start_angle + self._angle) % 360
+        if self._angle >= 0:
+            if start_angle <= end_angle:
+                return start_angle <= angle <= end_angle
+            else:
+                return angle >= start_angle or angle <= end_angle
+        else:
+            if end_angle <= start_angle:
+                return end_angle <= angle <= start_angle
+            else:
+                return angle >= end_angle or angle <= start_angle
 
 
 class BezierCurve(ShapeBase):

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -127,3 +127,62 @@ def test_blend_setter(shape_keywords_only):
     shape.blend_mode = blend_mode
     assert shape._group.blend_src == 1  # noqa: SLF001
     assert shape._group.blend_dest == 1  # noqa: SLF001
+
+
+# Regression tests for #887: Arc.__contains__ raised NotImplementedError,
+# and Arc's rotation was applied twice (see also the fix to
+# Arc._get_vertices, which removed a leftover manual rotation term).
+class TestArcContains:
+
+    def test_point_on_the_ring_is_contained(self):
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=360.0)
+        assert (10, 0) in arc
+
+    def test_point_in_the_hole_is_not_contained(self):
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=360.0)
+        assert (0, 0) not in arc
+
+    def test_point_far_outside_is_not_contained(self):
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=360.0)
+        assert (100, 100) not in arc
+
+    def test_point_within_half_thickness_of_the_ring_is_contained(self):
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=360.0)
+        assert (9.6, 0) in arc
+
+    def test_point_beyond_half_thickness_of_the_ring_is_not_contained(self):
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=360.0)
+        assert (9.0, 0) not in arc
+
+    def test_point_inside_the_swept_angle_is_contained(self):
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=90.0, start_angle=0.0)
+        assert (7.0710678, 7.0710678) in arc  # 45 degrees, within [0, 90]
+
+    def test_point_outside_the_swept_angle_is_not_contained(self):
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=90.0, start_angle=0.0)
+        assert (-10, 0) not in arc  # 180 degrees, outside [0, 90]
+
+    def test_contains_tracks_a_single_rotation_like_other_shapes(self):
+        """Rotating an Arc by 90 degrees should move its swept wedge by
+        exactly 90 degrees (matching Sector's convention), not by 180
+        degrees in the opposite direction as it did before this fix.
+        """
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=90.0, start_angle=0.0)
+        arc.rotation = 90
+        # The [0, 90] wedge, rotated -90 degrees, now covers [-90, 0].
+        assert (0, -10) in arc   # -90 degrees: new start of the wedge
+        assert (10, 0) in arc    # 0 degrees: new end of the wedge
+        assert (0, 10) not in arc  # 90 degrees: outside the rotated wedge
+
+    def test_local_vertices_do_not_depend_on_rotation(self):
+        """Arc._get_vertices() computes local-space geometry; rotation is
+        applied entirely by the shared shader-based rotation (like every
+        other shape). Before this fix, Arc uniquely also subtracted
+        self._rotation while building local vertices, applying rotation
+        twice: once here, and again in the shader.
+        """
+        arc = Arc(0, 0, radius=10, thickness=1.0, angle=90.0, start_angle=30.0)
+        unrotated = arc._get_vertices()  # noqa: SLF001
+        arc.rotation = 45
+        rotated = arc._get_vertices()  # noqa: SLF001
+        assert rotated == unrotated


### PR DESCRIPTION
Related to #887

## Problem 1: Arc.rotation applied twice
`Arc._get_vertices()` computed its swept angle using
`start_angle - self._rotation`. This predates PR #943, which added a
shared shader-based `rotation` attribute to every shape and removed the
old per-shape rotation properties. The shader already applies
`-rotation` to every shape's local vertices, so Arc ended up rotating
at *double* the angle, in the *opposite* direction, compared to Sector,
Rectangle, and every other shape (Sector's `_get_vertices`, for
comparison, never references `self._rotation` at all).

Verified numerically by simulating the exact GLSL rotation matrix in
Python: before this fix, `world_angle = start_angle - 2*rotation`;
after, `world_angle = start_angle - rotation`, matching Sector.

## Problem 2: Arc.__contains__ not implemented
Every other shape overrides `ShapeBase.__contains__`; `Arc` didn't, so
`point in arc` raised `NotImplementedError`. Implemented it using the
same angle-wraparound logic as `Sector.__contains__`, adapted to test
an annulus (`abs(distance_to_center - radius) <= thickness / 2`)
instead of a filled disc, since Arc is a stroked shape.

## Testing
Added 9 tests to `tests/unit/shapes/test_shapes.py`, covering: points on/
off the ring, within/beyond half-thickness, inside/outside the swept
angle, and one test that isolates the double-rotation bug directly via
`_get_vertices()`, independent of the `__contains__` fix. All 9 fail
against unmodified pyglet and pass after this fix.

Ran the full existing unit test suite under Xvfb: 639 passed, 18
skipped, 2 xfailed, 2 failed -- the 2 failures are OpenAL/PulseAudio
driver tests unrelated to this change (no audio hardware in my
sandbox); confirmed identical failures on unmodified pyglet. Ran `ruff
check` on the changed file: zero new violations.

Note: this only addresses Arc from #887. That issue also covers several
other shapes (BezierCurve/Polygon init, Line, Triangle rotation,
Ellipse/BorderedRectangle) which are unrelated and unaffected by this
change.