### PR TITLE
Preserve fractional Win32 refresh rates

### DIFF
--- a/pyglet/display/base.py
+++ b/pyglet/display/base.py
@@ -264,8 +264,8 @@ class ScreenMode:
     depth: int = None
     """Pixel color depth, in bits per pixel."""
 
-    rate: int = None
-    """Screen refresh rate in Hz."""
+    rate: int | float | None = None
+    """Screen refresh rate in Hz. May be fractional when provided by the operating system."""
 
     def __init__(self, screen: Screen) -> None:
         self.screen = screen

--- a/pyglet/display/win32.py
+++ b/pyglet/display/win32.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
 
 _ERROR_SUCCESS = 0
 _ERROR_INSUFFICIENT_BUFFER = 122
-_QUERY_DISPLAY_CONFIG_RETRIES = 3
 
 
 def set_dpi_awareness() -> None:
@@ -107,7 +106,7 @@ class Win32Screen(Screen):  # noqa: D101
 
     def _get_display_config_path(self) -> DISPLAYCONFIG_PATH_INFO | None:
         """Get the active Display Configuration path for this screen."""
-        for _ in range(_QUERY_DISPLAY_CONFIG_RETRIES):
+        while True:
             path_count = UINT32()
             mode_count = UINT32()
 
@@ -153,7 +152,6 @@ class Win32Screen(Screen):  # noqa: D101
                     return path
 
             return None
-        return None
 
     def _get_friendly_name_display_config_api(self) -> str:
         """Get the friendly name of a monitor using the newer Display Configuration API.

--- a/pyglet/display/win32.py
+++ b/pyglet/display/win32.py
@@ -43,6 +43,10 @@ if WINDOWS_8_1_OR_GREATER:
 if TYPE_CHECKING:
     from ctypes.wintypes import HDC, HMONITOR, LPARAM, LPRECT
 
+_ERROR_SUCCESS = 0
+_ERROR_INSUFFICIENT_BUFFER = 122
+_QUERY_DISPLAY_CONFIG_RETRIES = 3
+
 
 def set_dpi_awareness() -> None:
     """Setting DPI varies per Windows version.
@@ -101,6 +105,56 @@ class Win32Screen(Screen):  # noqa: D101
         info = self._get_monitor_info()
         return info.dwFlags & MONITORINFOF_PRIMARY
 
+    def _get_display_config_path(self) -> DISPLAYCONFIG_PATH_INFO | None:
+        """Get the active Display Configuration path for this screen."""
+        for _ in range(_QUERY_DISPLAY_CONFIG_RETRIES):
+            path_count = UINT32()
+            mode_count = UINT32()
+
+            result = _user32.GetDisplayConfigBufferSizes(
+                QDC_ONLY_ACTIVE_PATHS,
+                ctypes.byref(path_count),
+                ctypes.byref(mode_count),
+            )
+            if result != _ERROR_SUCCESS:
+                return None
+
+            paths = (DISPLAYCONFIG_PATH_INFO * path_count.value)()
+            modes = ctypes.create_string_buffer(64 * mode_count.value)  # dummy buffer
+
+            result = _user32.QueryDisplayConfig(
+                QDC_ONLY_ACTIVE_PATHS,
+                ctypes.byref(path_count),
+                paths,
+                ctypes.byref(mode_count),
+                modes,
+                0,
+            )
+            if result == _ERROR_INSUFFICIENT_BUFFER:
+                continue
+            if result != _ERROR_SUCCESS:
+                return None
+
+            for path in paths[: path_count.value]:
+                if not path.targetInfo.targetAvailable:
+                    continue
+
+                source_name = DISPLAYCONFIG_SOURCE_DEVICE_NAME()
+                source_name.header.adapterId = path.sourceInfo.adapterId
+                source_name.header.id = path.sourceInfo.id
+                source_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME
+                source_name.header.size = ctypes.sizeof(source_name)
+
+                result = _user32.DisplayConfigGetDeviceInfo(ctypes.byref(source_name.header))
+                if result != _ERROR_SUCCESS:
+                    continue
+
+                if source_name.viewGdiDeviceName.casefold() == self._device_name.casefold():
+                    return path
+
+            return None
+        return None
+
     def _get_friendly_name_display_config_api(self) -> str:
         """Get the friendly name of a monitor using the newer Display Configuration API.
 
@@ -108,54 +162,34 @@ class Win32Screen(Screen):  # noqa: D101
 
         Requires Windows Vista or higher.
         """
-        path_count = UINT32()
-        mode_count = UINT32()
-
-        result = _user32.GetDisplayConfigBufferSizes(
-            QDC_ONLY_ACTIVE_PATHS, ctypes.byref(path_count), ctypes.byref(mode_count),
-        )
-        if result != 0:
+        path = self._get_display_config_path()
+        if path is None:
             return "Unknown"
 
-        paths = (DISPLAYCONFIG_PATH_INFO * path_count.value)()
-        modes = ctypes.create_string_buffer(64 * mode_count.value)  # dummy buffer
+        target_name = DISPLAYCONFIG_TARGET_DEVICE_NAME()
 
-        result = _user32.QueryDisplayConfig(
-            QDC_ONLY_ACTIVE_PATHS, ctypes.byref(path_count), paths, ctypes.byref(mode_count), modes, 0,
-        )
-        if result != 0:
-            return "Unknown"
+        target_name.header.adapterId = path.targetInfo.adapterId
+        target_name.header.id = path.targetInfo.id
+        target_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME
+        target_name.header.size = ctypes.sizeof(target_name)
 
-        for i in range(path_count.value):
-            path = paths[i]
-
-            source_name = DISPLAYCONFIG_SOURCE_DEVICE_NAME()
-            source_name.header.adapterId = path.sourceInfo.adapterId
-            source_name.header.id = path.sourceInfo.id
-            source_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME
-            source_name.header.size = ctypes.sizeof(source_name)
-
-            result = _user32.DisplayConfigGetDeviceInfo(ctypes.byref(source_name.header))
-            if result != 0:
-                continue
-
-            if source_name.viewGdiDeviceName != self._device_name:
-                continue
-
-            if not path.targetInfo.targetAvailable:
-                  continue
-
-            target_name = DISPLAYCONFIG_TARGET_DEVICE_NAME()
-
-            target_name.header.adapterId = path.targetInfo.adapterId
-            target_name.header.id = path.targetInfo.id
-            target_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME
-            target_name.header.size = ctypes.sizeof(target_name)
-
-            if _user32.DisplayConfigGetDeviceInfo(ctypes.byref(target_name.header)) == 0:
-                return target_name.monitorFriendlyDeviceName
-
+        if _user32.DisplayConfigGetDeviceInfo(ctypes.byref(target_name.header)) == _ERROR_SUCCESS:
+            return target_name.monitorFriendlyDeviceName
         return "Unknown"
+
+    def _get_refresh_rate_display_config_api(self) -> float | None:
+        """Get the precise refresh rate of the current display path."""
+        path = self._get_display_config_path()
+        if path is None:
+            return None
+
+        refresh_rate = path.targetInfo.refreshRate
+        numerator = int(refresh_rate.Numerator)
+        denominator = int(refresh_rate.Denominator)
+        if numerator <= 0 or denominator <= 0:
+            return None
+        rate = numerator / denominator
+        return rate if rate >= 1 else None
 
     def _get_friendly_name(self) -> str:
         if WINDOWS_VISTA_OR_GREATER:
@@ -214,6 +248,7 @@ class Win32Screen(Screen):  # noqa: D101
 
     def get_modes(self) -> list[Win32ScreenMode]:
         device_name = self.get_device_name()
+        current_mode, current_rate = self._get_current_mode()
         i = 0
         modes = []
         while True:
@@ -223,18 +258,33 @@ class Win32Screen(Screen):  # noqa: D101
             if not r:
                 break
 
-            modes.append(Win32ScreenMode(self, mode))
+            rate = current_rate if self._same_mode(mode, current_mode) else None
+            modes.append(Win32ScreenMode(self, mode, rate))
             i += 1
 
         return modes
 
     def get_mode(self) -> Win32ScreenMode:
+        mode, rate = self._get_current_mode()
+        return Win32ScreenMode(self, mode, rate)
+
+    def _get_current_mode(self) -> tuple[DEVMODE, float | None]:
+        """Get the current legacy display mode and precise active-path rate."""
         mode = DEVMODE()
         mode.dmSize = sizeof(DEVMODE)
-        _user32.EnumDisplaySettingsW(self.get_device_name(),
-                                     ENUM_CURRENT_SETTINGS,
-                                     byref(mode))
-        return Win32ScreenMode(self, mode)
+        _user32.EnumDisplaySettingsW(self.get_device_name(), ENUM_CURRENT_SETTINGS, byref(mode))
+        rate = self._get_refresh_rate_display_config_api() if WINDOWS_VISTA_OR_GREATER else None
+        return mode, rate
+
+    @staticmethod
+    def _same_mode(first: DEVMODE, second: DEVMODE) -> bool:
+        """Return whether two legacy mode records describe the same mode."""
+        return (
+            first.dmPelsWidth == second.dmPelsWidth
+            and first.dmPelsHeight == second.dmPelsHeight
+            and first.dmBitsPerPel == second.dmBitsPerPel
+            and first.dmDisplayFrequency == second.dmDisplayFrequency
+        )
 
     def set_mode(self, mode: Win32ScreenMode) -> None:
         assert mode.screen is self
@@ -260,14 +310,16 @@ _win32_scale_name = {
     1: "center",
     2: "stretch",
 }
+
+
 class Win32ScreenMode(ScreenMode):  # noqa: D101
-    def __init__(self, screen: Win32Screen, mode: DEVMODE) -> None:  # noqa: D107
+    def __init__(self, screen: Win32Screen, mode: DEVMODE, rate: float | None = None) -> None:  # noqa: D107
         super().__init__(screen)
         self._mode = mode
         self.width = mode.dmPelsWidth
         self.height = mode.dmPelsHeight
         self.depth = mode.dmBitsPerPel
-        self.rate = mode.dmDisplayFrequency
+        self.rate = rate if rate is not None else mode.dmDisplayFrequency
         self.scaling = mode.dmDisplayFixedOutput
 
     def __repr__(self) -> str:

--- a/pyglet/display/win32.py
+++ b/pyglet/display/win32.py
@@ -162,19 +162,53 @@ class Win32Screen(Screen):  # noqa: D101
 
         Requires Windows Vista or higher.
         """
-        path = self._get_display_config_path()
-        if path is None:
+        path_count = UINT32()
+        mode_count = UINT32()
+
+        result = _user32.GetDisplayConfigBufferSizes(
+            QDC_ONLY_ACTIVE_PATHS, ctypes.byref(path_count), ctypes.byref(mode_count),
+        )
+        if result != 0:
             return "Unknown"
 
-        target_name = DISPLAYCONFIG_TARGET_DEVICE_NAME()
+        paths = (DISPLAYCONFIG_PATH_INFO * path_count.value)()
+        modes = ctypes.create_string_buffer(64 * mode_count.value)  # dummy buffer
 
-        target_name.header.adapterId = path.targetInfo.adapterId
-        target_name.header.id = path.targetInfo.id
-        target_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME
-        target_name.header.size = ctypes.sizeof(target_name)
+        result = _user32.QueryDisplayConfig(
+            QDC_ONLY_ACTIVE_PATHS, ctypes.byref(path_count), paths, ctypes.byref(mode_count), modes, 0,
+        )
+        if result != 0:
+            return "Unknown"
 
-        if _user32.DisplayConfigGetDeviceInfo(ctypes.byref(target_name.header)) == _ERROR_SUCCESS:
-            return target_name.monitorFriendlyDeviceName
+        for i in range(path_count.value):
+            path = paths[i]
+
+            source_name = DISPLAYCONFIG_SOURCE_DEVICE_NAME()
+            source_name.header.adapterId = path.sourceInfo.adapterId
+            source_name.header.id = path.sourceInfo.id
+            source_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME
+            source_name.header.size = ctypes.sizeof(source_name)
+
+            result = _user32.DisplayConfigGetDeviceInfo(ctypes.byref(source_name.header))
+            if result != 0:
+                continue
+
+            if source_name.viewGdiDeviceName != self._device_name:
+                continue
+
+            if not path.targetInfo.targetAvailable:
+                  continue
+
+            target_name = DISPLAYCONFIG_TARGET_DEVICE_NAME()
+
+            target_name.header.adapterId = path.targetInfo.adapterId
+            target_name.header.id = path.targetInfo.id
+            target_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME
+            target_name.header.size = ctypes.sizeof(target_name)
+
+            if _user32.DisplayConfigGetDeviceInfo(ctypes.byref(target_name.header)) == 0:
+                return target_name.monitorFriendlyDeviceName
+
         return "Unknown"
 
     def _get_refresh_rate_display_config_api(self) -> float | None:
@@ -248,7 +282,7 @@ class Win32Screen(Screen):  # noqa: D101
 
     def get_modes(self) -> list[Win32ScreenMode]:
         device_name = self.get_device_name()
-        current_mode, current_rate = self._get_current_mode()
+        current_mode = self.get_mode()
         i = 0
         modes = []
         while True:
@@ -258,23 +292,20 @@ class Win32Screen(Screen):  # noqa: D101
             if not r:
                 break
 
-            rate = current_rate if self._same_mode(mode, current_mode) else None
+            rate = current_mode.rate if self._same_mode(mode, current_mode._mode) else None
             modes.append(Win32ScreenMode(self, mode, rate))
             i += 1
 
         return modes
 
     def get_mode(self) -> Win32ScreenMode:
-        mode, rate = self._get_current_mode()
-        return Win32ScreenMode(self, mode, rate)
-
-    def _get_current_mode(self) -> tuple[DEVMODE, float | None]:
-        """Get the current legacy display mode and precise active-path rate."""
         mode = DEVMODE()
         mode.dmSize = sizeof(DEVMODE)
-        _user32.EnumDisplaySettingsW(self.get_device_name(), ENUM_CURRENT_SETTINGS, byref(mode))
+        _user32.EnumDisplaySettingsW(self.get_device_name(),
+                                     ENUM_CURRENT_SETTINGS,
+                                     byref(mode))
         rate = self._get_refresh_rate_display_config_api() if WINDOWS_VISTA_OR_GREATER else None
-        return mode, rate
+        return Win32ScreenMode(self, mode, rate)
 
     @staticmethod
     def _same_mode(first: DEVMODE, second: DEVMODE) -> bool:
@@ -310,8 +341,6 @@ _win32_scale_name = {
     1: "center",
     2: "stretch",
 }
-
-
 class Win32ScreenMode(ScreenMode):  # noqa: D101
     def __init__(self, screen: Win32Screen, mode: DEVMODE, rate: float | None = None) -> None:  # noqa: D107
         super().__init__(screen)

--- a/pyglet/display/win32.py
+++ b/pyglet/display/win32.py
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
 _ERROR_SUCCESS = 0
 _ERROR_INSUFFICIENT_BUFFER = 122
 
+# sizeof(DISPLAYCONFIG_MODE_INFO). Mode data is not used, but the API requires a buffer for it.
+_DISPLAYCONFIG_MODE_INFO_SIZE = 64
+
 
 def set_dpi_awareness() -> None:
     """Setting DPI varies per Windows version.
@@ -104,8 +107,16 @@ class Win32Screen(Screen):  # noqa: D101
         info = self._get_monitor_info()
         return info.dwFlags & MONITORINFOF_PRIMARY
 
-    def _get_display_config_path(self) -> DISPLAYCONFIG_PATH_INFO | None:
-        """Get the active Display Configuration path for this screen."""
+    @staticmethod
+    def _query_active_display_paths() -> list[DISPLAYCONFIG_PATH_INFO]:
+        """Query the currently active Display Configuration paths.
+
+        ``GetDisplayConfigBufferSizes`` only reports the sizes required at the moment it is
+        called. If the display topology changes before ``QueryDisplayConfig`` runs, the buffers
+        may no longer be large enough and it fails with ``ERROR_INSUFFICIENT_BUFFER``. In that
+        case the sizes have to be queried again and larger buffers allocated, so each attempt
+        re-runs the size query and reallocates.
+        """
         while True:
             path_count = UINT32()
             mode_count = UINT32()
@@ -116,10 +127,10 @@ class Win32Screen(Screen):  # noqa: D101
                 ctypes.byref(mode_count),
             )
             if result != _ERROR_SUCCESS:
-                return None
+                return []
 
             paths = (DISPLAYCONFIG_PATH_INFO * path_count.value)()
-            modes = ctypes.create_string_buffer(64 * mode_count.value)  # dummy buffer
+            modes = ctypes.create_string_buffer(_DISPLAYCONFIG_MODE_INFO_SIZE * mode_count.value)
 
             result = _user32.QueryDisplayConfig(
                 QDC_ONLY_ACTIVE_PATHS,
@@ -131,27 +142,33 @@ class Win32Screen(Screen):  # noqa: D101
             )
             if result == _ERROR_INSUFFICIENT_BUFFER:
                 continue
+
             if result != _ERROR_SUCCESS:
-                return None
+                return []
 
-            for path in paths[: path_count.value]:
-                if not path.targetInfo.targetAvailable:
-                    continue
+            # QueryDisplayConfig may fill in fewer paths than were allocated.
+            return paths[:path_count.value]
 
-                source_name = DISPLAYCONFIG_SOURCE_DEVICE_NAME()
-                source_name.header.adapterId = path.sourceInfo.adapterId
-                source_name.header.id = path.sourceInfo.id
-                source_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME
-                source_name.header.size = ctypes.sizeof(source_name)
+    def _get_display_config_path(self) -> DISPLAYCONFIG_PATH_INFO | None:
+        """Get the active Display Configuration path for this screen."""
+        for path in self._query_active_display_paths():
+            if not path.targetInfo.targetAvailable:
+                continue
 
-                result = _user32.DisplayConfigGetDeviceInfo(ctypes.byref(source_name.header))
-                if result != _ERROR_SUCCESS:
-                    continue
+            source_name = DISPLAYCONFIG_SOURCE_DEVICE_NAME()
+            source_name.header.adapterId = path.sourceInfo.adapterId
+            source_name.header.id = path.sourceInfo.id
+            source_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME
+            source_name.header.size = ctypes.sizeof(source_name)
 
-                if source_name.viewGdiDeviceName.casefold() == self._device_name.casefold():
-                    return path
+            result = _user32.DisplayConfigGetDeviceInfo(ctypes.byref(source_name.header))
+            if result != _ERROR_SUCCESS:
+                continue
 
-            return None
+            if source_name.viewGdiDeviceName.casefold() == self._device_name.casefold():
+                return path
+
+        return None
 
     def _get_friendly_name_display_config_api(self) -> str:
         """Get the friendly name of a monitor using the newer Display Configuration API.

--- a/tests/unit/platform/test_win32_display.py
+++ b/tests/unit/platform/test_win32_display.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import ctypes
+from types import SimpleNamespace
+import sys
+
+import pytest
+
+if sys.platform != 'win32':
+    pytest.skip('Win32 display tests require Windows', allow_module_level=True)
+
+from pyglet.display import win32
+from pyglet.libs.win32.types import (
+    DEVMODE,
+    DISPLAYCONFIG_PATH_INFO,
+    DISPLAYCONFIG_SOURCE_DEVICE_NAME,
+)
+
+
+def _screen(device_name=r'\\.\DISPLAY1'):
+    screen = object.__new__(win32.Win32Screen)
+    screen._device_name = device_name
+    return screen
+
+
+def _path(source_id, numerator=120_000, denominator=1_001, available=True):
+    path = DISPLAYCONFIG_PATH_INFO()
+    path.sourceInfo.id = source_id
+    path.targetInfo.id = source_id
+    path.targetInfo.targetAvailable = available
+    path.targetInfo.refreshRate.Numerator = numerator
+    path.targetInfo.refreshRate.Denominator = denominator
+    return path
+
+
+def test_display_config_path_matches_gdi_device_name(monkeypatch):
+    paths = (_path(1), _path(2))
+    names = {
+        1: r'\\.\DISPLAY2',
+        2: r'\\.\DISPLAY1',
+    }
+
+    def get_buffer_sizes(_flags, path_count, mode_count):
+        path_count._obj.value = len(paths)
+        mode_count._obj.value = 1
+        return 0
+
+    def query_display_config(_flags, path_count, output_paths, _mode_count, _modes, _topology):
+        for index, path in enumerate(paths):
+            output_paths[index] = path
+        path_count._obj.value = len(paths)
+        return 0
+
+    def get_device_info(header):
+        source = ctypes.cast(
+            header,
+            ctypes.POINTER(DISPLAYCONFIG_SOURCE_DEVICE_NAME),
+        ).contents
+        source.viewGdiDeviceName = names[source.header.id]
+        return 0
+
+    monkeypatch.setattr(win32._user32, 'GetDisplayConfigBufferSizes', get_buffer_sizes)
+    monkeypatch.setattr(win32._user32, 'QueryDisplayConfig', query_display_config)
+    monkeypatch.setattr(win32._user32, 'DisplayConfigGetDeviceInfo', get_device_info)
+
+    selected = _screen()._get_display_config_path()
+
+    assert selected is not None
+    assert selected.sourceInfo.id == 2
+
+
+def test_display_config_query_retries_changed_buffer(monkeypatch):
+    query_results = iter((win32._ERROR_INSUFFICIENT_BUFFER, 0))
+
+    def get_buffer_sizes(_flags, path_count, mode_count):
+        path_count._obj.value = 0
+        mode_count._obj.value = 0
+        return 0
+
+    monkeypatch.setattr(win32._user32, 'GetDisplayConfigBufferSizes', get_buffer_sizes)
+    monkeypatch.setattr(
+        win32._user32,
+        'QueryDisplayConfig',
+        lambda *_args: next(query_results),
+    )
+
+    assert _screen()._get_display_config_path() is None
+
+
+@pytest.mark.parametrize(
+    ('numerator', 'denominator'),
+    [
+        (0, 1_001),
+        (120_000, 0),
+        (1, 2),
+    ],
+)
+def test_refresh_rate_rejects_invalid_rationals(monkeypatch, numerator, denominator):
+    monkeypatch.setattr(
+        win32.Win32Screen,
+        '_get_display_config_path',
+        lambda _self: _path(1, numerator, denominator),
+    )
+
+    assert _screen()._get_refresh_rate_display_config_api() is None
+
+
+def test_refresh_rate_preserves_fractional_value(monkeypatch):
+    monkeypatch.setattr(
+        win32.Win32Screen,
+        '_get_display_config_path',
+        lambda _self: _path(1),
+    )
+
+    assert _screen()._get_refresh_rate_display_config_api() == pytest.approx(
+        119.88011988011988,
+    )
+
+
+def test_screen_mode_prefers_precise_rate():
+    mode = DEVMODE()
+    mode.dmPelsWidth = 3840
+    mode.dmPelsHeight = 2160
+    mode.dmBitsPerPel = 32
+    mode.dmDisplayFrequency = 119
+
+    screen_mode = win32.Win32ScreenMode(_screen(), mode, 120_000 / 1_001)
+
+    assert screen_mode.rate == pytest.approx(119.88011988011988)
+
+
+def test_screen_mode_falls_back_to_legacy_integer_rate():
+    mode = SimpleNamespace(
+        dmPelsWidth=3840,
+        dmPelsHeight=2160,
+        dmBitsPerPel=32,
+        dmDisplayFrequency=119,
+        dmDisplayFixedOutput=0,
+    )
+
+    assert win32.Win32ScreenMode(_screen(), mode).rate == 119
+
+
+def test_same_mode_includes_legacy_refresh_rate():
+    current = DEVMODE()
+    current.dmPelsWidth = 3840
+    current.dmPelsHeight = 2160
+    current.dmBitsPerPel = 32
+    current.dmDisplayFrequency = 119
+
+    same = DEVMODE()
+    ctypes.memmove(ctypes.byref(same), ctypes.byref(current), ctypes.sizeof(current))
+    different_rate = DEVMODE()
+    ctypes.memmove(
+        ctypes.byref(different_rate),
+        ctypes.byref(current),
+        ctypes.sizeof(current),
+    )
+    different_rate.dmDisplayFrequency = 120
+
+    assert win32.Win32Screen._same_mode(current, same)
+    assert not win32.Win32Screen._same_mode(current, different_rate)
+
+
+def test_get_modes_applies_precise_rate_only_to_current_mode(monkeypatch):
+    current = DEVMODE()
+    current.dmPelsWidth = 3840
+    current.dmPelsHeight = 2160
+    current.dmBitsPerPel = 32
+    current.dmDisplayFrequency = 119
+
+    other = DEVMODE()
+    ctypes.memmove(ctypes.byref(other), ctypes.byref(current), ctypes.sizeof(current))
+    other.dmDisplayFrequency = 60
+    modes = (current, other)
+
+    def enum_display_settings(_device_name, index, output):
+        if index >= len(modes):
+            return 0
+        ctypes.memmove(output, ctypes.byref(modes[index]), ctypes.sizeof(DEVMODE))
+        return 1
+
+    screen = _screen()
+    precise_rate = 120_000 / 1_001
+    monkeypatch.setattr(screen, 'get_device_name', lambda: screen._device_name)
+    monkeypatch.setattr(screen, '_get_current_mode', lambda: (current, precise_rate))
+    monkeypatch.setattr(win32._user32, 'EnumDisplaySettingsW', enum_display_settings)
+
+    found = screen.get_modes()
+
+    assert found[0].rate == pytest.approx(119.88011988011988)
+    assert found[1].rate == 60

--- a/tests/unit/platform/test_win32_display.py
+++ b/tests/unit/platform/test_win32_display.py
@@ -183,7 +183,7 @@ def test_get_modes_applies_precise_rate_only_to_current_mode(monkeypatch):
     screen = _screen()
     precise_rate = 120_000 / 1_001
     monkeypatch.setattr(screen, 'get_device_name', lambda: screen._device_name)
-    monkeypatch.setattr(screen, '_get_current_mode', lambda: (current, precise_rate))
+    monkeypatch.setattr(screen, 'get_mode', lambda: win32.Win32ScreenMode(screen, current, precise_rate))
     monkeypatch.setattr(win32._user32, 'EnumDisplaySettingsW', enum_display_settings)
 
     found = screen.get_modes()

--- a/tests/unit/platform/test_win32_display.py
+++ b/tests/unit/platform/test_win32_display.py
@@ -69,20 +69,42 @@ def test_display_config_path_matches_gdi_device_name(monkeypatch):
     assert selected.sourceInfo.id == 2
 
 
-def test_display_config_query_retries_changed_buffer(monkeypatch):
+def test_display_config_query_reallocates_after_insufficient_buffer(monkeypatch):
+    buffer_sizes = iter(((1, 1), (2, 2)))
     query_results = iter((win32._ERROR_INSUFFICIENT_BUFFER, 0))
+    allocations = []
 
     def get_buffer_sizes(_flags, path_count, mode_count):
-        path_count._obj.value = 0
-        mode_count._obj.value = 0
+        paths, modes = next(buffer_sizes)
+        path_count._obj.value = paths
+        mode_count._obj.value = modes
+        return 0
+
+    def query_display_config(_flags, _path_count, output_paths, _mode_count, modes, _topology):
+        allocations.append((len(output_paths), len(modes)))
+        return next(query_results)
+
+    monkeypatch.setattr(win32._user32, 'GetDisplayConfigBufferSizes', get_buffer_sizes)
+    monkeypatch.setattr(win32._user32, 'QueryDisplayConfig', query_display_config)
+
+    found = win32.Win32Screen._query_active_display_paths()
+
+    # The second attempt must re-query the sizes and allocate the larger buffers.
+    assert allocations == [
+        (1, win32._DISPLAYCONFIG_MODE_INFO_SIZE),
+        (2, 2 * win32._DISPLAYCONFIG_MODE_INFO_SIZE),
+    ]
+    assert len(found) == 2
+
+
+def test_display_config_query_failure_yields_no_path(monkeypatch):
+    def get_buffer_sizes(_flags, path_count, mode_count):
+        path_count._obj.value = 1
+        mode_count._obj.value = 1
         return 0
 
     monkeypatch.setattr(win32._user32, 'GetDisplayConfigBufferSizes', get_buffer_sizes)
-    monkeypatch.setattr(
-        win32._user32,
-        'QueryDisplayConfig',
-        lambda *_args: next(query_results),
-    )
+    monkeypatch.setattr(win32._user32, 'QueryDisplayConfig', lambda *_args: 5)  # ERROR_ACCESS_DENIED
 
     assert _screen()._get_display_config_path() is None
 


### PR DESCRIPTION
## Summary

Preserve fractional refresh rates for the active Win32 display mode.

`Win32Screen.get_mode()` currently obtains `rate` from
`DEVMODE.dmDisplayFrequency`, an integer field. On a display mode exposed by
Windows as 120000/1001 Hz, that API reports 119 Hz, which causes applications
using the value for presentation timing to run at the wrong nominal rate.

This change reuses pyglet's existing Display Configuration API path lookup to:

- match the active path to the screen by its GDI source name;
- obtain the active path's rational refresh rate;
- expose that precise value from `get_mode()` and from the matching active
  entry in `get_modes()`; and
- retain the legacy `DEVMODE` rate as a fallback when the modern query is
  unavailable, fails, races with a topology change, or returns invalid data.

Inactive enumerated modes continue to use their legacy integer rates because
the Display Configuration API describes the active path rather than every
available mode.

## Validation

- Native Windows 11, CPython 3.14.6 x64
- AMD Radeon RX 7900 XT, 3840x2160 display
- Live `ScreenMode.rate` at the Windows fractional 120 Hz mode:
  `119.88011988011988` (`120000/1001`), rather than `119`
- Focused Win32 unit tests: `10 passed`
- Linux unit collection: `629 passed, 19 skipped, 2 xfailed`; the three
  remaining failures were host audio/X11 environment failures unrelated to
  display handling
- BPS Linux suite against this checkout: `372 passed`
- `git diff --check`: passed

The focused tests cover multi-monitor GDI-name matching, buffer-size retry,
malformed rationals, precise-rate preservation, legacy fallback, and applying
the precise value only to the active enumerated mode.
