### PR TITLE
Mac controller fixes

### DIFF
--- a/pyglet/input/macos/darwin_gc.py
+++ b/pyglet/input/macos/darwin_gc.py
@@ -246,12 +246,43 @@ class HapticEngine:
             self.engine = None
 
     def __del__(self):
-        self.delete()
+        try:
+            self.delete()
+        except Exception:
+            pass
 
 
 class AppleGamepad(Device):
 
+    weak_motor_engine: HapticEngine | None
+    strong_motor_engine: HapticEngine | None
+
     def __init__(self, manager, controller: _GCController) -> None:
+        # Tracking when the device is deleted. (Disconnected)
+        self._deleted = False
+
+        # Haptic motors.
+        self.weak_motor_engine = None
+        self.strong_motor_engine = None
+
+        # Callback blocks.
+        self._button_cb_block = None
+        self._axes_cb_block = None
+        self._dpad_cb_block = None
+
+        # These all can potentially store references to ObjC instances.
+        self._button_ptrs = {}
+        self._axes_ptrs = {}
+        self._dpad_ptrs = {}
+
+        self.battery = None
+        self.haptics = None
+        self.light = None
+        self.profile = None
+
+        self.buttons = {}
+        self.axes = {}
+        self.dpads = {}
 
         with AutoReleasePool():
             self.manager = weakref.proxy(manager)
@@ -266,9 +297,6 @@ class AppleGamepad(Device):
             self.battery = controller.battery()  # GCDeviceBattery
             self.haptics = controller.haptics()  # GCDeviceHaptics
             self.light = controller.light()  # GCDeviceLight
-
-            self.weak_motor_engine = None
-            self.strong_motor_engine = None
 
             if self.haptics:
                 # self.weak_motor_engine = self._get_motor_engine(GCHapticsLocalityDefault)
@@ -365,6 +393,58 @@ class AppleGamepad(Device):
                 "hat": AbsoluteAxis('hat', 0, 1),
             }
 
+    def _clear_value_changed_handlers(self) -> None:
+        """Clears the various control handlers.
+
+        It seems sometimes these addresses can be re-assigned internally by Apple to
+        another controller instance. Ensure we remove them.
+        """
+        for collection in (self.buttons, self.axes, self.dpads):
+            if not collection:
+                continue
+
+            for objc_input in collection.values():
+                if objc_input and objc_input.is_valid:
+                    objc_input.setValueChangedHandler_(None)
+
+    def delete(self) -> None:
+        if getattr(self, '_deleted', True):
+            return
+
+        self._deleted = True
+        self._clear_value_changed_handlers()
+
+        if self.weak_motor_engine:
+            self.weak_motor_engine.delete()
+            self.weak_motor_engine = None
+
+        if self.strong_motor_engine:
+            self.strong_motor_engine.delete()
+            self.strong_motor_engine = None
+
+        self._button_ptrs.clear()
+        self._axes_ptrs.clear()
+        self._dpad_ptrs.clear()
+
+        self._button_cb_block = None
+        self._axes_cb_block = None
+        self._dpad_cb_block = None
+
+        self.controller = None
+        self.battery = None
+        self.haptics = None
+        self.light = None
+        self.profile = None
+        self.buttons.clear()
+        self.axes.clear()
+        self.dpads.clear()
+
+    def __del__(self):
+        try:
+            self.delete()
+        except Exception:
+            pass
+
     def _axis_changed_callback(self, axes_obj, value):
         name = self._axes_ptrs[axes_obj]
         self.controls[name].value = value
@@ -416,8 +496,7 @@ class AppleGamepad(Device):
             # print("Error starting engine")
             return None
 
-        self.haptic_engine = HapticEngine(locality, engine)
-        return self.haptic_engine
+        return HapticEngine(locality, engine)
 
     def get_controls(self) -> list[Control]:
         return list(self.controls.values())
@@ -501,22 +580,30 @@ class _AppleControllerManager_Implementation(EventDispatcher):
     @_PygletAppleControllerManager.method('v@')
     def controllerConnected_(self, notification: NSNotification):
         device: GCController = notification.object()
+        device_ptr = device.ptr.value
 
         wrapper = AppleGamepad(self, device)
         controller = AppleController(wrapper, {"name": wrapper.device_name, "guid": "MFI_APPLE_CONTROLLER"})
 
-        self.controllers[device] = controller
+        # Shouldn't happen, but just to be safe...
+        if old_controller := self.controllers.get(device_ptr):
+            old_controller.device.delete()
+
+        self.controllers[device_ptr] = controller
 
         self.dispatcher.dispatch_event('on_connect', controller)
 
     @_PygletAppleControllerManager.method('v@')
     def controllerDisconnected_(self, notification: NSNotification):
         device: GCController = notification.object()
+        device_ptr = device.ptr.value
 
-        if device in self.controllers:
-            self.dispatcher.dispatch_event('on_disconnect', self.controllers[device])
+        if device_ptr in self.controllers:
+            controller = self.controllers[device_ptr]
+            self.dispatcher.dispatch_event('on_disconnect', controller)
 
-            del self.controllers[device]
+            del self.controllers[device_ptr]
+            controller.device.delete()
 
     def get_controllers(self):
         return list(self.controllers.values())

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -1158,10 +1158,6 @@ class ObjCBoundMethod:
 
     def __call__(self, *args):
         """Call the method with the given arguments."""
-        if isinstance(self.objc_id, ObjCInstance) and not self.objc_id.is_valid:
-            msg = f'Cannot send selector {self.method.name!r} to deallocated Objective-C object {self.objc_id!r}'
-            raise ReferenceError(msg)
-
         return self.method(self.objc_id, *args)
 
 

--- a/pyglet/libs/darwin/cocoapy/runtime.py
+++ b/pyglet/libs/darwin/cocoapy/runtime.py
@@ -1158,6 +1158,10 @@ class ObjCBoundMethod:
 
     def __call__(self, *args):
         """Call the method with the given arguments."""
+        if isinstance(self.objc_id, ObjCInstance) and not self.objc_id.is_valid:
+            msg = f'Cannot send selector {self.method.name!r} to deallocated Objective-C object {self.objc_id!r}'
+            raise ReferenceError(msg)
+
         return self.method(self.objc_id, *args)
 
 
@@ -1352,9 +1356,19 @@ class ObjCInstance:
         # Store new object in the dictionary of cached objects, keyed
         # by the (integer) memory address pointed to by the object_ptr.
         cls._cached_objects[object_ptr.value] = objc_instance
+
+        # Tagged pointers are value-encoded Objective-C objects, not heap
+        # allocations.  They do not receive normal dealloc messages, so a
+        # retained dealloc observer would never be released.  The weak Python
+        # cache is enough for them.
+        if not _is_objc_tagged_pointer(object_ptr):
+            _set_cache_dealloc_observer(objc_instance)
         return objc_instance
 
     def release(self):
+        if not self.is_valid:
+            return
+
         self._retained = False
         send_message(self, "release")
 
@@ -1375,8 +1389,22 @@ class ObjCInstance:
 
         If we are retaining an allocation, release it.
         """
-        if self._retained:
+        if self._retained and self.is_valid:
             send_message(self, "release")
+
+    @property
+    def is_valid(self) -> bool:
+        """Return True if this wrapper still represents the current native object."""
+        return self._cached_objects.get(self.ptr.value) is self
+
+    def matches_native_class(self) -> bool:
+        """Return True if the pointer's current ObjC class matches this wrapper.
+
+        This is a diagnostic helper.  It calls ``object_getClass`` and should
+        not be used in hot paths.
+        """
+        native_class = c_void_p(objc.object_getClass(self.ptr))
+        return native_class.value == self.objc_class.ptr.value
 
     def associate(self, name: str, obj: Any):
         """Associate a Python object to the Objective-C instance with the given name.
@@ -1387,6 +1415,9 @@ class ObjCInstance:
         _set_dealloc_observer(self, name, obj)
 
     def __repr__(self):
+        if not self.is_valid:
+            return "<ObjCInstance %#x: deallocated %s at %s>" % (id(self), self.objc_class.name, str(self.ptr.value))
+
         if self.objc_class.name == b'NSCFString':
             # Display contents of NSString objects
             from .cocoalibs import cfstring_to_string
@@ -1400,6 +1431,10 @@ class ObjCInstance:
 
         This is only called when the name doesn't exist in __dict__.
         """
+        if not self.is_valid:
+            msg = f'Cannot access {name!r} on deallocated Objective-C object {self!r}'
+            raise ReferenceError(msg)
+
         # Search for named instance method in the class object and if it
         # exists, return callable object with self as hidden argument.
         # Note: you should give self and not self.ptr as a parameter to
@@ -1611,15 +1646,19 @@ class ObjCSubclass:
 ######################################################################
 
 _dealloc_argtype = [c_void_p]  # Just to prevent list creation every call.
+_cache_dealloc_argtypes = [c_void_p, c_void_p]
 
 # Cache Python objects we want to keep when associating with an instance.
 _python_objects = {}
 
-# Instances of DeallocationObserver are associated with every
-# Objective-C object that gets wrapped inside an ObjCInstance.
-# Their sole purpose is to watch for when the Objective-C object
-# is deallocated, and then remove the object from the dictionary
-# of cached ObjCInstance objects kept by the ObjCInstance class.
+# DeallocationObserver is used in two places:
+# - ObjCInstance cache observer: stores only the native ObjC pointer address
+#   in cached_object.  It does not pin any Python object; it only removes the
+#   stale address from ObjCInstance._cached_objects when Objective-C deallocs.
+# - ObjCInstance.associate observer: stores id(python_obj) in observed_object
+#   and keeps python_obj alive in _python_objects until the association is
+#   replaced or the native object is deallocated.  The value may be any Python
+#   object, not just a pointer-like object.
 #
 # The methods of the class defined below are decorated with
 # rawmethod() instead of method() because DeallocationObservers
@@ -1630,21 +1669,34 @@ _python_objects = {}
 class DeallocationObserver_Implementation:
     DeallocationObserver = ObjCSubclass('NSObject', 'DeallocationObserver', register=False)
     DeallocationObserver.add_ivar('observed_object', c_void_p)
+    DeallocationObserver.add_ivar('cached_object', c_void_p)
     DeallocationObserver.register()
 
     @DeallocationObserver.rawmethod('@@')
-    def initWithObjectId_(self, cmd, objc_ptr):
+    def initWithObjectId_(self, cmd, python_obj_id):
+        return DeallocationObserver_Implementation.initWithObjectId_cachedObject_(self, cmd, python_obj_id, 0)
+
+    @DeallocationObserver.rawmethod('@@@')
+    def initWithObjectId_cachedObject_(self, cmd, python_obj_id, cached_objc_ptr):
         self = send_super(self, 'init')
         if self is not None:
-            py_obj = cast(objc_ptr, py_object)
-            _python_objects[(self.value, objc_ptr)] = py_obj.value
-            set_instance_variable(self, 'observed_object', objc_ptr, c_void_p)
+            # python_obj_id is id(python_obj) passed as an opaque pointer-sized
+            # value.  Keeping the actual object in _python_objects is what
+            # prevents it from being garbage collected while associated.
+            if python_obj_id:
+                py_obj = cast(python_obj_id, py_object)
+                _python_objects[(self.value, python_obj_id)] = py_obj.value
+                set_instance_variable(self, 'observed_object', python_obj_id, c_void_p)
+
+            # cached_objc_ptr is the native ObjC object's address.  It is used
+            # only to remove stale wrappers from ObjCInstance._cached_objects
+            # when Objective-C deallocates the native object.
+            set_instance_variable(self, 'cached_object', cached_objc_ptr, c_void_p)
         return self.value
 
     @DeallocationObserver.rawmethod('v')
     def dealloc(self, cmd):
-        if objc_ptr := get_instance_variable(self, 'observed_object', c_void_p):
-            del _python_objects[(self, objc_ptr)]
+        _dealloc_observer_cleanup(self)
 
         send_super(self, "dealloc")
 
@@ -1655,32 +1707,67 @@ class DeallocationObserver_Implementation:
         # objc_startCollectorThread(), so probably not too much reason
         # to have this here, but I guess it can't hurt.)
         # _obj_observer_dealloc(self, 'finalize')
-        if objc_ptr := get_instance_variable(self, 'observed_object', c_void_p):
-            del _python_objects[(self, objc_ptr.value)]
+        _dealloc_observer_cleanup(self)
 
         send_super(self, 'finalize')
 
-def _obj_observer_dealloc(objc_obs, selector_name):
-    """Removes any cached ObjCInstances in Python to prevent memory leaks.
-    Manually break association as it's not implicitly mentioned that dealloc would break an association,
-    although we do not use the object after.
-    """
-    objc_ptr = get_instance_variable(objc_obs, 'observed_object', c_void_p)
-    if objc_ptr:
-        objc.objc_setAssociatedObject(objc_ptr, objc_obs, None, OBJC_ASSOCIATION_ASSIGN)
-        ObjCInstance._cached_objects.pop(objc_ptr, None)
 
-    send_super(objc_obs, selector_name)
+def _dealloc_observer_cleanup(observer):
+    if python_obj_id := get_instance_variable(observer, 'observed_object', c_void_p):
+        _python_objects.pop((observer, python_obj_id), None)
+
+    if cached_objc_ptr := get_instance_variable(observer, 'cached_object', c_void_p):
+        ObjCInstance._cached_objects.pop(cached_objc_ptr, None)
+
 
 def _assigned_internal_name(name: str):
     key = f'_internal.assign.{name}'
     return get_selector(key)
 
+
+def _cache_observer_internal_name():
+    return get_selector('_internal.objc_instance.dealloc_observer')
+
+
+def _is_objc_tagged_pointer(object_ptr):
+    """Return True for Objective-C tagged pointers.
+
+    Tagged pointers store small values directly in the pointer bits instead of
+    pointing to heap allocations.  Foundation commonly uses them for small
+    NSNumber and NSString values.  They are still valid Objective-C objects for
+    message sends, but they are not deallocated like normal objects.
+
+    Source: Apple objc4 runtime's objc-internal.h documents
+    _objc_isTaggedPointer and _OBJC_TAG_MASK:
+    https://github.com/apple-oss-distributions/objc4/blob/main/runtime/objc-internal.h
+    """
+    ptr = object_ptr.value if isinstance(object_ptr, c_void_p) else object_ptr
+    return bool(ptr and ((ptr & 1) or (__arm64__ and ptr & (1 << 63))))
+
+
+def _set_cache_dealloc_observer(self: ObjCInstance):
+    """Stop reusing this Python wrapper after Objective-C frees its object."""
+    observer_key = _cache_observer_internal_name()
+    if objc.objc_getAssociatedObject(self, observer_key):
+        return
+
+    observer = send_message('DeallocationObserver', 'alloc')
+    observer = send_message(
+        observer,
+        'initWithObjectId:cachedObject:',
+        0,
+        self.ptr.value,
+        argtypes=_cache_dealloc_argtypes,
+    )
+
+    objc.objc_setAssociatedObject(self, observer_key, observer, OBJC_ASSOCIATION_RETAIN)
+    send_message(observer, 'release')
+
+
 def _set_dealloc_observer(self, name, python_obj):
-    # Create a DeallocationObserver and associate it with this object.
-    # When the Objective-C object is deallocated, the observer will remove
-    # the ObjCInstance corresponding to the object from the cached objects
-    # dictionary, effectively destroying the ObjCInstance.
+    # Create a DeallocationObserver and associate it with this object.  The
+    # observer keeps the Python object alive until this association is replaced
+    # or the Objective-C object is deallocated.
     observer = send_message('DeallocationObserver', 'alloc')
     observer = send_message(observer, 'initWithObjectId:', id(python_obj), argtypes=_dealloc_argtype)
 
@@ -1691,11 +1778,6 @@ def _set_dealloc_observer(self, name, python_obj):
     # object is deallocated.
     send_message(observer, 'release')
     return observer
-
-
-def _remove_dealloc_observer(objc_ptr):
-    observer = objc_ptr._observer
-    objc.objc_setAssociatedObject(objc_ptr, observer, None, OBJC_ASSOCIATION_RETAIN)
 
 
 @contextmanager
@@ -1754,4 +1836,3 @@ class ObjCBlock:
 
     def _wrapper(self, _block, *args):
         return self.func(*args)
-

--- a/tests/unit/platform/test_mac_objc.py
+++ b/tests/unit/platform/test_mac_objc.py
@@ -10,12 +10,24 @@ pytestmark = require_platform(Platform.OSX)
 
 if pyglet.compat_platform in ("darwin",):
     from pyglet.libs.darwin import AutoReleasePool, ObjCSubclass, ObjCClass
-    from pyglet.libs.darwin.cocoapy.runtime import get_cached_instances, send_super
+    from pyglet.libs.darwin.cocoapy.runtime import (
+        _cache_observer_internal_name,
+        _is_objc_tagged_pointer,
+        get_cached_instances,
+        objc,
+        send_super,
+    )
 
     NSObject = ObjCClass('NSObject')
+    NSNumber = ObjCClass('NSNumber')
+    NSDate = ObjCClass('NSDate')
 
 
 class ObjCIntegrationTest(unittest.TestCase):
+    @staticmethod
+    def _has_cached_pointer(ptr):
+        return any(obj.ptr.value == ptr for _, _, _, obj in get_cached_instances())
+
     def test_objc_leak_gc(self):
         """Test deleting """
         start_count = len(get_cached_instances())
@@ -37,6 +49,137 @@ class ObjCIntegrationTest(unittest.TestCase):
         self.assertIs(test_object._retained, False)
 
         del test_object
+
+        self.assertEqual(len(get_cached_instances()), start_count)
+
+    def test_objc_cache_invalidates_on_manual_release_with_live_wrapper(self):
+        """A native release must evict the wrapper cache even if Python still holds the wrapper."""
+        start_count = len(get_cached_instances())
+
+        test_object = NSObject.alloc().init()
+        ptr = test_object.ptr.value
+
+        self.assertTrue(self._has_cached_pointer(ptr))
+
+        test_object.release()
+
+        self.assertFalse(self._has_cached_pointer(ptr))
+
+        reused_pointer = False
+        for _ in range(1000):
+            candidate = NSObject.alloc().init()
+
+            try:
+                if candidate.ptr.value == ptr:
+                    reused_pointer = True
+                    self.assertIsNot(candidate, test_object)
+                    break
+            finally:
+                candidate.release()
+
+        if not reused_pointer:
+            self.skipTest("Objective-C runtime did not reuse the released pointer.")
+
+        del test_object
+        gc.collect()
+
+        self.assertEqual(len(get_cached_instances()), start_count)
+
+    def test_objc_matches_native_class_debug_helper(self):
+        """The opt-in debug helper should report the current native class for a live wrapper."""
+        start_count = len(get_cached_instances())
+
+        test_object = NSObject.alloc().init()
+
+        self.assertTrue(test_object.matches_native_class())
+
+        test_object.release()
+        del test_object
+        gc.collect()
+
+        self.assertEqual(len(get_cached_instances()), start_count)
+
+    def test_objc_deallocated_wrapper_rejects_selector_messages(self):
+        """Stale wrappers should fail before sending selectors to a reused native address."""
+        start_count = len(get_cached_instances())
+
+        test_object = NSObject.alloc().init()
+        description = test_object.description
+
+        test_object.release()
+
+        with self.assertRaises(ReferenceError):
+            description()
+
+        with self.assertRaises(ReferenceError):
+            test_object.description()
+
+        del test_object
+        gc.collect()
+
+        self.assertEqual(len(get_cached_instances()), start_count)
+
+    def test_objc_cache_invalidates_on_autorelease_with_live_wrapper(self):
+        """Autorelease pool pop must evict wrappers while Python references are still alive."""
+        start_count = len(get_cached_instances())
+
+        with AutoReleasePool():
+            test_object = NSObject.alloc().init().autorelease()
+            ptr = test_object.ptr.value
+
+            self.assertTrue(self._has_cached_pointer(ptr))
+
+        self.assertFalse(self._has_cached_pointer(ptr))
+
+        del test_object
+        gc.collect()
+
+        self.assertEqual(len(get_cached_instances()), start_count)
+
+    def test_objc_heap_autorelease_churn_does_not_grow_cache(self):
+        """Repeated heap autorelease objects should leave no wrapper cache entries after pool drain."""
+        start_count = len(get_cached_instances())
+
+        for _ in range(1000):
+            with AutoReleasePool():
+                NSObject.alloc().init().autorelease()
+
+        gc.collect()
+
+        self.assertEqual(len(get_cached_instances()), start_count)
+
+    def test_objc_cache_does_not_observe_tagged_pointers(self):
+        """Tagged pointers are value encoded and should not receive retained dealloc observers."""
+        tagged_number = NSNumber.numberWithInt_(1)
+        ptr = tagged_number.ptr.value
+
+        if not _is_objc_tagged_pointer(tagged_number.ptr):
+            self.skipTest("Objective-C runtime did not use a tagged pointer for this NSNumber.")
+
+        observer = objc.objc_getAssociatedObject(tagged_number, _cache_observer_internal_name())
+        self.assertFalse(observer)
+
+        del tagged_number
+        gc.collect()
+
+        self.assertFalse(self._has_cached_pointer(ptr))
+
+    def test_objc_tagged_pointer_churn_does_not_grow_cache(self):
+        """Repeated tagged values should not accumulate cached wrappers like the old pool tracking did."""
+        start_count = len(get_cached_instances())
+        saw_tagged_date = False
+
+        for _ in range(1000):
+            with AutoReleasePool():
+                date = NSDate.dateWithTimeIntervalSinceNow_(0.001)
+                saw_tagged_date = saw_tagged_date or _is_objc_tagged_pointer(date.ptr)
+
+            del date
+
+        gc.collect()
+
+        if not saw_tagged_date:
+            self.skipTest("Objective-C runtime did not use tagged pointers for generated NSDate values.")
 
         self.assertEqual(len(get_cached_instances()), start_count)
 
@@ -107,6 +250,7 @@ class ObjCIntegrationTest(unittest.TestCase):
             gc.collect()
 
             self.assertIs(test_object.data, data_ref())
+            self.assertTrue(self._has_cached_pointer(test_object.ptr.value))
 
             del test_object
             gc.collect()

--- a/tests/unit/platform/test_mac_objc.py
+++ b/tests/unit/platform/test_mac_objc.py
@@ -99,17 +99,16 @@ class ObjCIntegrationTest(unittest.TestCase):
 
         self.assertEqual(len(get_cached_instances()), start_count)
 
-    def test_objc_deallocated_wrapper_rejects_selector_messages(self):
-        """Stale wrappers should fail before sending selectors to a reused native address."""
+    def test_objc_deallocated_wrapper_is_invalid(self):
+        """A released native object should mark the existing Python wrapper invalid."""
         start_count = len(get_cached_instances())
 
         test_object = NSObject.alloc().init()
-        description = test_object.description
+        self.assertTrue(test_object.is_valid)
 
         test_object.release()
 
-        with self.assertRaises(ReferenceError):
-            description()
+        self.assertFalse(test_object.is_valid)
 
         with self.assertRaises(ReferenceError):
             test_object.description()


### PR DESCRIPTION
This addresses #1465.

Explicitly cleanup controllers and their objective C instances when disconnected.

Also further additions to cocoapy to prevent further cache collisions. Restores previous cache observer behavior, but now detect and omit the tagged pointers that were previously building up and not get deallocated. Add additional tests to ensure build up is not occurring. 