### PR TITLE
Backend improvements

### DIFF
--- a/doc/modules/info.rst
+++ b/doc/modules/info.rst
@@ -1,5 +1,47 @@
+.. _pyglet-info:
+
 pyglet.info
 ===========
+
+``pyglet.info`` records system, driver, and active graphics-context details
+for bug reports::
+
+    python -m pyglet.info > info.txt
+
+Use the isolated graphics probe to test the OpenGL and OpenGL ES versions
+supported by pyglet on that machine. It also compiles pyglet's built-in
+startup shaders for each successful context::
+
+    python -m pyglet.info --probe-graphics > info.txt
+
+Test one specific request with ``--backend`` and ``--version``::
+
+    python -m pyglet.info --backend gles3 --version 3.1
+
+Command-line options
+--------------------
+
+``python -m pyglet.info`` accepts the following public options:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Purpose
+   * - ``-h``, ``--help``
+     - Show the command-line help text.
+   * - ``-extensions``
+     - Include complete graphics and audio extension lists instead of shortened previews.
+   * - ``--verbose``
+     - Include full tracebacks when a diagnostic section fails.
+   * - ``--backend BACKEND``
+     - Use ``opengl``, ``gl2``, ``gles3``, ``gles2``, ``webgl``, or ``vulkan`` for the main report.
+   * - ``--version MAJOR.MINOR``
+     - Explicitly request an OpenGL or OpenGL ES version for the main report. Requires ``--backend``; omit it to use the backend's default version.
+   * - ``--probe-graphics``
+     - Test pyglet's supported OpenGL-family requests in isolated processes and print a recommendation.
+
+The ``--graphics-worker`` option is reserved for the probe's internal subprocesses and is not part of the public CLI.
 
 .. automodule:: pyglet.info
   :members:

--- a/doc/modules/window_camera.rst
+++ b/doc/modules/window_camera.rst
@@ -1,0 +1,7 @@
+pyglet.window.camera
+====================
+
+.. automodule:: pyglet.window.camera
+  :members:
+  :imported-members:
+  :show-inheritance:

--- a/doc/programming_guide/context.rst
+++ b/doc/programming_guide/context.rst
@@ -267,6 +267,49 @@ or config, pyglet will use a default backend config with the following propertie
         * - depth_size
           - 24
 
+Recommended OpenGL-family versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For new applications, prefer a modern backend: use the driver's default/latest
+desktop OpenGL context (selected by default), or OpenGL ES 3.1 or
+newer. The ``gl2`` and ``gles2`` backends remain
+compatibility paths for systems that cannot run a modern backend; they are not
+the recommended target and are increasingly difficult to test on current
+hardware.
+
+The supported backend/version combinations are:
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Backend
+          - Supported versions
+          - Recommendation
+        * - ``opengl``
+          - OpenGL 3.3 and newer
+          - Driver default/latest
+        * - ``gles3``
+          - OpenGL ES 3.0, 3.1, and 3.2
+          - OpenGL ES 3.1 or newer
+        * - ``gl2``
+          - OpenGL 2.0 and 2.1
+          - Use ``opengl`` 3.3+ when available
+        * - ``gles2``
+          - OpenGL ES 2.0
+          - Use ``gles3`` 3.1+ when available
+
+Drivers differ in how they interpret a requested version; notably, some
+Windows drivers return a newer desktop context when a legacy 2.x context is
+requested. Treat the returned context as authoritative rather than relying on
+that upgrade behavior.
+
+.. note::
+
+   Use the :ref:`pyglet-info` graphics probe on the target computer to test
+   supported requests and obtain a recommendation.
+
+
+
 .. _guide_simple-context-configuration:
 
 Simple context configuration

--- a/doc/programming_guide/opengles.rst
+++ b/doc/programming_guide/opengles.rst
@@ -50,36 +50,55 @@ the default configuration will not have multisampling enabled.
 Textures
 ~~~~~~~~
 
-Pixel format for textures and images are limited to ``RGBA``. If you try to
-load any other pixel format through pyglet's image loading functions you
-will get an error when they are turned into OpenGL textures later.
+Textures created from pyglet images are not limited to ``RGBA``. The upload
+path retains directly supported component orders, including ``RGB`` and
+``RGBA``, and converts source data to a compatible order when necessary. In
+particular, ``BGR`` and ``BGRA`` data is uploaded directly only when the GLES
+implementation advertises a BGRA texture-format extension; otherwise pyglet
+converts it to ``RGB`` or ``RGBA`` before the upload. Legacy ``L`` and ``LA``
+images are represented with red and red/green components and texture swizzles.
 
-The reason for this limitation is that OpenGL ES does not support pixel
-format conversion during pixel transfer, meaning when calling ``glTexImage``
-to upload pixel data to the GPU, the pixel format must match the internalformat.
-In desktop OpenGL an RGB image will be automatically converted to RGBA during
-this transfer. This is not supported in OpenGL ES.
+OpenGL ES does not perform arbitrary component-order conversion as part of
+``glTexImage`` or ``glTexSubImage``. The external pixel format must be
+compatible with the texture's storage format. Pyglet therefore chooses a
+compatible external format and performs any required conversion on the CPU.
+Applications using the GL bindings directly must make the same choice and
+should check for a BGRA extension before using ``GL_BGRA``.
 
-You are, however, free to create your own textures with any pixel format
-using the gl bindings directly.
+When an image decoder can select its output format, pyglet normally requests
+``RGBA`` for OpenGL ES contexts. The exception is Windows, where pyglet may
+prefer ``BGRA`` when the active context supports direct BGRA uploads. This
+matches the native Windows decoder format and avoids a CPU conversion. Decoders
+are not required to produce the preferred format.
 
 Compute Shader
 ~~~~~~~~~~~~~~
 
-If you are planning to bind textures to image units with the intention of
-using them in a compute shader, you need to create these textures yourself
-using the gl bindings and allocate space using ``glTexStorage``. Pyglet is
-using ``glTexImage`` to allocate space and upload the pixel data for textures.
+Textures used as image units in a compute shader require immutable storage on
+OpenGL ES 3.1. Create them with ``immutable=True``::
 
-The difference here is that ``glTexStorage`` creates immutable storage. You can
-only call it once and then fill the allocated space with pixel data using
-``glTexSubImage``. ``glTexImage`` on the other hand can be called multiple times
-reallocating the texture storage each time. Likely OpenGL ES doesn't want to
-deal with the extra complexity of validating the texture storage of images
-every time a compute shader is dispatched.
+    from pyglet.enums import ComponentFormat
+    from pyglet.graphics import Texture
 
-In short: Create your own textures with immutable storage if you are planning
-to use them in a compute shader.
+    texture = Texture.create(
+        512,
+        512,
+        internal_format=ComponentFormat.RGBA,
+        internal_format_size=32,
+        internal_format_type="f",
+        blank_data=False,
+        immutable=True,
+    )
+
+The texture's dimensions, internal format, and number of mipmap levels are
+then fixed. You can still upload and update its pixel data normally. The
+texture format must match the image format declared in the shader.
+
+For GLSL ES 3.10, image formats other than ``r32f``, ``r32i``, and ``r32ui``
+also need an access qualifier. An ``rgba32f`` output image is typically
+declared as::
+
+    layout(rgba32f) writeonly uniform highp image2D output_image;
 
 Shaders
 -------

--- a/doc/programming_guide/opengles.rst
+++ b/doc/programming_guide/opengles.rst
@@ -4,9 +4,15 @@
 OpenGL ES
 =========
 
-Pyglet has experimental support for OpenGL ES 3.2, with some limitations. Devices like Raspberry Pi 4
-and 5 supports OpenGL ES 3.1 with extensions covering most of the missing 3.2 features (with the
-exception of tessellation shaders). There are likely other devices with ES support that can run Pyglet.
+Pyglet has experimental support for OpenGL ES 3.0, 3.1, and 3.2, with some limitations. OpenGL ES 3.1 or
+higher is recommended. Devices such as
+Raspberry Pi 4 and 5 commonly expose OpenGL ES 3.1, often with extensions covering portions of ES 3.2.
+
+.. tip::
+
+   Use the :ref:`pyglet-info` graphics probe on the target machine before
+   choosing a context version. It verifies candidate configurations and
+   reports a recommended request.
 
 Creating a window / context
 ---------------------------
@@ -23,8 +29,7 @@ Example::
     # Select OpenGL ES backend:
     pyglet.options.backend = "gles3"
 
-    # Specify that we want to use OpenGL ES 3.1:
-    # This is very specific to the Raspberry Pi 4 and 5. Use 3.2 if you can.
+    # Raspberry Pi 4 and 5 commonly use OpenGL ES 3.1.
     config = pyglet.config.Config()
     config.gles3.major_version = 3
     config.gles3.minor_version = 1
@@ -80,10 +85,15 @@ Shaders
 -------
 
 Pyglet's shader system supports basic conversion between GLSL 1.5/3.3 shaders
-to GLES 3.2 shaders when running in OpenGL ES mode. This is to ensure that
-pyglet's built-in shaders also works with GL ES. This system is not perfect
-and are likely to have some flaws.
+and GLES shaders when running in OpenGL ES mode. Built-in shaders are converted
+to GLSL ES 3.00 on GLES 3.0 and GLSL ES 3.10 on GLES 3.1 or newer. Precision
+qualifiers are injected using ``mediump`` by default.
 
-Currently the shaders are converted to ES 3.1 shaders as a careful approach
-manually enabling extensions needed for ES 3.2. Precisions qualifiers are
-injected using ``mediump`` by default.
+Use ``window.context.info.features`` for functionality that is not guaranteed
+by every supported ES version. For example, compute shaders and shader-storage
+buffers require GLES 3.1 (or a supported desktop equivalent)::
+
+    features = window.context.info.features
+    if features.compute_shaders and features.shader_storage_buffers:
+        # Safe to create pyglet ComputeShaderProgram objects.
+        pass

--- a/doc/programming_guide/texture.rst
+++ b/doc/programming_guide/texture.rst
@@ -85,7 +85,17 @@ Reading texture pixels back to CPU memory can be done with
 
     image_data = texture.fetch()
 
-These readbacks can be expensive, especially if done every frame.
+``fetch()`` is intended for image-oriented use. It returns unsigned-byte
+:py:class:`~pyglet.image.ImageData` and does not convert floating-point or
+integer textures. Use ``Texture.read_pixels()`` when typed values are needed::
+
+    pixels = texture.read_pixels()
+    float_values = memoryview(pixels.data).cast("f")
+
+The returned :py:class:`~pyglet.graphics.texture.PixelData` contains tightly
+packed raw bytes together with their component format and data type. Neither
+method should generally be called every frame because GPU readback can be
+expensive.
 
 Writing into textures
 ---------------------

--- a/pyglet/enums.py
+++ b/pyglet/enums.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from enum import Enum, auto
 
 
@@ -106,6 +107,18 @@ class ComponentFormat(str, Enum):
     BGRA = 'BGRA'
     L = 'L'  # Luminance (R) - Deprecated
     LA = 'LA'  # Luminance Alpha (LA) - Deprecated
+
+
+class PixelFormat(str, Enum):
+    """Sized byte formats used for image decode and pixel-transfer preferences."""
+
+    RGBA8 = "RGBA8"
+    BGRA8 = "BGRA8"
+
+    @property
+    def component_format(self) -> str:
+        """Return the corresponding :class:`ImageData` component-order string."""
+        return self.value.removesuffix("8")
 
 
 class TextureType(Enum):

--- a/pyglet/graphics/__init__.py
+++ b/pyglet/graphics/__init__.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from pyglet.graphics.shader import get_default_shader  # noqa: F401
     from pyglet.graphics.buffer import UniformBufferRegion  # noqa: F401
     from pyglet.graphics.draw import get_default_batch  # noqa: F401
-    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
+    from pyglet.graphics.texture import PixelData, Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
     from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas  # noqa: F401
     from pyglet.graphics.framebuffer import Framebuffer, RenderTexture, Renderbuffer, TextureRenderTarget  # noqa: F401
 else:
@@ -55,6 +55,6 @@ else:
     from pyglet.graphics.state import State, Viewport, ViewportProtocol  # noqa: F401
     from pyglet.graphics.api import core  # noqa: F401
     from pyglet.graphics.buffer import UniformBufferRegion  # noqa: F401
-    from pyglet.graphics.texture import Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
+    from pyglet.graphics.texture import PixelData, Texture, TextureGrid, Texture3D, TextureArray  # noqa: F401
     from pyglet.graphics.atlas import TextureBin, TextureArrayBin, TextureAtlas  # noqa: F401
     from pyglet.graphics.framebuffer import Framebuffer, RenderTexture, Renderbuffer, TextureRenderTarget  # noqa: F401

--- a/pyglet/graphics/api/base.py
+++ b/pyglet/graphics/api/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import atexit
 import os
-import sys
 import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -150,6 +149,8 @@ class SurfaceFeatures:
     separate_shader_objects: bool = False
     #: Enables asynchronous pixel transfers through pixel buffer objects.
     pixel_buffer_objects: bool = False
+    #: Enables immutable-format texture allocation through glTexStorage.
+    texture_storage: bool = False
 
 
 @dataclass(frozen=True)
@@ -285,108 +286,9 @@ class SurfaceInfo(ABC):
         """Compatibility alias for existing OpenGL callers."""
         return self.api
 
+    @abstractmethod
     def update_features(self) -> None:
-        """Populate feature and pixel-transfer support after version and extensions are known."""
-        is_desktop_gl = self.api == "opengl"
-        is_gles = self.api in ("gles2", "gles3")
-
-        def desktop_at_least(major: int, minor: int = 0) -> bool:
-            return is_desktop_gl and self.have_version(major, minor)
-
-        def gles_at_least(major: int, minor: int = 0) -> bool:
-            return is_gles and self.have_version(major, minor)
-
-        uniform_buffers = desktop_at_least(3, 1) or gles_at_least(3, 0)
-        sync_objects = (
-            desktop_at_least(3, 2)
-            or gles_at_least(3, 0)
-            or self.have_extension("GL_ARB_sync")
-        )
-        compute_shaders = (
-            desktop_at_least(4, 3)
-            or gles_at_least(3, 1)
-            or self.have_extension("GL_ARB_compute_shader")
-        )
-        shader_storage_buffers = (
-            desktop_at_least(4, 3)
-            or gles_at_least(3, 1)
-            or self.have_extension("GL_ARB_shader_storage_buffer_object")
-        )
-        geometry_shaders = (
-            desktop_at_least(3, 2)
-            or gles_at_least(3, 2)
-            or self.have_extension("GL_ARB_geometry_shader4")
-            or self.have_extension("GL_EXT_geometry_shader")
-        )
-        tessellation_shaders = (
-            desktop_at_least(4, 0)
-            or gles_at_least(3, 2)
-            or self.have_extension("GL_ARB_tessellation_shader")
-            or self.have_extension("GL_OES_tessellation_shader")
-        )
-        base_vertex = (
-            desktop_at_least(3, 2)
-            or gles_at_least(3, 2)
-            or self.have_extension("GL_ARB_draw_elements_base_vertex")
-            or self.have_extension("GL_OES_draw_elements_base_vertex")
-        )
-        persistent_buffers = desktop_at_least(4, 4) or self.have_extension("GL_ARB_buffer_storage")
-        separate_shader_objects = (
-            desktop_at_least(4, 1)
-            or gles_at_least(3, 1)
-            or self.have_extension("GL_ARB_separate_shader_objects")
-            or self.have_extension("GL_EXT_separate_shader_objects")
-        )
-
-        pixel_buffer_objects = (
-            desktop_at_least(2, 1)
-            or gles_at_least(3, 0)
-            or (self.api == "webgl" and self.have_version(2, 0))
-            or self.have_extension("GL_ARB_pixel_buffer_object")
-            or self.have_extension("GL_EXT_pixel_buffer_object")
-            or self.have_extension("GL_NV_pixel_buffer_object")
-        )
-        self.features = SurfaceFeatures(
-            compute_shaders=compute_shaders,
-            shader_storage_buffers=shader_storage_buffers,
-            uniform_buffers=uniform_buffers,
-            sync_objects=sync_objects,
-            geometry_shaders=geometry_shaders,
-            tessellation_shaders=tessellation_shaders,
-            base_vertex=base_vertex,
-            persistent_buffers=persistent_buffers,
-            separate_shader_objects=separate_shader_objects,
-            pixel_buffer_objects=pixel_buffer_objects,
-        )
-
-        bgra_upload = is_desktop_gl or any(
-            self.have_extension(extension)
-            for extension in (
-                "GL_EXT_texture_format_BGRA8888",
-                "GL_APPLE_texture_format_BGRA8888",
-                "GL_IMG_texture_format_BGRA8888",
-            )
-        )
-        bgra_readback = is_desktop_gl or self.have_extension("GL_EXT_read_format_bgra")
-        is_webgl2 = self.api == "webgl" and self.have_version(2, 0)
-        self.pixel_transfer = PixelTransferFeatures(
-            bgra_upload=bgra_upload,
-            bgra_readback=bgra_readback,
-            unpack_row_length=is_desktop_gl or gles_at_least(3, 0) or is_webgl2
-            or self.have_extension("GL_EXT_unpack_subimage"),
-            pack_row_length=is_desktop_gl or gles_at_least(3, 0) or is_webgl2
-            or self.have_extension("GL_NV_pack_subimage"),
-            direct_texture_readback=is_desktop_gl,
-        )
-
-        prefer_bgra = sys.platform == "win32" and bgra_upload
-        self.pixel_format_preferences = PixelFormatPreferences(
-            preferred_decode_format=PixelFormat.BGRA8 if prefer_bgra else PixelFormat.RGBA8,
-            readback_format=(
-                PixelFormat.BGRA8 if sys.platform == "win32" and is_desktop_gl else PixelFormat.RGBA8
-            ),
-        )
-        self._apply_image_decode_policy()
+        """Populate backend-specific feature support after querying the device."""
 
     def _apply_image_decode_policy(self) -> None:
         """Publish backend preferences without requiring image to import graphics."""

--- a/pyglet/graphics/api/base.py
+++ b/pyglet/graphics/api/base.py
@@ -503,6 +503,7 @@ class SurfaceContext(ABC):  # Temp name for now.
         """
         # Backends need to implement setting this value.
 
+
     @abstractmethod
     def attach(self, window: Window) -> None:
         """Attaches the specified Window into the backend context.
@@ -562,6 +563,17 @@ class SurfaceContext(ABC):  # Temp name for now.
     @abstractmethod
     def clear(self) -> None:
         """Clears the framebuffer."""
+
+
+class PixelReadback(ABC):
+    """Base interface for backend-owned texture pixel readback resources."""
+
+    def __init__(self, context: SurfaceContext) -> None:
+        self._context = context
+
+    @abstractmethod
+    def read_texture(self, *args: Any, **kwargs: Any) -> tuple[int, int, Any]:
+        """Read one texture image or layer into backend-owned CPU memory."""
 
 
 class UnavailableContextError(GraphicsBackendError):

--- a/pyglet/graphics/api/base.py
+++ b/pyglet/graphics/api/base.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import atexit
 import os
+import sys
 import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol, get_type_hints, Sequence, Callable, NoReturn
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, Protocol, Sequence, get_type_hints
 
-from pyglet.graphics import GraphicsIntegrationError, GraphicsBackendError
+from pyglet.enums import PixelFormat
+from pyglet.graphics import GraphicsBackendError, GraphicsIntegrationError
 from pyglet.util import debug_print
 
 if TYPE_CHECKING:
@@ -125,7 +127,7 @@ class NullBackend(BackendGlobalObject):  # noqa: D101
         self._raise_no_backend()
 
 
-@dataclass
+@dataclass(frozen=True)
 class SurfaceFeatures:
     """Optional graphics features available to a surface context."""
     #: Enables GPU compute workloads through compute shaders.
@@ -146,6 +148,34 @@ class SurfaceFeatures:
     persistent_buffers: bool = False
     #: Enables updating program uniforms without binding the program first.
     separate_shader_objects: bool = False
+    #: Enables asynchronous pixel transfers through pixel buffer objects.
+    pixel_buffer_objects: bool = False
+
+
+@dataclass(frozen=True)
+class PixelTransferFeatures:
+    """Pixel-transfer operations supported by a surface context."""
+
+    #: Accepts BGRA-ordered source pixels without CPU conversion.
+    bgra_upload: bool = False
+    #: Can return BGRA-ordered pixels from a read operation.
+    bgra_readback: bool = False
+    #: Supports row length and skip state for pixel uploads.
+    unpack_row_length: bool = False
+    #: Supports row length and skip state for pixel readback.
+    pack_row_length: bool = False
+    #: Reads texture storage directly without a framebuffer attachment.
+    direct_texture_readback: bool = False
+
+
+@dataclass(frozen=True)
+class PixelFormatPreferences:
+    """Backend-preferred formats for decoding and reading pixels."""
+
+    #: Preferred 32-bit output for decoders that can choose without slow Python conversion.
+    preferred_decode_format: PixelFormat = PixelFormat.RGBA8
+    #: Preferred component order for GPU pixel readback.
+    readback_format: PixelFormat = PixelFormat.RGBA8
 
 
 class SurfaceInfo(ABC):
@@ -163,6 +193,8 @@ class SurfaceInfo(ABC):
     api: str
     was_queried: bool
     features: SurfaceFeatures
+    pixel_transfer: PixelTransferFeatures
+    pixel_format_preferences: PixelFormatPreferences
 
     # Common capability limits shared by backends these should be automatically queried by the API.
     MAX_ARRAY_TEXTURE_LAYERS: int
@@ -188,6 +220,8 @@ class SurfaceInfo(ABC):
         self.api = "unknown"
         self.was_queried = False
         self.features = SurfaceFeatures()
+        self.pixel_transfer = PixelTransferFeatures()
+        self.pixel_format_preferences = PixelFormatPreferences()
 
         self.MAX_ARRAY_TEXTURE_LAYERS = 0
         self.MAX_TEXTURE_SIZE = 0
@@ -252,7 +286,7 @@ class SurfaceInfo(ABC):
         return self.api
 
     def update_features(self) -> None:
-        """Populate optional feature support after API version and extensions are known."""
+        """Populate feature and pixel-transfer support after version and extensions are known."""
         is_desktop_gl = self.api == "opengl"
         is_gles = self.api in ("gles2", "gles3")
 
@@ -262,46 +296,104 @@ class SurfaceInfo(ABC):
         def gles_at_least(major: int, minor: int = 0) -> bool:
             return is_gles and self.have_version(major, minor)
 
-        self.features.uniform_buffers = desktop_at_least(3, 1) or gles_at_least(3, 0)
-        self.features.sync_objects = (
+        uniform_buffers = desktop_at_least(3, 1) or gles_at_least(3, 0)
+        sync_objects = (
             desktop_at_least(3, 2)
             or gles_at_least(3, 0)
             or self.have_extension("GL_ARB_sync")
         )
-        self.features.compute_shaders = (
+        compute_shaders = (
             desktop_at_least(4, 3)
             or gles_at_least(3, 1)
             or self.have_extension("GL_ARB_compute_shader")
         )
-        self.features.shader_storage_buffers = (
+        shader_storage_buffers = (
             desktop_at_least(4, 3)
             or gles_at_least(3, 1)
             or self.have_extension("GL_ARB_shader_storage_buffer_object")
         )
-        self.features.geometry_shaders = (
+        geometry_shaders = (
             desktop_at_least(3, 2)
             or gles_at_least(3, 2)
             or self.have_extension("GL_ARB_geometry_shader4")
             or self.have_extension("GL_EXT_geometry_shader")
         )
-        self.features.tessellation_shaders = (
+        tessellation_shaders = (
             desktop_at_least(4, 0)
             or gles_at_least(3, 2)
             or self.have_extension("GL_ARB_tessellation_shader")
             or self.have_extension("GL_OES_tessellation_shader")
         )
-        self.features.base_vertex = (
+        base_vertex = (
             desktop_at_least(3, 2)
             or gles_at_least(3, 2)
             or self.have_extension("GL_ARB_draw_elements_base_vertex")
             or self.have_extension("GL_OES_draw_elements_base_vertex")
         )
-        self.features.persistent_buffers = desktop_at_least(4, 4) or self.have_extension("GL_ARB_buffer_storage")
-        self.features.separate_shader_objects = (
+        persistent_buffers = desktop_at_least(4, 4) or self.have_extension("GL_ARB_buffer_storage")
+        separate_shader_objects = (
             desktop_at_least(4, 1)
             or gles_at_least(3, 1)
             or self.have_extension("GL_ARB_separate_shader_objects")
             or self.have_extension("GL_EXT_separate_shader_objects")
+        )
+
+        pixel_buffer_objects = (
+            desktop_at_least(2, 1)
+            or gles_at_least(3, 0)
+            or (self.api == "webgl" and self.have_version(2, 0))
+            or self.have_extension("GL_ARB_pixel_buffer_object")
+            or self.have_extension("GL_EXT_pixel_buffer_object")
+            or self.have_extension("GL_NV_pixel_buffer_object")
+        )
+        self.features = SurfaceFeatures(
+            compute_shaders=compute_shaders,
+            shader_storage_buffers=shader_storage_buffers,
+            uniform_buffers=uniform_buffers,
+            sync_objects=sync_objects,
+            geometry_shaders=geometry_shaders,
+            tessellation_shaders=tessellation_shaders,
+            base_vertex=base_vertex,
+            persistent_buffers=persistent_buffers,
+            separate_shader_objects=separate_shader_objects,
+            pixel_buffer_objects=pixel_buffer_objects,
+        )
+
+        bgra_upload = is_desktop_gl or any(
+            self.have_extension(extension)
+            for extension in (
+                "GL_EXT_texture_format_BGRA8888",
+                "GL_APPLE_texture_format_BGRA8888",
+                "GL_IMG_texture_format_BGRA8888",
+            )
+        )
+        bgra_readback = is_desktop_gl or self.have_extension("GL_EXT_read_format_bgra")
+        is_webgl2 = self.api == "webgl" and self.have_version(2, 0)
+        self.pixel_transfer = PixelTransferFeatures(
+            bgra_upload=bgra_upload,
+            bgra_readback=bgra_readback,
+            unpack_row_length=is_desktop_gl or gles_at_least(3, 0) or is_webgl2
+            or self.have_extension("GL_EXT_unpack_subimage"),
+            pack_row_length=is_desktop_gl or gles_at_least(3, 0) or is_webgl2
+            or self.have_extension("GL_NV_pack_subimage"),
+            direct_texture_readback=is_desktop_gl,
+        )
+
+        prefer_bgra = sys.platform == "win32" and bgra_upload
+        self.pixel_format_preferences = PixelFormatPreferences(
+            preferred_decode_format=PixelFormat.BGRA8 if prefer_bgra else PixelFormat.RGBA8,
+            readback_format=(
+                PixelFormat.BGRA8 if sys.platform == "win32" and is_desktop_gl else PixelFormat.RGBA8
+            ),
+        )
+        self._apply_image_decode_policy()
+
+    def _apply_image_decode_policy(self) -> None:
+        """Publish backend preferences without requiring image to import graphics."""
+        from pyglet import image  # noqa: PLC0415
+
+        image.set_default_decode_policy(
+            image.ImageDecodePolicy(self.pixel_format_preferences.preferred_decode_format),
         )
 
 

--- a/pyglet/graphics/api/base.py
+++ b/pyglet/graphics/api/base.py
@@ -125,6 +125,29 @@ class NullBackend(BackendGlobalObject):  # noqa: D101
         self._raise_no_backend()
 
 
+@dataclass
+class SurfaceFeatures:
+    """Optional graphics features available to a surface context."""
+    #: Enables GPU compute workloads through compute shaders.
+    compute_shaders: bool = False
+    #: Enables shader programs to access shader storage buffer objects.
+    shader_storage_buffers: bool = False
+    #: Enables sharing uniform data between shaders through uniform buffers.
+    uniform_buffers: bool = False
+    #: Enables GPU synchronization with fence and sync objects.
+    sync_objects: bool = False
+    #: Enables geometry-shader pipeline stages.
+    geometry_shaders: bool = False
+    #: Enables tessellation-control and tessellation-evaluation shader stages.
+    tessellation_shaders: bool = False
+    #: Enables indexed drawing with a per-draw base-vertex offset.
+    base_vertex: bool = False
+    #: Enables persistently mapped GPU buffer storage.
+    persistent_buffers: bool = False
+    #: Enables updating program uniforms without binding the program first.
+    separate_shader_objects: bool = False
+
+
 class SurfaceInfo(ABC):
     """Base backend capability info shared by all rendering APIs.
 
@@ -139,6 +162,7 @@ class SurfaceInfo(ABC):
     minor_version: int
     api: str
     was_queried: bool
+    features: SurfaceFeatures
 
     # Common capability limits shared by backends these should be automatically queried by the API.
     MAX_ARRAY_TEXTURE_LAYERS: int
@@ -163,6 +187,7 @@ class SurfaceInfo(ABC):
         self.minor_version = 0
         self.api = "unknown"
         self.was_queried = False
+        self.features = SurfaceFeatures()
 
         self.MAX_ARRAY_TEXTURE_LAYERS = 0
         self.MAX_TEXTURE_SIZE = 0
@@ -225,6 +250,59 @@ class SurfaceInfo(ABC):
     def get_opengl_api(self) -> str:
         """Compatibility alias for existing OpenGL callers."""
         return self.api
+
+    def update_features(self) -> None:
+        """Populate optional feature support after API version and extensions are known."""
+        is_desktop_gl = self.api == "opengl"
+        is_gles = self.api in ("gles2", "gles3")
+
+        def desktop_at_least(major: int, minor: int = 0) -> bool:
+            return is_desktop_gl and self.have_version(major, minor)
+
+        def gles_at_least(major: int, minor: int = 0) -> bool:
+            return is_gles and self.have_version(major, minor)
+
+        self.features.uniform_buffers = desktop_at_least(3, 1) or gles_at_least(3, 0)
+        self.features.sync_objects = (
+            desktop_at_least(3, 2)
+            or gles_at_least(3, 0)
+            or self.have_extension("GL_ARB_sync")
+        )
+        self.features.compute_shaders = (
+            desktop_at_least(4, 3)
+            or gles_at_least(3, 1)
+            or self.have_extension("GL_ARB_compute_shader")
+        )
+        self.features.shader_storage_buffers = (
+            desktop_at_least(4, 3)
+            or gles_at_least(3, 1)
+            or self.have_extension("GL_ARB_shader_storage_buffer_object")
+        )
+        self.features.geometry_shaders = (
+            desktop_at_least(3, 2)
+            or gles_at_least(3, 2)
+            or self.have_extension("GL_ARB_geometry_shader4")
+            or self.have_extension("GL_EXT_geometry_shader")
+        )
+        self.features.tessellation_shaders = (
+            desktop_at_least(4, 0)
+            or gles_at_least(3, 2)
+            or self.have_extension("GL_ARB_tessellation_shader")
+            or self.have_extension("GL_OES_tessellation_shader")
+        )
+        self.features.base_vertex = (
+            desktop_at_least(3, 2)
+            or gles_at_least(3, 2)
+            or self.have_extension("GL_ARB_draw_elements_base_vertex")
+            or self.have_extension("GL_OES_draw_elements_base_vertex")
+        )
+        self.features.persistent_buffers = desktop_at_least(4, 4) or self.have_extension("GL_ARB_buffer_storage")
+        self.features.separate_shader_objects = (
+            desktop_at_least(4, 1)
+            or gles_at_least(3, 1)
+            or self.have_extension("GL_ARB_separate_shader_objects")
+            or self.have_extension("GL_EXT_separate_shader_objects")
+        )
 
 
 @dataclass

--- a/pyglet/graphics/api/gl/context.py
+++ b/pyglet/graphics/api/gl/context.py
@@ -125,7 +125,7 @@ class OpenGLSurfaceContext(SurfaceContext, GLFunctions):
         super().frame_begin()
 
     def create_frame_fence(self) -> object | None:
-        if not (self.info.have_version(3, 2) or self.info.have_extension("GL_ARB_sync")):
+        if not self.info.features.sync_objects:
             return None
         return self.glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
 

--- a/pyglet/graphics/api/gl/context.py
+++ b/pyglet/graphics/api/gl/context.py
@@ -7,7 +7,7 @@ from typing import Callable, TYPE_CHECKING
 from pyglet.enums import GraphicsAPI
 from pyglet.graphics import GraphicsAPIError, GraphicsIntegrationError
 from pyglet.graphics.api.gl import gl, gl_info, ObjectSpace
-from pyglet.graphics.api.base import SurfaceContext, NullContext
+from pyglet.graphics.api.base import PixelReadback, SurfaceContext, NullContext
 from pyglet.graphics.api.gl.gl import (
     GL_ALREADY_SIGNALED,
     GL_COLOR_BUFFER_BIT,
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
     from pyglet.graphics.api.gl.xlib.glx_info import GLXInfo
     from pyglet.graphics.api.gl.win32.wgl_info import WGLInfo
     from pyglet.graphics.api.gl.global_opengl import OpenGLBackend
-    from pyglet.graphics.api.gl.framebuffer import GLFramebuffer
 
 
 class OpenGLSurfaceContext(SurfaceContext, GLFunctions):
@@ -39,7 +38,7 @@ class OpenGLSurfaceContext(SurfaceContext, GLFunctions):
 
     Use ``DisplayConfig.create_context`` to create a context.
     """
-    gles_pixel_fbo: GLFramebuffer | None
+    _pixel_readback: PixelReadback | None
     #: gl_info.GLInfo instance, filled in on first set_current
     _info: gl_info.GLInfo
 
@@ -81,8 +80,21 @@ class OpenGLSurfaceContext(SurfaceContext, GLFunctions):
         self.cached_programs = weakref.WeakValueDictionary()
         self.renderer = GLRenderer(self)
 
-        # GLES needs an FBO to read pixel data.
-        self.gles_pixel_fbo = None
+        self._pixel_readback = None
+
+    @property
+    def pixel_readback(self) -> PixelReadback:
+        """Return the lazily created texture pixel readback helper."""
+        if self._pixel_readback is None:
+            if self.core.gl_api in (GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2):
+                from pyglet.graphics.api.gl2.pixel import GL2PixelReadback  # noqa: PLC0415
+
+                self._pixel_readback = GL2PixelReadback(self)
+            else:
+                from pyglet.graphics.api.gl.pixel import GLPixelReadback  # noqa: PLC0415
+
+                self._pixel_readback = GLPixelReadback(self)
+        return self._pixel_readback
 
     def resized(self, width, height):
         ...
@@ -169,15 +181,6 @@ class OpenGLSurfaceContext(SurfaceContext, GLFunctions):
                 self.platform_func = self.platform_func_class()
             self.uniform_getters, self.uniform_setters = self._get_uniform_func_tables()
             self._info.query(self)
-            if self.info.get_opengl_api() in (GraphicsAPI.OPENGL_ES_2, GraphicsAPI.OPENGL_ES_3):
-                if self.info.get_opengl_api() == GraphicsAPI.OPENGL_ES_2:
-                    from pyglet.graphics.api.gl2.framebuffer import GL2Framebuffer
-
-                    self.gles_pixel_fbo = GL2Framebuffer(context=self)
-                else:
-                    from pyglet.graphics.api.gl.framebuffer import GLFramebuffer
-
-                    self.gles_pixel_fbo = GLFramebuffer(context=self)
 
         if self.object_space.doomed_textures:
             self._delete_objects(self.object_space.doomed_textures, self.glDeleteTextures)

--- a/pyglet/graphics/api/gl/gl_info.py
+++ b/pyglet/graphics/api/gl/gl_info.py
@@ -9,11 +9,18 @@ Usage::
 from __future__ import annotations
 
 import re
+import sys
 import warnings
 from ctypes import c_char_p, cast, c_int, c_float
 from typing import TYPE_CHECKING
 
-from pyglet.graphics.api.base import SurfaceInfo
+from pyglet.enums import PixelFormat
+from pyglet.graphics.api.base import (
+    PixelFormatPreferences,
+    PixelTransferFeatures,
+    SurfaceFeatures,
+    SurfaceInfo,
+)
 from pyglet.graphics.api.gl import gl
 from pyglet.graphics.api.gl.lib import GLException
 
@@ -124,6 +131,106 @@ class GLInfo(SurfaceInfo):
 
         self.update_features()
         self.was_queried = True
+
+    def update_features(self) -> None:
+        """Populate OpenGL and OpenGL ES feature support."""
+        is_desktop_gl = self.api == "opengl"
+        is_gles = self.api in ("gles2", "gles3")
+
+        def desktop_at_least(major: int, minor: int = 0) -> bool:
+            return is_desktop_gl and self.have_version(major, minor)
+
+        def gles_at_least(major: int, minor: int = 0) -> bool:
+            return is_gles and self.have_version(major, minor)
+
+        self.features = SurfaceFeatures(
+            compute_shaders=(
+                desktop_at_least(4, 3)
+                or gles_at_least(3, 1)
+                or self.have_extension("GL_ARB_compute_shader")
+            ),
+            shader_storage_buffers=(
+                desktop_at_least(4, 3)
+                or gles_at_least(3, 1)
+                or self.have_extension("GL_ARB_shader_storage_buffer_object")
+            ),
+            uniform_buffers=desktop_at_least(3, 1) or gles_at_least(3, 0),
+            sync_objects=(
+                desktop_at_least(3, 2)
+                or gles_at_least(3, 0)
+                or self.have_extension("GL_ARB_sync")
+            ),
+            geometry_shaders=(
+                desktop_at_least(3, 2)
+                or gles_at_least(3, 2)
+                or self.have_extension("GL_ARB_geometry_shader4")
+                or self.have_extension("GL_EXT_geometry_shader")
+            ),
+            tessellation_shaders=(
+                desktop_at_least(4, 0)
+                or gles_at_least(3, 2)
+                or self.have_extension("GL_ARB_tessellation_shader")
+                or self.have_extension("GL_OES_tessellation_shader")
+            ),
+            base_vertex=(
+                desktop_at_least(3, 2)
+                or gles_at_least(3, 2)
+                or self.have_extension("GL_ARB_draw_elements_base_vertex")
+                or self.have_extension("GL_OES_draw_elements_base_vertex")
+            ),
+            persistent_buffers=desktop_at_least(4, 4) or self.have_extension("GL_ARB_buffer_storage"),
+            separate_shader_objects=(
+                desktop_at_least(4, 1)
+                or gles_at_least(3, 1)
+                or self.have_extension("GL_ARB_separate_shader_objects")
+                or self.have_extension("GL_EXT_separate_shader_objects")
+            ),
+            pixel_buffer_objects=(
+                desktop_at_least(2, 1)
+                or gles_at_least(3, 0)
+                or self.have_extension("GL_ARB_pixel_buffer_object")
+                or self.have_extension("GL_EXT_pixel_buffer_object")
+                or self.have_extension("GL_NV_pixel_buffer_object")
+            ),
+            texture_storage=(
+                desktop_at_least(4, 2)
+                or gles_at_least(3, 0)
+                or self.have_extension("GL_ARB_texture_storage")
+            ),
+        )
+
+        bgra_upload = is_desktop_gl or any(
+            self.have_extension(extension)
+            for extension in (
+                "GL_EXT_texture_format_BGRA8888",
+                "GL_APPLE_texture_format_BGRA8888",
+                "GL_IMG_texture_format_BGRA8888",
+            )
+        )
+        self.pixel_transfer = PixelTransferFeatures(
+            bgra_upload=bgra_upload,
+            bgra_readback=is_desktop_gl or self.have_extension("GL_EXT_read_format_bgra"),
+            unpack_row_length=(
+                is_desktop_gl
+                or gles_at_least(3, 0)
+                or self.have_extension("GL_EXT_unpack_subimage")
+            ),
+            pack_row_length=(
+                is_desktop_gl
+                or gles_at_least(3, 0)
+                or self.have_extension("GL_NV_pack_subimage")
+            ),
+            direct_texture_readback=is_desktop_gl,
+        )
+
+        prefer_bgra = sys.platform == "win32" and bgra_upload
+        self.pixel_format_preferences = PixelFormatPreferences(
+            preferred_decode_format=PixelFormat.BGRA8 if prefer_bgra else PixelFormat.RGBA8,
+            readback_format=(
+                PixelFormat.BGRA8 if sys.platform == "win32" and is_desktop_gl else PixelFormat.RGBA8
+            ),
+        )
+        self._apply_image_decode_policy()
 
     def get_int(self, enum: int, default: int = 0) -> int:
         try:

--- a/pyglet/graphics/api/gl/gl_info.py
+++ b/pyglet/graphics/api/gl/gl_info.py
@@ -122,6 +122,7 @@ class GLInfo(SurfaceInfo):
         if self.platform_info:
             self.extensions.update(set(self.platform_info.get_extensions(context)))
 
+        self.update_features()
         self.was_queried = True
 
     def get_int(self, enum: int, default: int = 0) -> int:

--- a/pyglet/graphics/api/gl/pixel.py
+++ b/pyglet/graphics/api/gl/pixel.py
@@ -1,0 +1,85 @@
+"""OpenGL texture pixel readback helpers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from ctypes import sizeof
+from typing import TYPE_CHECKING, Iterator
+
+from pyglet.customtypes import Buffer
+from pyglet.graphics import GraphicsAPIError
+from pyglet.graphics.api.base import PixelReadback
+from pyglet.graphics.api.gl import gl
+
+if TYPE_CHECKING:
+    from pyglet.graphics.api.gl.context import OpenGLSurfaceContext
+    from pyglet.graphics.api.gl.framebuffer import GLFramebuffer
+    from pyglet.graphics.api.gl.texture import GLTexture
+
+
+class GLPixelReadback(PixelReadback):
+    """Context-owned resources and state handling for texture readback."""
+
+    def __init__(self, context: OpenGLSurfaceContext) -> None:
+        """Create a readback helper for an OpenGL surface context."""
+        super().__init__(context)
+        self._framebuffer: GLFramebuffer | None = None
+
+    def get_framebuffer(self) -> GLFramebuffer:
+        """Return the lazily created framebuffer used for GLES readback."""
+        if self._framebuffer is None:
+            from pyglet.graphics.api.gl.framebuffer import GLFramebuffer  # noqa: PLC0415
+
+            self._framebuffer = GLFramebuffer(context=self._context)
+        return self._framebuffer
+
+    @contextmanager
+    def _pack_state(self) -> Iterator[None]:
+        alignment = gl.GLint()
+        self._context.glGetIntegerv(gl.GL_PACK_ALIGNMENT, alignment)
+        self._context.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
+        try:
+            yield
+        finally:
+            self._context.glPixelStorei(gl.GL_PACK_ALIGNMENT, alignment.value)
+
+    def read_texture(self, texture: GLTexture, z: int, level: int,
+                     gl_format: int, gl_type: int, component_type: type,
+                     components: int) -> tuple[int, int, Buffer]:
+        """Read one texture image or layer into tightly packed CPU memory."""
+        width, height, depth = texture._get_mipmap_dimensions(level)
+        if not 0 <= z < depth:
+            msg = f"Texture layer {z} is outside the valid range 0..{depth - 1}."
+            raise ValueError(msg)
+
+        layer_elements = width * height * components
+        direct_readback = self._context.info.pixel_transfer.direct_texture_readback
+
+        with self._pack_state():
+            if direct_readback:
+                buffer = (component_type * (layer_elements * depth))()
+                self._context.glBindTexture(texture.target, texture.id)
+                self._context.glGetTexImage(texture.target, level, gl_format, gl_type, buffer)
+
+                if depth == 1:
+                    data = buffer
+                else:
+                    start = z * layer_elements
+                    data = (component_type * layer_elements).from_buffer(
+                        buffer, start * sizeof(component_type),
+                    )
+            else:
+                buffer = (component_type * layer_elements)()
+                framebuffer = self.get_framebuffer()
+                with framebuffer:
+                    texture._set_readback_framebuffer_attachment(texture.id, z, level)
+                    try:
+                        if not framebuffer.is_complete:
+                            msg = f"Texture cannot be read through a framebuffer: {framebuffer.get_status()}"
+                            raise GraphicsAPIError(msg)
+                        self._context.glReadPixels(0, 0, width, height, gl_format, gl_type, buffer)
+                    finally:
+                        texture._set_readback_framebuffer_attachment(0, z, level)
+                data = buffer
+
+        return width, height, data

--- a/pyglet/graphics/api/gl/shader.py
+++ b/pyglet/graphics/api/gl/shader.py
@@ -718,9 +718,7 @@ def _introspect_uniform_blocks(ctx, program: GLShaderProgram | GLComputeShaderPr
 
 
 def _supports_shader_storage_blocks() -> bool:
-    return pyglet.graphics.api.have_version(4, 3) or pyglet.graphics.api.have_extension(
-        "GL_ARB_shader_storage_buffer_object",
-    )
+    return pyglet.graphics.api.core.current_context.info.features.shader_storage_buffers
 
 
 def _get_program_resource_name(ctx, program_id: int, interface: int, index: int) -> str:
@@ -901,11 +899,13 @@ class GLShaderSource(ShaderSource):
 
         self._version = self._find_glsl_version()
 
-        if pyglet.graphics.api.core.current_context.info.get_opengl_api() == GraphicsAPI.OPENGL_ES_3:
-            self._lines[0] = "#version 310 es"
+        context_info = pyglet.graphics.api.core.current_context.info
+        if context_info.get_opengl_api() == GraphicsAPI.OPENGL_ES_3:
+            glsl_version = 310 if context_info.have_version(3, 1) else 300
+            self._lines[0] = f"#version {glsl_version} es"
             self._lines.insert(1, "precision mediump float;")
 
-            if self._type == gl.GL_GEOMETRY_SHADER:
+            if self._type == gl.GL_GEOMETRY_SHADER and context_info.features.geometry_shaders:
                 self._lines.insert(1, "#extension GL_EXT_geometry_shader : require")
 
             if self._type == gl.GL_COMPUTE_SHADER:
@@ -1003,7 +1003,15 @@ class GLShader(_AbstractShader):
 
     @classmethod
     def supported_shaders(cls: type[GLShader]) -> tuple[ShaderType, ...]:
-        return 'vertex', 'fragment', 'compute', 'geometry', 'tesscontrol', 'tessevaluation'
+        features = pyglet.graphics.api.core.current_context.info.features
+        shader_types: tuple[ShaderType, ...] = ('vertex', 'fragment')
+        if features.compute_shaders:
+            shader_types += ('compute',)
+        if features.geometry_shaders:
+            shader_types += ('geometry',)
+        if features.tessellation_shaders:
+            shader_types += ('tesscontrol', 'tessevaluation')
+        return shader_types
 
     @property
     def id(self) -> int:
@@ -1077,7 +1085,7 @@ class GLShaderProgram(ShaderProgram):
 
         # Query if Direct State Access is available:
 
-        have_dsa = pyglet.graphics.api.have_version(4, 1) or pyglet.graphics.api.have_extension("GL_ARB_separate_shader_objects")
+        have_dsa = self._context.info.features.separate_shader_objects
         self._attributes = _introspect_attributes(self._context, self._id)
         self._uniforms = _introspect_uniforms(self._context, self._id, have_dsa)
         self._uniform_blocks = self._get_uniform_blocks()
@@ -1249,10 +1257,10 @@ class GLComputeShaderProgram(_AbstractShaderProgram):
         """Create an OpenGL ComputeShaderProgram from source."""
         super().__init__()
 
-        if not (pyglet.graphics.api.have_version(4, 3) or pyglet.graphics.api.have_extension("GL_ARB_compute_shader")):
+        if not pyglet.graphics.api.core.current_context.info.features.compute_shaders:
             msg = (
-                "Compute Shader not supported. OpenGL Context version must be at least "
-                "4.3 or higher, or 4.2 with the 'GL_ARB_compute_shader' extension."
+                "Compute Shader not supported. It requires desktop OpenGL 4.3, OpenGL ES 3.1, "
+                "or the required driver extension."
             )
             raise ShaderException(msg)
 
@@ -1263,7 +1271,7 @@ class GLComputeShaderProgram(_AbstractShaderProgram):
         if _debug_api_shaders:
             assert _debug_api_shader_print(_get_program_log(self._context, self._id))
 
-        have_dsa = pyglet.graphics.api.have_version(4, 1) or pyglet.graphics.api.have_extension("GL_ARB_separate_shader_objects")
+        have_dsa = self._context.info.features.separate_shader_objects
         self._uniforms = _introspect_uniforms(self._context, self._id, have_dsa)
         self._uniform_blocks = _introspect_uniform_blocks(self._context, self)
         self._shader_storage_blocks = _introspect_shader_storage_blocks(self._context, self)

--- a/pyglet/graphics/api/gl/texture.py
+++ b/pyglet/graphics/api/gl/texture.py
@@ -31,7 +31,6 @@ from pyglet.graphics.api.gl.gl import (
     GL_READ_WRITE,
     GL_RGBA32F,
     GLubyte,
-    GL_PACK_ALIGNMENT,
     GL_UNPACK_SKIP_PIXELS,
     GL_UNPACK_SKIP_ROWS,
     GL_UNPACK_ALIGNMENT,
@@ -70,7 +69,7 @@ from pyglet.graphics.api.gl.enums import texture_map
 from pyglet.image.base import ImageData, ImageDataRegion, CompressionFormat, \
     CompressedImageData
 from pyglet.image.base import ImageException
-from pyglet.graphics.texture import Texture, UniformTextureSequence, CompressedTexture, \
+from pyglet.graphics.texture import PixelData, Texture, UniformTextureSequence, CompressedTexture, \
     _TextureRegionShared, _Texture3DShared, _TextureArrayShared, TextureGrid
 
 _api_base_internal_formats = {
@@ -162,6 +161,17 @@ _data_types = {
     "f": gl.GL_FLOAT,
     "f.5": gl.GL_HALF_FLOAT,
     "d": gl.GL_DOUBLE,
+}
+
+_component_types = {
+    "b": gl.GLbyte,
+    "B": gl.GLubyte,
+    "h": gl.GLshort,
+    "H": gl.GLushort,
+    "i": gl.GLint,
+    "I": gl.GLuint,
+    "f": gl.GLfloat,
+    "d": gl.GLdouble,
 }
 
 
@@ -471,13 +481,18 @@ class GLTexture(Texture):
                              data)
         self._context.glFlush()
 
-    def _attach_gles_fbo_texture(self, _z: int = 0, level: int = 0) -> None:
-        self._context.glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, self.id, level)
+    def _set_readback_framebuffer_attachment(self, texture_id: int, _z: int = 0, level: int = 0) -> None:
+        self._context.glFramebufferTexture2D(
+            GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture_id, level,
+        )
 
     def fetch(self, z: int = 0, level: int = 0) -> ImageData:
-        """Fetch the image data of this texture from the GPU.
+        """Fetch an unsigned-byte, image-oriented copy of this texture.
 
-        Binds the texture and reads the pixel data back from the GPU, as such, can be a costly operation.
+        Floating-point and integer textures cannot be fetched as
+        :class:`~pyglet.image.ImageData` without conversion. Use
+        :meth:`read_pixels` for those typed values.
+        Reading data back from the GPU can be a costly operation.
 
         Modifying the returned ImageData object has no effect on the
         texture itself. Uploading ImageData back to the GPU/texture
@@ -489,30 +504,43 @@ class GLTexture(Texture):
             level:
                 The mipmap level of the texture to retrieve.
         """
-        self._context.glBindTexture(self.target, self.id)
-
         pixel_format = self._context.info.pixel_format_preferences.readback_format
         fmt = pixel_format.component_format
         gl_format = _api_pixel_formats[fmt]
 
-        size = self.width * self.height * self.images * len(fmt)
-        buf = (GLubyte * size)()
+        if self.internal_format_type in ("f", "i", "I"):
+            msg = (
+                "Texture.fetch() only supports normalized byte image formats. "
+                "Use Texture.read_pixels() for floating-point or integer textures."
+            )
+            raise NotImplementedError(msg)
 
-        if not self._context.info.pixel_transfer.direct_texture_readback:
-            self._context.gles_pixel_fbo.bind()
-            self._context.glPixelStorei(GL_PACK_ALIGNMENT, 1)
-            self._attach_gles_fbo_texture(z, level)
-            self._context.glReadPixels(0, 0, self.width, self.height, gl_format, GL_UNSIGNED_BYTE, buf)
-            self._context.gles_pixel_fbo.unbind()
-            data = ImageData(self.width, self.height, fmt, buf)
+        width, height, image_bytes = self._context.pixel_readback.read_texture(
+            self, z, level, gl_format, GL_UNSIGNED_BYTE, GLubyte, len(fmt),
+        )
+        return ImageData(width, height, fmt, image_bytes)
+
+    def read_pixels(self, z: int = 0, level: int = 0) -> PixelData:
+        """Read typed, tightly packed RGBA pixel values from this texture."""
+        if self.internal_format in (ComponentFormat.D, ComponentFormat.DS):
+            raise NotImplementedError("Typed depth and depth-stencil texture readback is not yet supported.")
+
+        if self.internal_format_type in ("i", "I"):
+            gl_format = GL_RGBA_INTEGER
+            data_type = self.internal_format_type
+        elif self.internal_format_type == "f":
+            gl_format = GL_RGBA
+            data_type = "f"
         else:
-            self._context.glPixelStorei(GL_PACK_ALIGNMENT, 1)
-            self._context.glGetTexImage(self.target, level, gl_format, GL_UNSIGNED_BYTE, buf)
+            gl_format = GL_RGBA
+            data_type = "B"
 
-            data = ImageData(self.width, self.height, fmt, buf)
-            if self.images > 1:
-                data = data.get_region(0, z * self.height, self.width, self.height)
-        return data
+        gl_type = _data_types[data_type]
+        component_type = _component_types[data_type]
+        width, height, data = self._context.pixel_readback.read_texture(
+            self, z, level, gl_format, gl_type, component_type, 4,
+        )
+        return PixelData(width, height, ComponentFormat.RGBA, data_type, data)
 
     def _update_subregion(self, image_data: ImageData | ImageDataRegion, x: int, y: int, z: int,
                           level: int = 0) -> None:
@@ -665,8 +693,8 @@ class GLTexture3D(_Texture3DShared[GLTextureRegion], GLTexture, UniformTextureSe
         texture.item_height = item_height
         return texture
 
-    def _attach_gles_fbo_texture(self, z: int = 0, level: int = 0) -> None:
-        self._context.glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, self.id, level, z)
+    def _set_readback_framebuffer_attachment(self, texture_id: int, z: int = 0, level: int = 0) -> None:
+        self._context.glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture_id, level, z)
 
     def _update_subregion(self, image_data: ImageData, x: int, y: int, z: int,
                           level: int = 0):
@@ -754,8 +782,8 @@ class GLTextureArray(_TextureArrayShared[GLTextureArrayRegion], GLTexture, Unifo
         texture._allocate(None)
         return texture
 
-    def _attach_gles_fbo_texture(self, z: int = 0, level: int = 0) -> None:
-        self._context.glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, self.id, level, z)
+    def _set_readback_framebuffer_attachment(self, texture_id: int, z: int = 0, level: int = 0) -> None:
+        self._context.glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture_id, level, z)
 
     def _update_subregion(self, image_data: ImageData, x: int, y: int, z: int,
                           level: int = 0):

--- a/pyglet/graphics/api/gl/texture.py
+++ b/pyglet/graphics/api/gl/texture.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 
 from ctypes import byref, Array
-from typing import Sequence
+from typing import cast, Sequence
 
 import pyglet
 from pyglet.enums import TextureType, TextureFilter, ComponentFormat, AddressMode, GraphicsAPI
 from pyglet.graphics.api.gl import OpenGLSurfaceContext, GL_COMPRESSED_RGB8_ETC2
+from pyglet.graphics.api.base import SurfaceContext
 from pyglet.graphics.api.gl.gl import (
     GL_RED,
     GL_RG,
@@ -25,6 +26,7 @@ from pyglet.graphics.api.gl.gl import (
     GL_UNSIGNED_BYTE,
     GL_TEXTURE_MIN_FILTER,
     GL_TEXTURE_MAG_FILTER,
+    GL_TEXTURE_MAX_LEVEL,
     GL_TEXTURE_2D,
     GLuint,
     GL_TEXTURE0,
@@ -276,7 +278,8 @@ class GLTexture(Texture):
                            layer: int = 0, access: int = GL_READ_WRITE, fmt: int = GL_RGBA32F):
         """Bind as an ImageTexture for use with a :py:class:`~pyglet.shader.ComputeShaderProgram`.
 
-        .. note:: OpenGL 4.3, or 4.2 with the GL_ARB_compute_shader extention is required.
+        OpenGL ES requires the texture to have immutable-format storage. Create
+        it with ``immutable=True`` when it will be bound as an image texture.
         """
         self._context.glBindImageTexture(unit, self.id, level, layered, layer, access, fmt)
 
@@ -321,6 +324,13 @@ class GLTexture(Texture):
     def _allocate_mipmap_level(self, level: int, width: int, height: int, depth: int,
                                data_size: int | None) -> None:
         data = (GLubyte * data_size)() if data_size is not None else None
+        if self.immutable:
+            if data is not None:
+                self._context.glTexSubImage2D(
+                    self.target, level, 0, 0, width, height,
+                    _get_base_format(self.internal_format), GL_UNSIGNED_BYTE, data,
+                )
+            return
         self._context.glTexImage2D(self.target, level,
                                    self._gl_internal_format,
                                    width, height,
@@ -422,7 +432,10 @@ class GLTexture(Texture):
                filters: TextureFilter | tuple[TextureFilter, TextureFilter] | None = None,
                address_mode: AddressMode = AddressMode.REPEAT,
                anisotropic_level: int = 0,
-               blank_data: bool = True, context: OpenGLSurfaceContext | None = None) -> GLTexture:
+               blank_data: bool = True,
+               immutable: bool = False,
+               mipmap_levels: int = 1,
+               context: SurfaceContext | None = None) -> GLTexture:
         """Create a Texture.
 
         Create a Texture with the specified dimensions, and attributes.
@@ -448,30 +461,73 @@ class GLTexture(Texture):
                 The maximum anisotropic level.
             blank_data:
                 If True, initialize the texture data with all zeros. If False, do not pass initial data.
+            immutable:
+                If True, allocate immutable-format storage with ``glTexStorage2D``.
+            mipmap_levels:
+                Number of mipmap levels to allocate. Immutable textures cannot add levels later.
             context:
                 A specific OpenGL Surface context, otherwise the current active context.
 
         Returns:
             A currently bound texture.
         """
-        ctx = context or pyglet.graphics.api.core.current_context
+        ctx = cast(OpenGLSurfaceContext, context or pyglet.graphics.api.core.current_context)
+
+        max_mipmap_levels = max(width, height).bit_length()
+        if not 1 <= mipmap_levels <= max_mipmap_levels:
+            msg = f"Mipmap levels must be between 1 and {max_mipmap_levels} for this texture size."
+            raise ImageException(msg)
+        if immutable and not ctx.info.features.texture_storage:
+            raise ImageException("Immutable texture storage is not supported by the current context.")
 
         tex_id = GLuint()
         target = texture_map[tex_type]
         ctx.glGenTextures(1, byref(tex_id))
 
-        texture = cls(ctx, width, height, tex_id.value, tex_type, internal_format, internal_format_size, internal_format_type, filters, address_mode, anisotropic_level)
+        texture = cls(
+            ctx, width, height, tex_id.value, tex_type, internal_format,
+            internal_format_size, internal_format_type, filters, address_mode,
+            anisotropic_level,
+        )
+        texture.immutable = immutable
+        if immutable:
+            texture._mipmap_levels = mipmap_levels
         ctx.glBindTexture(target, tex_id.value)
         ctx.glTexParameteri(target, GL_TEXTURE_MIN_FILTER, texture._gl_min_filter)
         ctx.glTexParameteri(target, GL_TEXTURE_MAG_FILTER, texture._gl_mag_filter)
+        if immutable or mipmap_levels > 1:
+            ctx.glTexParameteri(target, GL_TEXTURE_MAX_LEVEL, mipmap_levels - 1)
 
         data = (GLubyte * (width * height * len(internal_format)))() if blank_data else None
         texture._allocate(data)
         if blank_data:
             texture._mark_mipmap_valid(0)
+        if mipmap_levels > 1:
+            if immutable:
+                for level in range(1, mipmap_levels):
+                    level_width = max(1, width >> level)
+                    level_height = max(1, height >> level)
+                    data_size = level_width * level_height * len(internal_format) if blank_data else None
+                    texture._allocate_mipmap_level(level, level_width, level_height, 1, data_size)
+                    if blank_data:
+                        texture._mark_mipmap_valid(level)
+            else:
+                texture.init_mipmaps(mipmap_levels, blank_data)
         return texture
 
     def _allocate(self, data: None | Array) -> None:
+        if self.immutable:
+            self._context.glTexStorage2D(
+                self.target, self._mipmap_levels, self._gl_internal_format, self.width, self.height,
+            )
+            if data is not None:
+                self._context.glTexSubImage2D(
+                    self.target, 0, 0, 0, self.width, self.height,
+                    _get_base_format(self.internal_format), GL_UNSIGNED_BYTE, data,
+                )
+            self._context.glFlush()
+            return
+
         self._context.glTexImage2D(self.target, 0,
                              self._gl_internal_format,
                              self.width, self.height,

--- a/pyglet/graphics/api/gl/texture.py
+++ b/pyglet/graphics/api/gl/texture.py
@@ -196,6 +196,16 @@ def _normalize_upload_format(data_format: str) -> str:
     return fmt
 
 
+def _get_upload_format(context: OpenGLSurfaceContext, data_format: str) -> str:
+    """Return a component order that the active backend can upload directly."""
+    if not context.info.pixel_transfer.bgra_upload:
+        if data_format == "BGRA":
+            return "RGBA"
+        if data_format == "BGR":
+            return "RGB"
+    return _normalize_upload_format(data_format)
+
+
 def _get_pixel_format(image_data: ImageData) -> tuple[int, int]:
     """Determine the pixel format from format string for the Graphics API."""
     data_format = _normalize_upload_format(image_data.format)
@@ -230,6 +240,14 @@ class GLTexture(Texture):
         self._gl_min_filter = texture_map[self.min_filter]
         self._gl_mag_filter = texture_map[self.mag_filter]
         self._gl_internal_format = _get_internal_format(internal_format, internal_format_size, internal_format_type)
+        if (
+            internal_format == ComponentFormat.BGRA
+            and context.info.get_opengl_api() in (GraphicsAPI.OPENGL_ES_2, GraphicsAPI.OPENGL_ES_3)
+            and context.info.pixel_transfer.bgra_upload
+        ):
+            # GL_EXT_texture_format_BGRA8888 requires matching unsized BGRA
+            # internal and external formats on OpenGL ES.
+            self._gl_internal_format = GL_BGRA
 
     def delete(self) -> None:
         """Delete this texture and the memory it occupies.
@@ -263,6 +281,9 @@ class GLTexture(Texture):
         align, row_length = self._get_image_alignment(image_data)
 
         self._context.glPixelStorei(GL_UNPACK_ALIGNMENT, align)
+        if not self._context.info.pixel_transfer.unpack_row_length:
+            return
+
         self._context.glPixelStorei(GL_UNPACK_ROW_LENGTH, row_length)
 
         if isinstance(image_data, ImageDataRegion):
@@ -270,6 +291,9 @@ class GLTexture(Texture):
             self._context.glPixelStorei(GL_UNPACK_SKIP_ROWS, image_data.y)
 
     def _end_upload(self, image_data: ImageData | ImageDataRegion) -> None:
+        if not self._context.info.pixel_transfer.unpack_row_length:
+            return
+
         self._context.glPixelStorei(GL_UNPACK_ROW_LENGTH, 0)
 
         if isinstance(image_data, ImageDataRegion):
@@ -337,25 +361,27 @@ class GLTexture(Texture):
         target = texture_map[tex_type]
         ctx.glBindTexture(target, tex_id.value)
 
+        pixel_fmt = _get_upload_format(ctx, image_data.format)
         texture = cls(ctx, image_data.width, image_data.height, tex_id.value, tex_type,
-                      ComponentFormat(image_data.format), internal_format_size, image_data.data_type, filters,
+                      ComponentFormat(pixel_fmt), internal_format_size, image_data.data_type, filters,
                       address_mode, anisotropic_level)
 
         ctx.glTexParameteri(target, GL_TEXTURE_MIN_FILTER, texture._gl_min_filter)
         ctx.glTexParameteri(target, GL_TEXTURE_MAG_FILTER, texture._gl_mag_filter)
 
-        pixel_fmt = image_data.format
         image_bytes = image_data.get_bytes(pixel_fmt, image_data.width * len(pixel_fmt))
-        gl_pfmt, gl_type = _get_pixel_format(image_data)
+        gl_pfmt, gl_type = _get_gl_format_and_type(pixel_fmt, image_data.data_type)
 
         # !!! Better place for this?
         if pixel_fmt in ("L", "LA"):
             texture._swizzle_legacy_fmts(pixel_fmt)
 
-        align, row_length = texture._get_image_alignment(image_data)
+        align, _ = texture._get_image_alignment(image_data)
 
         ctx.glPixelStorei(GL_UNPACK_ALIGNMENT, align)
-        ctx.glPixelStorei(GL_UNPACK_ROW_LENGTH, row_length)
+        if ctx.info.pixel_transfer.unpack_row_length:
+            # get_bytes above always returns tightly packed rows.
+            ctx.glPixelStorei(GL_UNPACK_ROW_LENGTH, 0)
 
         ctx.glTexImage2D(target, 0,
                          texture._gl_internal_format,
@@ -465,14 +491,14 @@ class GLTexture(Texture):
         """
         self._context.glBindTexture(self.target, self.id)
 
-        # Some tests seem to rely on this always being RGBA
-        fmt = 'RGBA'
-        gl_format = GL_RGBA
+        pixel_format = self._context.info.pixel_format_preferences.readback_format
+        fmt = pixel_format.component_format
+        gl_format = _api_pixel_formats[fmt]
 
         size = self.width * self.height * self.images * len(fmt)
         buf = (GLubyte * size)()
 
-        if self._context.info.get_opengl_api() in (GraphicsAPI.OPENGL_ES_2, GraphicsAPI.OPENGL_ES_3):
+        if not self._context.info.pixel_transfer.direct_texture_readback:
             self._context.gles_pixel_fbo.bind()
             self._context.glPixelStorei(GL_PACK_ALIGNMENT, 1)
             self._attach_gles_fbo_texture(z, level)
@@ -493,7 +519,7 @@ class GLTexture(Texture):
         data_pitch = abs(image_data._current_pitch)
 
         api = self._context.info.get_opengl_api()
-        upload_fmt = image_data.format
+        upload_fmt = _get_upload_format(self._context, image_data.format)
         upload_pitch = data_pitch
 
         # GLES drivers can be strict about sub-image upload format compatibility.
@@ -506,7 +532,11 @@ class GLTexture(Texture):
 
         # Get data in required format (hopefully will be the same format it's already
         # in, unless that's an obscure format, upside-down or the driver is old).
-        data = image_data.convert(upload_fmt, upload_pitch)
+        if self._context.info.pixel_transfer.unpack_row_length:
+            data = image_data.convert(upload_fmt, upload_pitch)
+        else:
+            upload_pitch = image_data.width * len(upload_fmt)
+            data = image_data.get_bytes(upload_fmt, upload_pitch)
 
         upload_fmt = _normalize_upload_format(upload_fmt)
         fmt, gl_type = _get_gl_format_and_type(upload_fmt, image_data.data_type)

--- a/pyglet/graphics/api/gl/vertexdomain.py
+++ b/pyglet/graphics/api/gl/vertexdomain.py
@@ -118,7 +118,7 @@ class _GLVertexStreamMix(VertexStream):
         info = ctx.info
         if info.get_opengl_api() != GraphicsAPI.OPENGL:
             return False
-        return info.have_version(4, 4) or info.have_extension("GL_ARB_buffer_storage")
+        return info.features.persistent_buffers
 
     def get_buffer(self, size: int, attribute: GraphicsAttribute) -> GLAttributeBufferObject | PersistentBufferObject:
         if self._persistent_buffers_supported:
@@ -730,8 +730,7 @@ class GLIndexedVertexDomain(IndexedVertexDomain):
     def __init__(self, context: OpenGLSurfaceContext, initial_count: int, attribute_meta: dict[str, Attribute],  # noqa: D107
                  index_type: DataTypes = "I") -> None:
         self.index_type = index_type
-        #self._supports_base_vertex = False
-        self._supports_base_vertex = context.info.have_extension("GL_ARB_draw_elements_base_vertex")
+        self._supports_base_vertex = context.info.features.base_vertex
         super().__init__(context, initial_count, attribute_meta)
 
     def _has_multi_draw_extension(self, ctx: OpenGLSurfaceContext) -> bool:

--- a/pyglet/graphics/api/gl2/pixel.py
+++ b/pyglet/graphics/api/gl2/pixel.py
@@ -1,0 +1,22 @@
+"""OpenGL 2 and OpenGL ES 2 texture pixel readback helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyglet.graphics.api.gl.pixel import GLPixelReadback
+
+if TYPE_CHECKING:
+    from pyglet.graphics.api.gl.framebuffer import GLFramebuffer
+
+
+class GL2PixelReadback(GLPixelReadback):
+    """Pixel readback using OpenGL 2-compatible framebuffer state."""
+
+    def get_framebuffer(self) -> GLFramebuffer:
+        """Return the lazily created OpenGL 2 framebuffer used for readback."""
+        if self._framebuffer is None:
+            from pyglet.graphics.api.gl2.framebuffer import GL2Framebuffer  # noqa: PLC0415
+
+            self._framebuffer = GL2Framebuffer(context=self._context)
+        return self._framebuffer

--- a/pyglet/graphics/api/gl2/shapes.py
+++ b/pyglet/graphics/api/gl2/shapes.py
@@ -33,7 +33,7 @@ vertex_source = """#version 110
     }
 """
 
-fragment_source = """#version 150 core
+fragment_source = """#version 110
     varying vec4 vertex_colors;
 
     void main()

--- a/pyglet/graphics/api/webgl/gl_info.py
+++ b/pyglet/graphics/api/webgl/gl_info.py
@@ -77,4 +77,5 @@ class GLInfo(SurfaceInfo):
         self.MAX_UNIFORM_BLOCK_SIZE = self._get_parameter(gl, "MAX_UNIFORM_BLOCK_SIZE")
         self.MAX_VERTEX_ATTRIBS = self._get_parameter(gl, "MAX_VERTEX_ATTRIBS")
 
+        self.update_features()
         self.was_queried = True

--- a/pyglet/graphics/api/webgl/gl_info.py
+++ b/pyglet/graphics/api/webgl/gl_info.py
@@ -1,7 +1,17 @@
+"""Information about the active WebGL implementation."""
+
 from __future__ import annotations
+
+import sys
 from typing import TYPE_CHECKING
 
-from pyglet.graphics.api.base import SurfaceInfo
+from pyglet.enums import PixelFormat
+from pyglet.graphics.api.base import (
+    PixelFormatPreferences,
+    PixelTransferFeatures,
+    SurfaceFeatures,
+    SurfaceInfo,
+)
 from pyglet.graphics.api.webgl.gl import GL_VENDOR, GL_RENDERER, GL_VERSION, GL_SHADING_LANGUAGE_VERSION
 
 if TYPE_CHECKING:
@@ -79,3 +89,37 @@ class GLInfo(SurfaceInfo):
 
         self.update_features()
         self.was_queried = True
+
+    def update_features(self) -> None:
+        """Populate WebGL-specific feature support."""
+        is_webgl2 = self.have_version(2, 0)
+        self.features = SurfaceFeatures(
+            pixel_buffer_objects=(
+                is_webgl2
+                or self.have_extension("GL_ARB_pixel_buffer_object")
+                or self.have_extension("GL_EXT_pixel_buffer_object")
+                or self.have_extension("GL_NV_pixel_buffer_object")
+            ),
+        )
+
+        bgra_upload = any(
+            self.have_extension(extension)
+            for extension in (
+                "GL_EXT_texture_format_BGRA8888",
+                "GL_APPLE_texture_format_BGRA8888",
+                "GL_IMG_texture_format_BGRA8888",
+            )
+        )
+        self.pixel_transfer = PixelTransferFeatures(
+            bgra_upload=bgra_upload,
+            bgra_readback=self.have_extension("GL_EXT_read_format_bgra"),
+            unpack_row_length=is_webgl2 or self.have_extension("GL_EXT_unpack_subimage"),
+            pack_row_length=is_webgl2 or self.have_extension("GL_NV_pack_subimage"),
+        )
+
+        prefer_bgra = sys.platform == "win32" and bgra_upload
+        self.pixel_format_preferences = PixelFormatPreferences(
+            preferred_decode_format=PixelFormat.BGRA8 if prefer_bgra else PixelFormat.RGBA8,
+            readback_format=PixelFormat.RGBA8,
+        )
+        self._apply_image_decode_policy()

--- a/pyglet/graphics/api/webgl/texture.py
+++ b/pyglet/graphics/api/webgl/texture.py
@@ -438,6 +438,9 @@ class WebGLTexture(Texture):
         align, row_length = self._get_image_alignment(image_data)
 
         self._gl.pixelStorei(GL_UNPACK_ALIGNMENT, align)
+        if not self._context.info.pixel_transfer.unpack_row_length:
+            return
+
         self._gl.pixelStorei(GL_UNPACK_ROW_LENGTH, row_length)
 
         if isinstance(image_data, ImageDataRegion):
@@ -447,6 +450,9 @@ class WebGLTexture(Texture):
                 self._gl.pixelStorei(GL_UNPACK_IMAGE_HEIGHT, image_data.y + image_data.height)
 
     def _end_upload(self, image_data: ImageData | ImageDataRegion) -> None:
+        if not self._context.info.pixel_transfer.unpack_row_length:
+            return
+
         self._gl.pixelStorei(GL_UNPACK_ROW_LENGTH, 0)
 
         if isinstance(image_data, ImageDataRegion):
@@ -497,7 +503,11 @@ class WebGLTexture(Texture):
 
         # Get data in required format (hopefully will be the same format it's already
         # in, unless that's an obscure format, upside-down or the driver is old).
-        data = image_data.convert(upload_fmt, upload_pitch)
+        if self._context.info.pixel_transfer.unpack_row_length:
+            data = image_data.convert(upload_fmt, upload_pitch)
+        else:
+            upload_pitch = image_data.width * len(upload_fmt)
+            data = image_data.get_bytes(upload_fmt, upload_pitch)
         js_array = _to_uint8_array(data)
         fmt, gl_type = _get_gl_format_and_type(upload_fmt)
 
@@ -592,10 +602,12 @@ class WebGLTexture(Texture):
         js_array = _to_uint8_array(image_bytes)
         gl_pfmt, gl_type = _get_gl_format_and_type(pixel_fmt)
 
-        align, row_length = texture._get_image_alignment(image_data)
+        align, _ = texture._get_image_alignment(image_data)
 
         gl.pixelStorei(GL_UNPACK_ALIGNMENT, align)
-        gl.pixelStorei(GL_UNPACK_ROW_LENGTH, row_length)
+        if ctx.info.pixel_transfer.unpack_row_length:
+            # get_bytes above always returns tightly packed rows.
+            gl.pixelStorei(GL_UNPACK_ROW_LENGTH, 0)
 
         gl.texImage2D(
             target,

--- a/pyglet/graphics/api/webgl/texture.py
+++ b/pyglet/graphics/api/webgl/texture.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Sequence
+from typing import TYPE_CHECKING, Callable, cast, Sequence
 
 import js  # noqa: F821
 import pyodide  # noqa: F821
 
 import pyglet
+from pyglet.graphics.api.base import SurfaceContext
 from pyglet.enums import TextureFilter, TextureType, ComponentFormat, \
     AddressMode
 from pyglet.graphics.api.webgl.enums import texture_map
@@ -633,7 +634,10 @@ class WebGLTexture(Texture):
                filters: TextureFilter | tuple[TextureFilter, TextureFilter] | None = None,
                address_mode: AddressMode = AddressMode.REPEAT,
                anisotropic_level: int = 0,
-               blank_data: bool = True, context: OpenGLSurfaceContext | None = None) -> WebGLTexture:
+               blank_data: bool = True,
+               immutable: bool = False,
+               mipmap_levels: int = 1,
+               context: SurfaceContext | None = None) -> WebGLTexture:
         """Create a Texture.
 
         Create a Texture with the specified dimensions, and attributes.
@@ -659,13 +663,22 @@ class WebGLTexture(Texture):
                 The maximum anisotropic level.
             blank_data:
                 If True, initialize the texture data with all zeros. If False, do not pass initial data.
+            immutable:
+                If True, allocate immutable-format texture storage.
+            mipmap_levels:
+                Number of mipmap levels to allocate.
             context:
                 A specific OpenGL Surface context, otherwise the current active context.
 
         Returns:
             A currently bound texture.
         """
-        ctx = context or pyglet.graphics.api.core.current_context
+        if immutable:
+            raise NotImplementedError("Immutable texture creation is not implemented by the WebGL backend.")
+        if mipmap_levels != 1:
+            raise NotImplementedError("Explicit mipmap allocation is not implemented by the WebGL backend.")
+
+        ctx = cast("OpenGLSurfaceContext", context or pyglet.graphics.api.core.current_context)
         gl = ctx.gl
 
         tex_id = gl.createTexture()

--- a/pyglet/graphics/texture.py
+++ b/pyglet/graphics/texture.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import struct
 import sys
+from dataclasses import dataclass
 from typing import Generic, Iterator, Literal, Protocol, Sequence, TYPE_CHECKING, TypeVar, overload
 
 import pyglet
+from pyglet.customtypes import Buffer, DataTypes
 from pyglet.enums import AddressMode, ComponentFormat, TextureFilter, TextureType, GraphicsAPI
 from pyglet.image.base import (
     _AbstractImage,
@@ -29,6 +32,38 @@ class TextureArrayDepthExceeded(ImageException):
 
 
 TTexture = TypeVar("TTexture", bound="Texture")
+
+
+@dataclass(frozen=True)
+class PixelData:
+    """Typed pixel data read from GPU memory.
+
+    Unlike :class:`~pyglet.image.ImageData`, this class does not perform image
+    format conversions. Its data is stored as tightly packed native values of
+    ``data_type``.
+    """
+
+    width: int
+    height: int
+    format: ComponentFormat
+    data_type: DataTypes
+    data: Buffer
+
+    @property
+    def pitch(self) -> int:
+        """Number of bytes in one tightly packed row."""
+        return self.width * len(self.format.value) * struct.calcsize(self.data_type)
+
+    def __bytes__(self) -> bytes:
+        return bytes(self.data)
+
+    def to_image_data(self) -> ImageData:
+        """Return an :class:`~pyglet.image.ImageData` view of this pixel data.
+
+        No pixel conversion is performed. ``ImageData`` retains this object's
+        underlying buffer until it needs to convert or repack it.
+        """
+        return ImageData(self.width, self.height, self.format.value, self.data, self.pitch, self.data_type)
 
 
 class TextureSequence(_AbstractImageSequence, Generic[TTexture]):
@@ -255,17 +290,37 @@ class Texture(_AbstractImage):
         raise NotImplementedError("This method has been removed. See the 3.0 migration documentation.")
 
     def fetch(self, z: int = 0, level: int = 0) -> ImageData:
-        """Fetch the image data of this texture by reading pixel data back from the GPU.
+        """Fetch an image-oriented copy of this texture from the GPU.
 
-        This can be a somewhat costly operation.
+        Reading data back from the GPU can be a costly operation.
 
         Modifying the returned ImageData object has no effect on the
         texture itself. Uploading ImageData back to the GPU/texture
         can be done with the :py:meth:`~Texture.upload` method.
 
+        The returned :class:`~pyglet.image.ImageData` uses unsigned-byte image
+        components. Floating-point and integer textures are unsupported here;
+        use :meth:`read_pixels` to retrieve their typed pixel values instead.
+
         Args:
             z:
                 For 3D textures, the image slice to retrieve.
+            level:
+                The mipmap level of the texture to retrieve.
+        """
+        raise NotImplementedError
+
+    def read_pixels(self, z: int = 0, level: int = 0) -> PixelData:
+        """Read typed pixel values from this texture.
+
+        Floating-point and integer textures retain their numeric data type;
+        normalized textures use unsigned-byte components. Unlike
+        :meth:`fetch`, this method does not provide general-purpose image
+        conversion.
+
+        Args:
+            z:
+                For 3D or array textures, the image layer to retrieve.
             level:
                 The mipmap level of the texture to retrieve.
         """
@@ -599,6 +654,21 @@ class _TextureRegionShared:
     def fetch(self, _z: int = 0, level: int = 0) -> ImageDataRegion:
         image_data = self.owner.fetch(self.z, level)
         return image_data.get_region(self.x, self.y, self.width, self.height)
+
+    def read_pixels(self, _z: int = 0, level: int = 0) -> PixelData:
+        """Read typed pixel values for this region from its owning texture."""
+        pixels = self.owner.read_pixels(self.z, level)
+        component_size = struct.calcsize(pixels.data_type)
+        pixel_size = len(pixels.format.value) * component_size
+        width = max(1, self.width >> level)
+        height = max(1, self.height >> level)
+        x = self.x >> level
+        y = self.y >> level
+        rows = []
+        for row in range(y, y + height):
+            start = row * pixels.pitch + x * pixel_size
+            rows.append(pixels.data[start:start + width * pixel_size])
+        return PixelData(width, height, pixels.format, pixels.data_type, b"".join(rows))
 
     def get_image_data(self) -> ImageDataRegion:
         return self.fetch()

--- a/pyglet/graphics/texture.py
+++ b/pyglet/graphics/texture.py
@@ -159,6 +159,7 @@ class Texture(_AbstractImage):
         super().__init__(width, height)
         self.id = tex_id
         self.tex_type = tex_type
+        self.immutable = False
         self._mipmap_levels = 1
         self._valid_mipmaps: set[int] = set()
 
@@ -207,11 +208,14 @@ class Texture(_AbstractImage):
     def create(cls, width: int, height: int,
                tex_type: TextureType = TextureType.TYPE_2D,
                internal_format: ComponentFormat = ComponentFormat.RGBA,
-               data_type: str = "b",
+               internal_format_size: int = 8,
+               internal_format_type: str = "B",
                filters: TextureFilter | tuple[TextureFilter, TextureFilter] | None = None,
                address_mode: AddressMode = AddressMode.REPEAT,
                anisotropic_level: int = 0,
                blank_data: bool = True,
+               immutable: bool = False,
+               mipmap_levels: int = 1,
                context: SurfaceContext | None = None) -> Texture:
         """Create a Texture.
 
@@ -227,8 +231,10 @@ class Texture(_AbstractImage):
                 The type of texture.
             internal_format:
                 The components of the internal format.
-            data_type:
-                The data type of the internal format, as a struct string value.
+            internal_format_size:
+                Bit size of each component in the internal format.
+            internal_format_type:
+                Internal format type, as a struct string value.
             filters:
                 The texture filter for the min and mag filters. If a single value is passed, both values will
                 be used as the filter.
@@ -238,6 +244,10 @@ class Texture(_AbstractImage):
                 The anisotropic level of the texture.
             blank_data:
                 If True, initialize the texture data with all zeros. If False, do not pass initial data.
+            immutable:
+                If True, allocate immutable-format texture storage.
+            mipmap_levels:
+                Number of mipmap levels to allocate. Immutable textures cannot add levels later.
             context:
                 If multiple contexts are being used, a specified context the texture is tied to.
         """
@@ -429,6 +439,12 @@ class Texture(_AbstractImage):
                 If True, initialize levels with zeroed data. If False, allocate the
                 levels without initializing their contents.
         """
+        if self.immutable:
+            raise ImageException(
+                "Immutable texture mipmap levels are fixed at creation. "
+                "Pass mipmap_levels to Texture.create()."
+            )
+
         max_levels = self._compute_mipmap_count()
         target_levels = levels if levels is not None else max_levels
         if target_levels < 1:
@@ -462,7 +478,8 @@ class Texture(_AbstractImage):
         """Generate mipmaps for this texture from the base level."""
         self.bind()
         self._generate_mipmaps()
-        self._mipmap_levels = max(self._mipmap_levels, self._compute_mipmap_count())
+        if not self.immutable:
+            self._mipmap_levels = max(self._mipmap_levels, self._compute_mipmap_count())
         self._valid_mipmaps = set(range(self._mipmap_levels))
 
     def get_mipmapped_texture(self) -> Texture:

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -748,7 +748,7 @@ class IndexedVertexDomain(VertexDomain):
     def __init__(self, context: SurfaceContext, initial_count: int, attribute_meta: dict[str, Attribute],
                  index_type: DataTypes = "I") -> None:
         self.index_type = index_type
-        self._supports_base_vertex = context.info.have_extension("GL_ARB_draw_elements_base_vertex")
+        self._supports_base_vertex = context.info.features.base_vertex
         super().__init__(context, initial_count, attribute_meta)
 
     def get_group_bucket(self, group: Group) -> IndexedVertexGroupBucket:

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -96,11 +96,12 @@ use of the data in this arbitrary format).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, BinaryIO
 
-import pyglet
 
 if TYPE_CHECKING:
+    from pyglet.enums import PixelFormat
     from pyglet.customtypes import RGBAColor
 
 from pyglet.image import animation  # noqa: F401
@@ -111,6 +112,31 @@ from pyglet.image.base import ImageGrid, ImagePattern, _color_as_bytes  # noqa: 
 from pyglet.image.codecs import ImageDecoder
 from pyglet.image.codecs import add_default_codecs as _add_default_codecs
 from pyglet.image.codecs import registry as _codec_registry
+
+
+@dataclass(frozen=True)
+class ImageDecodePolicy:
+    """Backend-optimal 32-bit output format for decoders to choose efficiently."""
+
+    preferred_format: PixelFormat | None = None
+
+
+_default_decode_policy = ImageDecodePolicy()
+
+
+def get_default_decode_policy() -> ImageDecodePolicy:
+    """Return the process-wide format policy used by image decoders."""
+    return _default_decode_policy
+
+
+def set_default_decode_policy(policy: ImageDecodePolicy) -> None:
+    """Set decoder output preferences."""
+    # This avoids coupling image codecs to a graphics backend.
+    if not isinstance(policy, ImageDecodePolicy):
+        raise TypeError("Policy must be an ImageDecodePolicy.")
+
+    global _default_decode_policy  # noqa: PLW0603
+    _default_decode_policy = policy
 
 
 def load(filename: str, file: BinaryIO | None = None, decoder: ImageDecoder | None = None) -> ImageData:

--- a/pyglet/image/codecs/pil.py
+++ b/pyglet/image/codecs/pil.py
@@ -1,7 +1,7 @@
 import os.path
 
-from pyglet.image import *
-from pyglet.image.codecs import *
+from pyglet.image import ImageData
+from pyglet.image.codecs import ImageDecodeException, ImageDecoder, ImageEncodeException, ImageEncoder
 
 from PIL import Image
 

--- a/pyglet/image/codecs/wic.py
+++ b/pyglet/image/codecs/wic.py
@@ -4,9 +4,9 @@ import os
 from ctypes import byref, memmove
 from typing import BinaryIO, Sequence
 
-import pyglet
-from pyglet.image import ImageData
-from pyglet.image.codecs import ImageDecodeException, ImageDecoder, ImageEncoder
+from pyglet.enums import PixelFormat
+from pyglet.image import ImageData, get_default_decode_policy
+from pyglet.image.codecs import ImageDecodeException, ImageDecoder, ImageEncodeException, ImageEncoder
 from pyglet.libs.win32.wincodec import (
     CLSID_WICImagingFactory1,
     CLSID_WICImagingFactory2,
@@ -44,6 +44,7 @@ from pyglet.libs.win32 import _ole32 as ole32
 from pyglet.libs.win32 import com
 from pyglet.libs.win32.constants import (
     CLSCTX_INPROC_SERVER,
+    GENERIC_READ,
     GENERIC_WRITE,
     GMEM_MOVEABLE,
     STREAM_SEEK_SET,
@@ -96,6 +97,9 @@ def _get_bitmap_frame(bitmap_decoder: IWICBitmapDecoder, frame_index: int) -> IW
     bitmap_decoder.GetFrame(frame_index, byref(bitmap))
     return bitmap
 
+_guid_null = com.GUID(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+
 def get_bitmap(width: int, height: int, target_fmt: com.GUID=GUID_WICPixelFormat32bppBGRA) -> IWICBitmap:
     """Create a WIC Bitmap.
 
@@ -109,14 +113,20 @@ def get_bitmap(width: int, height: int, target_fmt: com.GUID=GUID_WICPixelFormat
     return bitmap
 
 
-def extract_image_data(bitmap: IWICBitmap, target_fmt: com.GUID = GUID_WICPixelFormat32bppBGRA) -> ImageData:
+def extract_image_data(bitmap: IWICBitmap, target_fmt: com.GUID | None = None) -> ImageData:
     """Extra image data from IWICBitmap into ImageData, specifying target format.
 
     .. note:: ``bitmap`` is released before this function returns.
     """
-    if "es" in pyglet.options.backend:
-        target_fmt = GUID_WICPixelFormat32bppRGBA
+    if target_fmt is None:
+        pixel_format = get_default_decode_policy().preferred_format or PixelFormat.BGRA8
+        target_fmt = (
+            GUID_WICPixelFormat32bppRGBA if pixel_format == PixelFormat.RGBA8 else GUID_WICPixelFormat32bppBGRA
+        )
+    if target_fmt == GUID_WICPixelFormat32bppRGBA:
         fmt = "RGBA"
+    elif target_fmt == GUID_WICPixelFormat24bppBGR:
+        fmt = "BGR"
     else:
         fmt = "BGRA"
 
@@ -140,11 +150,9 @@ def extract_image_data(bitmap: IWICBitmap, target_fmt: com.GUID = GUID_WICPixelF
         conversion_possible = BOOL()
         converter.CanConvert(pf, target_fmt, byref(conversion_possible))
 
-        # 99% of the time conversion will be possible to default.
-        # However, we check to be safe and fallback to 24 bit BGR if not possible.
+        # 99% of the time conversion will be possible to the preferred format.
+        # However, check and fall back to 24-bit BGR if it is not.
         if not conversion_possible:
-            if "es" in pyglet.options.backend:
-                    raise Exception("Could not convert image to proper format.")
             target_fmt = GUID_WICPixelFormat24bppBGR
             fmt = 'BGR'
 
@@ -207,19 +215,30 @@ class WICDecoder(ImageDecoder):
 
         return decoder, stream
 
+    def _load_bitmap_decoder_from_filename(self, filename: str) -> IWICBitmapDecoder:
+        """Create a decoder directly from a path, without copying it through Python memory."""
+        decoder = IWICBitmapDecoder()
+        self._factory.CreateDecoderFromFilename(
+            filename, _guid_null, GENERIC_READ, WICDecodeMetadataCacheOnDemand, byref(decoder),
+        )
+        return decoder
+
     def decode(self, filename: str, file: BinaryIO | None) -> ImageData:
         if not file:
-            with open(filename, 'rb') as f:
-                bitmap_decoder, stream = self._load_bitmap_decoder(filename, f)
+            bitmap_decoder = self._load_bitmap_decoder_from_filename(filename)
+            try:
                 bitmap = _get_bitmap_frame(bitmap_decoder, 0)
                 image_data = extract_image_data(bitmap)
+            finally:
+                bitmap_decoder.Release()
         else:
             bitmap_decoder, stream = self._load_bitmap_decoder(filename, file)
-            bitmap = _get_bitmap_frame(bitmap_decoder, 0)
-            image_data = extract_image_data(bitmap)
-
-        bitmap_decoder.Release()
-        stream.Release()
+            try:
+                bitmap = _get_bitmap_frame(bitmap_decoder, 0)
+                image_data = extract_image_data(bitmap)
+            finally:
+                bitmap_decoder.Release()
+                stream.Release()
         return image_data
 
     @staticmethod
@@ -278,76 +297,79 @@ class WICEncoder(ImageEncoder):  # noqa: D101
         # Choose container based on extension. Default to PNG.
         container = extension_to_container.get(ext, GUID_ContainerFormatPng)
 
-        _factory.CreateStream(byref(wicstream))
-        # https://docs.microsoft.com/en-us/windows/win32/wic/-wic-codec-native-pixel-formats#native-image-formats
-        if container == GUID_ContainerFormatJpeg:
-            # Expects BGR, no transparency available. Hard coded.
-            fmt = 'BGR'
-            default_format = GUID_WICPixelFormat24bppBGR
-        else:
-            # Windows encodes in BGRA.
-            if len(image.format) == 3:
+        istream = None
+        try:
+            _factory.CreateStream(byref(wicstream))
+            # https://docs.microsoft.com/en-us/windows/win32/wic/-wic-codec-native-pixel-formats#native-image-formats
+            if container == GUID_ContainerFormatJpeg:
+                # Expects BGR, no transparency available. Hard coded.
                 fmt = 'BGR'
                 default_format = GUID_WICPixelFormat24bppBGR
             else:
-                fmt = 'BGRA'
-                default_format = GUID_WICPixelFormat32bppBGRA
+                # Windows encodes in BGRA.
+                if len(image.format) == 3:
+                    fmt = 'BGR'
+                    default_format = GUID_WICPixelFormat24bppBGR
+                else:
+                    fmt = 'BGRA'
+                    default_format = GUID_WICPixelFormat32bppBGRA
 
-        pitch = image.width * len(fmt)
+            pitch = image.width * len(fmt)
+            image_data = image.get_bytes(fmt, -pitch)
+            size = pitch * image.height
 
-        image_data = image.get_bytes(fmt, -pitch)
-
-        size = pitch * image.height
-
-        if file:
-            istream = IStream()
-            ole32.CreateStreamOnHGlobal(None, True, byref(istream))
-            wicstream.InitializeFromIStream(istream)
-        else:
-            istream = None
-            wicstream.InitializeFromFilename(filename, GENERIC_WRITE)
-
-        _factory.CreateEncoder(container, None, byref(encoder))
-
-        encoder.Initialize(wicstream, WICBitmapEncoderNoCache)
-
-        encoder.CreateNewFrame(byref(frame), byref(property_bag))
-
-        frame.Initialize(property_bag)
-
-        frame.SetSize(image.width, image.height)
-
-        frame.SetPixelFormat(byref(default_format))
-
-        data = (BYTE * size).from_buffer(bytearray(image_data))
-
-        frame.WritePixels(image.height, pitch, size, data)
-
-        frame.Commit()
-
-        encoder.Commit()
-
-        if file and istream:
-            sts = STATSTG()
-            istream.Stat(byref(sts), 0)
-            stream_size = sts.cbSize
-            istream.Seek(0, STREAM_SEEK_SET, None)
-
-            buf = (BYTE * stream_size)()
-            written = ULONG()
-            istream.Read(byref(buf), stream_size, byref(written))
-
-            if written.value == stream_size:
-                file.write(buf)
+            if file:
+                istream = IStream()
+                ole32.CreateStreamOnHGlobal(None, True, byref(istream))
+                wicstream.InitializeFromIStream(istream)
             else:
-                print(f"Failed to read all of the data from stream attempting to save {file}")
+                wicstream.InitializeFromFilename(filename, GENERIC_WRITE)
 
-            istream.Release()
+            _factory.CreateEncoder(container, None, byref(encoder))
+            encoder.Initialize(wicstream, WICBitmapEncoderNoCache)
+            encoder.CreateNewFrame(byref(frame), byref(property_bag))
+            frame.Initialize(property_bag)
+            frame.SetSize(image.width, image.height)
 
-        encoder.Release()
-        frame.Release()
-        property_bag.Release()
-        wicstream.Release()
+            # SetPixelFormat is an in/out parameter. Never let WIC overwrite
+            # the module-level GUID constants shared by the decoder.
+            pixel_format = default_format.copy()
+            frame.SetPixelFormat(byref(pixel_format))
+
+            # WritePixels consumes the buffer synchronously. Keep the backing
+            # bytearray alive until it returns.
+            data_buffer = bytearray(image_data)
+            data = (BYTE * size).from_buffer(data_buffer)
+            frame.WritePixels(image.height, pitch, size, data)
+            frame.Commit()
+            encoder.Commit()
+
+            if file and istream:
+                sts = STATSTG()
+                istream.Stat(byref(sts), 0)
+                stream_size = sts.cbSize
+                istream.Seek(0, STREAM_SEEK_SET, None)
+
+                buf = (BYTE * stream_size)()
+                written = ULONG()
+                istream.Read(byref(buf), stream_size, byref(written))
+
+                if written.value == stream_size:
+                    file.write(buf)
+                else:
+                    msg = f"WIC could not read all encoded data for {file!r}"
+                    raise ImageEncodeException(msg)
+        finally:
+            if istream:
+                istream.Release()
+            if frame:
+                frame.Release()
+            if property_bag:
+                property_bag.Release()
+            if encoder:
+                encoder.Release()
+            if wicstream:
+                wicstream.Release()
 
 
 def get_encoders() -> Sequence[ImageEncoder]:  # noqa: D103

--- a/pyglet/info.py
+++ b/pyglet/info.py
@@ -4,14 +4,24 @@ Intended usage is to create a file for bug reports, e.g.::
 
     python -m pyglet.info > info.txt
 
+Graphics API and version support can be tested in isolated subprocesses::
+
+    python -m pyglet.info --probe-graphics > info.txt
+
+One specific configuration can also be requested::
+
+    python -m pyglet.info --backend gles3 --version 3.1
+
 """
 from __future__ import annotations
 # ruff: noqa: T201, PLW0603, BLE001, SLF001
 
 import os
+import json
+import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 from pyglet.enums import GraphicsAPI
 
@@ -22,6 +32,18 @@ if TYPE_CHECKING:
 _first_heading: bool = True
 _printed_extensions_hint: bool = False
 _EXTENSION_PREVIEW_LIMIT = 12
+_GRAPHICS_WORKER_PREFIX = "PYGLET_GRAPHICS_PROBE="
+_GRAPHICS_PROBES = (
+    # A versionless desktop request lets the driver select its preferred modern context.
+    (GraphicsAPI.OPENGL, None),
+    (GraphicsAPI.OPENGL, (3, 3)),
+    (GraphicsAPI.OPENGL_ES_3, (3, 2)),
+    (GraphicsAPI.OPENGL_ES_3, (3, 1)),
+    (GraphicsAPI.OPENGL_ES_3, (3, 0)),
+    (GraphicsAPI.OPENGL_2, (2, 1)),
+    (GraphicsAPI.OPENGL_2, (2, 0)),
+    (GraphicsAPI.OPENGL_ES_2, (2, 0)),
+)
 
 
 def _heading(heading: str) -> None:
@@ -36,6 +58,10 @@ def _heading(heading: str) -> None:
 
 def _show_full_extensions() -> bool:
     return "-extensions" in sys.argv
+
+
+def _show_verbose_errors() -> bool:
+    return "--verbose" in sys.argv
 
 
 def _dump_extensions(name: str, extensions: Iterable[str]) -> None:
@@ -69,6 +95,15 @@ def _is_opengl_backend(backend: GraphicsAPI) -> bool:
     )
 
 
+def _graphics_api_family(api: GraphicsAPI | str) -> str:
+    api = GraphicsAPI(api)
+    if api in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_2):
+        return "desktop"
+    if api in (GraphicsAPI.OPENGL_ES_2, GraphicsAPI.OPENGL_ES_3):
+        return "es"
+    return api.value
+
+
 def dump_platform() -> None:
     """Dump OS specific."""
     import platform  # noqa: PLC0415
@@ -88,7 +123,7 @@ def dump_python() -> None:
     print("sys.version:", sys.version)
     print("sys.maxint:", sys.maxsize)
     print("sys.argv:", sys.argv)
-    print('os.getcwd():', os.getcwd())
+    print('os.getcwd():', Path.cwd())
     for key, value in os.environ.items():
         if key.startswith("PYGLET_"):
             print(f"os.environ['{key}']: {value}")
@@ -105,58 +140,150 @@ def dump_pyglet() -> None:
         print(f"pyglet.options.{key} = {value!r}")
 
 
-def dump_window() -> None:
+def _dump_window(window: Any) -> None:
+    """Dump an already-created window without taking ownership of it."""
+    display = window.display
+    print("display:", repr(display))
+    print("window:", repr(window))
+    print("window.get_size():", window.get_size())
+    print("window.get_framebuffer_size():", window.get_framebuffer_size())
+    print("window.get_pixel_ratio():", window.get_pixel_ratio())
+
+    screens = display.get_screens()
+    for i, screen in enumerate(screens):
+        print(f"screens[{i}]: {screen!r}")
+    print("window.context:", repr(window.context))
+
+
+def dump_window(window: Any | None = None) -> None:
     """Dump display, window, and screen info."""
     import pyglet.window  # noqa: PLC0415
 
-    window = pyglet.window.Window(visible=False)
+    owns_window = window is None
+    window = window or pyglet.window.Window(visible=False)
     try:
-        display = window.display
-        print("display:", repr(display))
-        print("window:", repr(window))
-        print("window.get_size():", window.get_size())
-        print("window.get_framebuffer_size():", window.get_framebuffer_size())
-        print("window.get_pixel_ratio():", window.get_pixel_ratio())
-
-        screens = display.get_screens()
-        for i, screen in enumerate(screens):
-            print(f"screens[{i}]: {screen!r}")
-        print("window.context:", repr(window.context))
+        _dump_window(window)
     finally:
-        window.close()
+        if owns_window:
+            window.close()
 
 
-def dump_backend() -> None:
-    """Dump active backend details and selected surface config."""
+def _dump_backend(window: Any) -> None:
+    """Dump backend details from an already-created window."""
     import pyglet  # noqa: PLC0415
-    import pyglet.window  # noqa: PLC0415
     from pyglet.graphics.api import core  # noqa: PLC0415
 
-    window = pyglet.window.Window(visible=False)
+    print("status: available")
+    print("configured backend option:", pyglet.options.backend)
+    print("active context:", repr(window.context))
+
+    if _is_opengl_backend(pyglet.options.backend):
+        actual_api = window.context.info.get_opengl_api()
+        if _graphics_api_family(actual_api) != _graphics_api_family(pyglet.options.backend):
+            print(f"WARNING: requested {pyglet.options.backend}, but the driver returned {actual_api}.")
+
+    if _is_opengl_backend(pyglet.options.backend) and (
+        (not core.have_version(3) and pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_ES_3))
+        or (
+            not core.have_version(2)
+            and pyglet.options.backend in (GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2)
+        )
+    ):
+        print(f"Insufficient OpenGL version: {core.info.get_version_string()}")
+        return
+
+    _heading("backend.selected_surface_config")
+    print("Selected surface config attributes (chosen by backend/system):")
+    for key, value in window.config.attributes.items():
+        print(f"selected_config['{key}'] = {value!r}")
+
+    _heading("backend.graphics_api")
+    dump_graphics_api(window.context)
+
+    _heading("backend.platform_api")
+    dump_backend_platform_api(window.context)
+
+
+def dump_backend(window: Any | None = None) -> None:
+    """Dump active backend details and selected surface config."""
+    import pyglet.window  # noqa: PLC0415
+
+    owns_window = window is None
+    window = window or pyglet.window.Window(visible=False)
     try:
-        print("configured backend option:", pyglet.options.backend)
-        print("active context:", repr(window.context))
+        _dump_backend(window)
+    finally:
+        if owns_window:
+            window.close()
 
-        if _is_opengl_backend(pyglet.options.backend) and (
-            (not core.have_version(3) and pyglet.options.backend in (GraphicsAPI.OPENGL, GraphicsAPI.OPENGL_ES_3))
-            or (
-                not core.have_version(2)
-                and pyglet.options.backend in (GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2)
-            )
-        ):
-            print(f"Insufficient OpenGL version: {core.info.get_version_string()}")
-            return
 
-        _heading("backend.selected_surface_config")
-        print("Selected surface config attributes (chosen by backend/system):")
-        for key, value in window.config.attributes.items():
-            print(f"selected_config['{key}'] = {value!r}")
+def _requested_graphics_details(config: Any | None) -> tuple[Any, Any, Any]:
+    """Return the requested backend and version without creating a context."""
+    import pyglet  # noqa: PLC0415
 
-        _heading("backend.graphics_api")
-        dump_graphics_api(window.context)
+    backend = pyglet.options.backend
+    requested = getattr(config, backend, None) if config is not None else None
+    if requested is None:
+        from pyglet.graphics.api import get_default_configs  # noqa: PLC0415
 
-        _heading("backend.platform_api")
-        dump_backend_platform_api(window.context)
+        try:
+            defaults = get_default_configs()
+        except Exception:
+            defaults = ()
+        requested = defaults[0] if defaults else None
+
+    return backend, getattr(requested, "major_version", None), getattr(requested, "minor_version", None)
+
+
+def _print_graphics_failure(exc: Exception, config: Any | None) -> None:
+    """Print a useful, redirect-safe summary for graphics initialization errors."""
+    backend, major, minor = _requested_graphics_details(config)
+    print("status: context creation failed")
+    print("requested backend:", backend)
+    if major is not None:
+        print(f"requested version: {major}.{minor or 0}")
+    print(f"exception: {type(exc).__name__}: {exc}")
+    print("This request failing does not necessarily mean that graphics are unavailable.")
+    print("Run 'python -m pyglet.info --probe-graphics' to test other supported configurations.")
+    print("Pass --verbose to include the full traceback.")
+    if _show_verbose_errors():
+        import traceback  # noqa: PLC0415
+
+        traceback.print_exc(file=sys.stdout)
+
+
+def _print_dump_failure(exc: Exception) -> None:
+    print("status: diagnostic collection failed")
+    print(f"exception: {type(exc).__name__}: {exc}")
+    if _show_verbose_errors():
+        import traceback  # noqa: PLC0415
+
+        traceback.print_exc(file=sys.stdout)
+
+
+def dump_window_and_backend(config: Any | None = None) -> None:
+    """Create one diagnostic window and use it for all graphics output."""
+    import pyglet.window  # noqa: PLC0415
+
+    _heading("pyglet.window")
+    try:
+        window = pyglet.window.Window(visible=False, config=config)
+    except Exception as exc:
+        _print_graphics_failure(exc, config)
+        _heading("pyglet.graphics.backend")
+        print("status: unavailable because diagnostic context creation failed")
+        return
+
+    try:
+        try:
+            _dump_window(window)
+        except Exception as exc:
+            _print_dump_failure(exc)
+        _heading("pyglet.graphics.backend")
+        try:
+            _dump_backend(window)
+        except Exception as exc:
+            _print_dump_failure(exc)
     finally:
         window.close()
 
@@ -187,6 +314,8 @@ def dump_graphics_api(context: OpenGLSurfaceContext | None = None) -> None:
     print("info.max_uniform_buffer_bindings:", info.MAX_UNIFORM_BUFFER_BINDINGS)
     print("info.max_uniform_block_size:", info.MAX_UNIFORM_BLOCK_SIZE)
     print("info.max_vertex_attribs:", info.MAX_VERTEX_ATTRIBS)
+    for feature, available in vars(info.features).items():
+        print(f"info.features.{feature}:", available)
     _dump_extensions("info.extensions", info.get_extensions())
 
 
@@ -370,25 +499,251 @@ def _try_dump(heading: str, func: Callable[[], None]) -> None:
     _heading(heading)
     try:
         func()
-    except Exception:
-        import traceback  # noqa: PLC0415
-
-        traceback.print_exc()
+    except Exception as exc:
+        _print_dump_failure(exc)
 
 
-def dump() -> None:
+def _make_graphics_config(backend: GraphicsAPI, version: tuple[int, int] | None) -> Any:
+    """Build a conservative config for a single graphics probe."""
+    import pyglet  # noqa: PLC0415
+
+    config = pyglet.config.Config()
+    backend_config = getattr(config, backend)
+    if version is None:
+        backend_config.major_version = backend_config.minor_version = None
+    else:
+        backend_config.major_version, backend_config.minor_version = version
+    backend_config.double_buffer = True
+    backend_config.depth_size = 16
+    return config
+
+
+def _graphics_probe_worker(backend_name: str, version_text: str) -> int:
+    """Create one context and emit a machine-readable result for the parent."""
+    import pyglet  # noqa: PLC0415
+
+    backend = GraphicsAPI(backend_name)
+    version = None if version_text == "default" else _parse_version(version_text)
+    result: dict[str, Any] = {
+        "backend": backend.value,
+        "requested_version": list(version) if version is not None else None,
+        "success": False,
+    }
+    window = None
+    try:
+        pyglet.options.backend = backend
+        pyglet.options.debug_api = False
+        config = _make_graphics_config(backend, version)
+        import pyglet.window  # noqa: PLC0415
+
+        window = pyglet.window.Window(visible=False, config=config)
+        info = window.context.info
+        actual_api = info.get_opengl_api()
+        if _graphics_api_family(actual_api) != _graphics_api_family(backend):
+            result.update(
+                error_type="GraphicsAPIMismatch",
+                error=f"requested {backend.value}, but the driver returned {actual_api}",
+                actual_api=str(actual_api),
+                actual_version=list(info.get_version()),
+            )
+        else:
+            from pyglet.graphics.api import get_default_shader  # noqa: PLC0415
+            from pyglet.shapes import get_default_shader as get_default_shapes_shader  # noqa: PLC0415
+
+            get_default_shader()
+            get_default_shapes_shader()
+            result.update(
+                success=True,
+                actual_api=str(actual_api),
+                actual_version=list(info.get_version()),
+                version_string=info.get_version_string(),
+                renderer=info.get_renderer(),
+                features=vars(info.features),
+            )
+    except Exception as exc:
+        result.update(error_type=type(exc).__name__, error=str(exc))
+    finally:
+        if window is not None:
+            window.close()
+
+    print(_GRAPHICS_WORKER_PREFIX + json.dumps(result, sort_keys=True))
+    return 0
+
+
+def _parse_graphics_worker_output(output: str) -> dict[str, Any] | None:
+    for line in reversed(output.splitlines()):
+        if line.startswith(_GRAPHICS_WORKER_PREFIX):
+            try:
+                return json.loads(line.removeprefix(_GRAPHICS_WORKER_PREFIX))
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def _run_graphics_probe(backend: GraphicsAPI, version: tuple[int, int] | None) -> dict[str, Any]:
+    """Run one probe in a clean interpreter to isolate backend global state."""
+    env = os.environ.copy()
+    env["PYGLET_BACKEND"] = backend.value
+    env["PYGLET_DEBUG_API"] = "false"
+    command = (
+        sys.executable,
+        "-m",
+        "pyglet.info",
+        "--graphics-worker",
+        backend.value,
+        _format_graphics_probe_version(version),
+    )
+    try:
+        completed = subprocess.run(  # noqa: S603
+            command,
+            capture_output=True,
+            check=False,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "backend": backend.value,
+            "requested_version": list(version) if version is not None else None,
+            "success": False,
+            "error_type": "TimeoutExpired",
+            "error": "probe did not finish within 15 seconds",
+        }
+
+    result = _parse_graphics_worker_output(completed.stdout)
+    if result is not None:
+        return result
+
+    error = completed.stderr.strip() or completed.stdout.strip() or f"worker exited with code {completed.returncode}"
+    return {
+        "backend": backend.value,
+        "requested_version": list(version) if version is not None else None,
+        "success": False,
+        "error_type": "WorkerError",
+        "error": error.splitlines()[-1],
+    }
+
+
+def dump_graphics_probe() -> None:
+    """Probe pyglet graphics backends and versions in isolated processes."""
+    _heading("Graphics capability probe")
+    print("Each request is tested in a separate process. Please wait...")
+    print(f"{'Backend':<9} {'Request':<9} {'Result':<9} {'Actual API/version or error'}")
+    print(f"{'-' * 7:<9} {'-' * 7:<9} {'-' * 7:<9} {'-' * 37}")
+
+    results = [_run_graphics_probe(backend, version) for backend, version in _GRAPHICS_PROBES]
+    for result in results:
+        backend = result["backend"]
+        requested = _format_graphics_probe_version(result["requested_version"])
+        if result["success"]:
+            actual = ".".join(str(part) for part in result["actual_version"])
+            details = f"{result['actual_api']} {actual} ({result['renderer']})"
+            status = "success"
+        else:
+            details = f"{result.get('error_type', 'Error')}: {result.get('error', 'unknown error')}"
+            status = "failed"
+        print(f"{backend:<9} {requested:<9} {status:<9} {details}")
+
+    successful = [result for result in results if result["success"]]
+    if successful:
+        suggested = max(successful, key=_graphics_probe_priority)
+        requested = _format_graphics_probe_version(suggested["requested_version"])
+        print()
+        print(f"recommended request: {suggested['backend']} {requested}")
+        command = f"python -m pyglet.info --backend {suggested['backend']}"
+        if suggested["requested_version"] is not None:
+            command += f" --version {requested}"
+        print(f"suggested info command: {command}")
+    else:
+        print()
+        print("No probed pyglet graphics configuration created a context.")
+
+
+def _graphics_probe_priority(result: dict[str, Any]) -> tuple[int, int]:
+    """Prefer pyglet's modern desktop backend, then modern GLES, then legacy backends."""
+    backend = GraphicsAPI(result["backend"])
+    version = result["requested_version"]
+    if backend == GraphicsAPI.OPENGL:
+        if version is None:
+            return 500, 0
+        return 400, version[0] * 10 + version[1]
+    if backend == GraphicsAPI.OPENGL_ES_3:
+        return 300, version[0] * 10 + version[1]
+    if backend == GraphicsAPI.OPENGL_2:
+        return 200, version[0] * 10 + version[1]
+    if backend == GraphicsAPI.OPENGL_ES_2:
+        return 100, version[0] * 10 + version[1]
+    return 0, 0
+
+
+def _format_graphics_probe_version(version: tuple[int, int] | list[int] | None) -> str:
+    """Return a human- and worker-readable graphics probe request version."""
+    return "default" if version is None else ".".join(str(part) for part in version)
+
+
+def dump(graphics_config: Any | None = None) -> None:
     """Dump all information to stdout."""
     import pyglet  # noqa: PLC0415
 
     _try_dump("Platform", dump_platform)
     _try_dump("Python", dump_python)
     _try_dump("pyglet", dump_pyglet)
-    _try_dump("pyglet.window", dump_window)
-    _try_dump("pyglet.graphics.backend", dump_backend)
+    dump_window_and_backend(graphics_config)
     _try_dump("pyglet.media", dump_media)
     if pyglet.compat_platform.startswith("win"):
         _try_dump("pyglet.input.wintab", dump_wintab)
 
 
+def _parse_version(value: str) -> tuple[int, int]:
+    try:
+        major, minor = value.split(".", 1)
+        return int(major), int(minor)
+    except (ValueError, TypeError) as exc:
+        import argparse  # noqa: PLC0415
+
+        raise argparse.ArgumentTypeError("version must be in MAJOR.MINOR form, for example 3.1") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the environment report or an isolated graphics probe worker."""
+    import argparse  # noqa: PLC0415
+    import pyglet  # noqa: PLC0415
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-extensions", action="store_true", help="include complete extension lists")
+    parser.add_argument("--verbose", action="store_true", help="include tracebacks for diagnostic failures")
+    parser.add_argument("--backend", choices=[api.value for api in GraphicsAPI], help="backend for the main report")
+    parser.add_argument("--version", type=_parse_version, help="graphics version for the main report (MAJOR.MINOR)")
+    parser.add_argument(
+        "--probe-graphics",
+        action="store_true",
+        help="test supported OpenGL and OpenGL ES configurations in isolated processes",
+    )
+    parser.add_argument("--graphics-worker", nargs=2, metavar=("BACKEND", "VERSION"), help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    if args.graphics_worker:
+        return _graphics_probe_worker(*args.graphics_worker)
+
+    if args.version and not args.backend:
+        parser.error("--version requires --backend")
+
+    graphics_config = None
+    if args.backend:
+        backend = GraphicsAPI(args.backend)
+        pyglet.options.backend = backend
+        if args.version:
+            if not _is_opengl_backend(backend):
+                parser.error("--version is supported only for OpenGL and OpenGL ES backends")
+            graphics_config = _make_graphics_config(backend, args.version)
+
+    dump(graphics_config)
+    if args.probe_graphics:
+        dump_graphics_probe()
+    return 0
+
+
 if __name__ == "__main__":
-    dump()
+    raise SystemExit(main())

--- a/pyglet/libs/win32/com.py
+++ b/pyglet/libs/win32/com.py
@@ -73,6 +73,10 @@ class GUID(ctypes.Structure):
     def __hash__(self) -> int:
         return hash(bytes(self))
 
+    def copy(self) -> GUID:
+        """Return an independent copy of this GUID."""
+        return GUID(self.Data1, self.Data2, self.Data3, *self.Data4)
+
     @classmethod
     def from_string(cls, text: str) -> GUID:
         """Convert a GUID string into a GUID object.

--- a/tests/integration/graphics/__init__.py
+++ b/tests/integration/graphics/__init__.py
@@ -1,0 +1,7 @@
+"""Graphics integration tests.
+
+Tests in this directory must be backend-agnostic and run on every supported
+graphics backend. Backend-specific coverage belongs in the ``opengl``,
+``gl2``, or ``webgl`` subdirectory so normal and Pyodide test selections stay
+reliable.
+"""

--- a/tests/integration/graphics/gl2/test_texture_readback.py
+++ b/tests/integration/graphics/gl2/test_texture_readback.py
@@ -1,0 +1,31 @@
+import pyglet
+
+from pyglet.graphics.api.gl import gl
+from pyglet.graphics.api.gl2.framebuffer import GL2Framebuffer
+from tests.annotations import GraphicsAPIGroups, require_graphics_api
+
+
+pytestmark = require_graphics_api(GraphicsAPIGroups.GL2)
+
+
+def test_gles2_fetch_uses_gl2_framebuffer_and_restores_state(test_window):
+    test_window.switch_to()
+    context = test_window.context
+    texture = pyglet.graphics.Texture.create(2, 2, blank_data=True, context=context)
+    framebuffer = GL2Framebuffer(context=context)
+    framebuffer.bind()
+    expected = gl.GLint()
+    context.glGetIntegerv(gl.GL_FRAMEBUFFER_BINDING, expected)
+
+    try:
+        texture.fetch()
+        if context.info.pixel_transfer.direct_texture_readback:
+            return
+        assert isinstance(context.pixel_readback.get_framebuffer(), GL2Framebuffer)
+
+        actual = gl.GLint()
+        context.glGetIntegerv(gl.GL_FRAMEBUFFER_BINDING, actual)
+        assert actual.value == expected.value
+    finally:
+        framebuffer.unbind()
+        framebuffer.delete()

--- a/tests/integration/graphics/opengl/test_compute_shader.py
+++ b/tests/integration/graphics/opengl/test_compute_shader.py
@@ -1,6 +1,9 @@
 import pytest
 
 import pyglet
+from pyglet.enums import ComponentFormat
+from pyglet.graphics import Texture
+from pyglet.graphics.api.gl import gl
 from pyglet.graphics.shader import ShaderException
 
 from tests.annotations import skip_graphics_api, GraphicsAPIGroups
@@ -30,8 +33,7 @@ void main() {
 """
 
 
-@skip_graphics_api(GraphicsAPIGroups.GL2)
-def test_compute_shader_program_creation(test_window):
+def _create_compute_program(test_window):
     test_window.switch_to()
     backend = pyglet.options.backend
 
@@ -45,7 +47,7 @@ def test_compute_shader_program_creation(test_window):
         compute_src = COMPUTE_SRC_GL
 
     try:
-        program = pyglet.graphics.ComputeShaderProgram(compute_src)
+        return pyglet.graphics.ComputeShaderProgram(compute_src)
     except ShaderException as exc:
         error_text = str(exc)
         if ("Compute Shader not supported" in error_text
@@ -54,9 +56,42 @@ def test_compute_shader_program_creation(test_window):
             pytest.skip(f"Compute shader is unavailable for this runner/context: {error_text.splitlines()[-1]}")
         raise
 
+
+@skip_graphics_api(GraphicsAPIGroups.GL2)
+def test_compute_shader_program_creation(test_window):
+    program = _create_compute_program(test_window)
     try:
         assert program.id > 0
         assert "img_output" in program.uniforms
         assert program.max_work_group_invocations > 0
     finally:
+        program.delete()
+
+
+@skip_graphics_api(GraphicsAPIGroups.GL2)
+def test_compute_shader_dispatch_to_image_texture(test_window):
+    test_window.switch_to()
+    if not test_window.context.info.features.texture_storage:
+        pytest.skip("Immutable texture storage is not supported by this context.")
+
+    program = _create_compute_program(test_window)
+    texture = None
+    try:
+        texture = Texture.create(
+            1,
+            1,
+            internal_format=ComponentFormat.RGBA,
+            internal_format_size=32,
+            internal_format_type="f",
+            blank_data=False,
+            immutable=True,
+            context=test_window.context,
+        )
+        program.use()
+        texture.bind_image_texture(0, access=gl.GL_WRITE_ONLY, fmt=gl.GL_RGBA32F)
+        program.dispatch()
+    finally:
+        program.stop()
+        if texture is not None:
+            texture.delete()
         program.delete()

--- a/tests/integration/graphics/opengl/test_compute_shader.py
+++ b/tests/integration/graphics/opengl/test_compute_shader.py
@@ -21,7 +21,7 @@ COMPUTE_SRC_GLES = """#version 310 es
 precision highp float;
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(rgba32f) uniform highp image2D img_output;
+layout(rgba32f) writeonly uniform highp image2D img_output;
 
 void main() {
     ivec2 texel_coord = ivec2(gl_GlobalInvocationID.xy);

--- a/tests/integration/graphics/opengl/test_surface_info.py
+++ b/tests/integration/graphics/opengl/test_surface_info.py
@@ -1,0 +1,82 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from pyglet import image
+from pyglet.enums import PixelFormat
+from pyglet.graphics.api.base import SurfaceInfo
+from tests.annotations import GraphicsAPIGroups, require_graphics_api
+
+
+pytestmark = require_graphics_api(GraphicsAPIGroups.GL3)
+
+
+class _TestSurfaceInfo(SurfaceInfo):
+    def query(self) -> None:
+        pass
+
+
+def test_surface_features_cover_gles3_versions_and_extensions() -> None:
+    surface_info = _TestSurfaceInfo()
+    surface_info.api = "gles3"
+    surface_info.major_version, surface_info.minor_version = 3, 0
+    surface_info.update_features()
+
+    assert surface_info.features.uniform_buffers
+    assert surface_info.features.sync_objects
+    assert not surface_info.features.compute_shaders
+    assert not surface_info.features.shader_storage_buffers
+
+    surface_info.minor_version = 1
+    surface_info.update_features()
+    assert surface_info.features.compute_shaders
+    assert surface_info.features.shader_storage_buffers
+    assert not surface_info.features.tessellation_shaders
+    assert surface_info.features.pixel_buffer_objects
+    assert surface_info.pixel_transfer.unpack_row_length
+    assert not surface_info.pixel_transfer.direct_texture_readback
+    assert surface_info.pixel_format_preferences.preferred_decode_format == PixelFormat.RGBA8
+
+    surface_info.api = "opengl"
+    surface_info.major_version, surface_info.minor_version = 4, 2
+    surface_info.extensions = {"GL_ARB_compute_shader", "GL_ARB_shader_storage_buffer_object"}
+    surface_info.update_features()
+    assert surface_info.features.compute_shaders
+    assert surface_info.features.shader_storage_buffers
+
+
+def test_surface_features_are_immutable() -> None:
+    surface_info = _TestSurfaceInfo()
+
+    with pytest.raises(FrozenInstanceError):
+        surface_info.features.compute_shaders = True
+    with pytest.raises(FrozenInstanceError):
+        surface_info.pixel_transfer.bgra_upload = True
+    with pytest.raises(FrozenInstanceError):
+        surface_info.pixel_format_preferences.readback_format = PixelFormat.BGRA8
+
+
+def test_surface_info_publishes_image_decode_policy() -> None:
+    surface_info = _TestSurfaceInfo()
+    surface_info.api = "gles3"
+    surface_info.major_version, surface_info.minor_version = 3, 1
+    surface_info.update_features()
+
+    assert image.get_default_decode_policy() == image.ImageDecodePolicy(
+        surface_info.pixel_format_preferences.preferred_decode_format,
+    )
+
+
+def test_gles2_pixel_transfer_features_use_extension_support() -> None:
+    surface_info = _TestSurfaceInfo()
+    surface_info.api = "gles2"
+    surface_info.major_version, surface_info.minor_version = 2, 0
+    surface_info.extensions = {"GL_EXT_unpack_subimage", "GL_EXT_texture_format_BGRA8888"}
+    surface_info.update_features()
+
+    assert surface_info.pixel_transfer.bgra_upload
+    assert not surface_info.pixel_transfer.bgra_readback
+    assert surface_info.pixel_transfer.unpack_row_length
+    assert not surface_info.pixel_transfer.pack_row_length
+    assert not surface_info.pixel_transfer.direct_texture_readback
+    assert not surface_info.features.pixel_buffer_objects

--- a/tests/integration/graphics/opengl/test_surface_info.py
+++ b/tests/integration/graphics/opengl/test_surface_info.py
@@ -4,14 +4,17 @@ import pytest
 
 from pyglet import image
 from pyglet.enums import PixelFormat
-from pyglet.graphics.api.base import SurfaceInfo
+from pyglet.graphics.api.gl.gl_info import GLInfo
 from tests.annotations import GraphicsAPIGroups, require_graphics_api
 
 
 pytestmark = require_graphics_api(GraphicsAPIGroups.GL3)
 
 
-class _TestSurfaceInfo(SurfaceInfo):
+class _TestSurfaceInfo(GLInfo):
+    def __init__(self) -> None:
+        super().__init__(platform_info=None)
+
     def query(self) -> None:
         pass
 
@@ -24,6 +27,7 @@ def test_surface_features_cover_gles3_versions_and_extensions() -> None:
 
     assert surface_info.features.uniform_buffers
     assert surface_info.features.sync_objects
+    assert surface_info.features.texture_storage
     assert not surface_info.features.compute_shaders
     assert not surface_info.features.shader_storage_buffers
 
@@ -31,6 +35,7 @@ def test_surface_features_cover_gles3_versions_and_extensions() -> None:
     surface_info.update_features()
     assert surface_info.features.compute_shaders
     assert surface_info.features.shader_storage_buffers
+    assert surface_info.features.texture_storage
     assert not surface_info.features.tessellation_shaders
     assert surface_info.features.pixel_buffer_objects
     assert surface_info.pixel_transfer.unpack_row_length

--- a/tests/integration/graphics/opengl/test_texture.py
+++ b/tests/integration/graphics/opengl/test_texture.py
@@ -1,11 +1,13 @@
-from ctypes import Array, c_float
+from ctypes import Array, byref, c_float
 
 import pyglet
 import pytest
 
 from pyglet.enums import ComponentFormat
+from pyglet.graphics import Texture
 from pyglet.graphics.api.gl import gl
 from pyglet.graphics.api.gl.framebuffer import GLFramebuffer
+from pyglet.image import ImageData, ImageException
 from tests.annotations import GraphicsAPIGroups, require_graphics_api
 
 
@@ -81,3 +83,34 @@ def test_float_texture_read_pixels(test_window):
     assert tuple(pixels.data) == values
     with pytest.raises(NotImplementedError, match="read_pixels"):
         texture.fetch()
+
+
+def test_create_immutable_texture(test_window):
+    context = test_window.context
+    if not context.info.features.texture_storage:
+        pytest.skip("Immutable texture storage is not supported by this context.")
+
+    texture = Texture.create(4, 2, immutable=True, mipmap_levels=2, context=context)
+    try:
+        immutable = gl.GLint()
+        levels = gl.GLint()
+        max_level = gl.GLint()
+        context.glGetTexParameteriv(texture.target, gl.GL_TEXTURE_IMMUTABLE_FORMAT, byref(immutable))
+        context.glGetTexParameteriv(texture.target, gl.GL_TEXTURE_IMMUTABLE_LEVELS, byref(levels))
+        context.glGetTexParameteriv(texture.target, gl.GL_TEXTURE_MAX_LEVEL, byref(max_level))
+
+        assert texture.immutable
+        assert texture.mipmap_count == 2
+        assert texture.valid_mipmaps == (0, 1)
+        assert immutable.value == gl.GL_TRUE
+        assert levels.value == 2
+        assert max_level.value == 1
+
+        data = bytes((9, 9, 9, 255)) * 2
+        texture.upload(ImageData(2, 1, "RGBA", data), 0, 0, 0, level=1)
+        texture.generate_mipmaps()
+        assert texture.mipmap_count == 2
+        with pytest.raises(ImageException, match="fixed at creation"):
+            texture.init_mipmaps()
+    finally:
+        texture.delete()

--- a/tests/integration/graphics/opengl/test_texture.py
+++ b/tests/integration/graphics/opengl/test_texture.py
@@ -93,17 +93,14 @@ def test_create_immutable_texture(test_window):
     texture = Texture.create(4, 2, immutable=True, mipmap_levels=2, context=context)
     try:
         immutable = gl.GLint()
-        levels = gl.GLint()
         max_level = gl.GLint()
         context.glGetTexParameteriv(texture.target, gl.GL_TEXTURE_IMMUTABLE_FORMAT, byref(immutable))
-        context.glGetTexParameteriv(texture.target, gl.GL_TEXTURE_IMMUTABLE_LEVELS, byref(levels))
         context.glGetTexParameteriv(texture.target, gl.GL_TEXTURE_MAX_LEVEL, byref(max_level))
 
         assert texture.immutable
         assert texture.mipmap_count == 2
         assert texture.valid_mipmaps == (0, 1)
         assert immutable.value == gl.GL_TRUE
-        assert levels.value == 2
         assert max_level.value == 1
 
         data = bytes((9, 9, 9, 255)) * 2

--- a/tests/integration/graphics/opengl/test_texture_readback.py
+++ b/tests/integration/graphics/opengl/test_texture_readback.py
@@ -1,0 +1,83 @@
+from ctypes import Array, c_float
+
+import pyglet
+import pytest
+
+from pyglet.enums import ComponentFormat
+from pyglet.graphics.api.gl import gl
+from pyglet.graphics.api.gl.framebuffer import GLFramebuffer
+from tests.annotations import GraphicsAPIGroups, require_graphics_api
+
+
+pytestmark = require_graphics_api(GraphicsAPIGroups.GL3)
+
+
+def test_read_pixels_returns_zero_copy_typed_buffer(test_window):
+    test_window.switch_to()
+    texture = pyglet.graphics.Texture.create(2, 2, blank_data=True, context=test_window.context)
+
+    pixels = texture.read_pixels()
+
+    assert pixels.format == ComponentFormat.RGBA
+    assert pixels.data_type == "B"
+    assert isinstance(pixels.data, Array)
+    assert pixels.pitch == 8
+
+    image_data = pixels.to_image_data()
+    assert image_data._current_data is pixels.data  # noqa: SLF001
+
+
+@require_graphics_api(GraphicsAPIGroups.GLES)
+def test_gles_fetch_restores_framebuffer_and_pack_state(test_window):
+    test_window.switch_to()
+    context = test_window.context
+    texture = pyglet.graphics.Texture.create(2, 2, blank_data=True, context=context)
+    framebuffer = GLFramebuffer(context=context)
+    framebuffer.bind()
+    expected = gl.GLint()
+    context.glGetIntegerv(gl.GL_FRAMEBUFFER_BINDING, expected)
+    context.glPixelStorei(gl.GL_PACK_ALIGNMENT, 8)
+
+    try:
+        texture.fetch()
+        scratch_framebuffer = context.pixel_readback.get_framebuffer()
+        texture.fetch()
+        assert context.pixel_readback.get_framebuffer() is scratch_framebuffer
+
+        actual = gl.GLint()
+        context.glGetIntegerv(gl.GL_FRAMEBUFFER_BINDING, actual)
+        assert actual.value == expected.value
+        pack_alignment = gl.GLint()
+        context.glGetIntegerv(gl.GL_PACK_ALIGNMENT, pack_alignment)
+        assert pack_alignment.value == 8
+    finally:
+        context.glPixelStorei(gl.GL_PACK_ALIGNMENT, 4)
+        framebuffer.unbind()
+        framebuffer.delete()
+
+
+@require_graphics_api(GraphicsAPIGroups.DESKTOP_GL)
+def test_float_texture_read_pixels(test_window):
+    test_window.switch_to()
+    values = tuple(i / 16 for i in range(16))
+    source = (c_float * len(values))(*values)
+    texture = pyglet.graphics.Texture.create(
+        2,
+        2,
+        internal_format=ComponentFormat.RGBA,
+        internal_format_size=32,
+        internal_format_type="f",
+        blank_data=False,
+        context=test_window.context,
+    )
+    context = test_window.context
+    context.glBindTexture(texture.target, texture.id)
+    context.glTexSubImage2D(texture.target, 0, 0, 0, 2, 2, gl.GL_RGBA, gl.GL_FLOAT, source)
+
+    pixels = texture.read_pixels()
+
+    assert pixels.data_type == "f"
+    assert pixels.pitch == 2 * 4 * 4
+    assert tuple(pixels.data) == values
+    with pytest.raises(NotImplementedError, match="read_pixels"):
+        texture.fetch()

--- a/tests/integration/graphics/test_texture2d.py
+++ b/tests/integration/graphics/test_texture2d.py
@@ -1,6 +1,7 @@
 import unittest
 
-from pyglet.graphics import Texture
+from pyglet.enums import ComponentFormat
+from pyglet.graphics import Texture, PixelData
 from pyglet.image import ImageData
 from pyglet.window import Window
 
@@ -33,6 +34,7 @@ class TestTextureUploadFetch(unittest.TestCase):
         fetched = texture.get_image_data()
         fetched_bytes = bytes(fetched.get_bytes('RGBA', fetched.width * 4))
         self.assertEqual(fetched_bytes, data)
+
 
     def test_region_upload_fetch(self):
         width, height = 4, 4
@@ -72,3 +74,17 @@ class TestTextureUploadFetch(unittest.TestCase):
         texture = Texture.create(4, 4, blank_data=True)
         with self.assertRaisesRegex(Exception, "Mipmap level must be non-negative"):
             texture.upload(self.create_image(2, 2, 1), 0, 0, 0, level=-1)
+
+
+
+def test_pixel_data_pitch_bytes_and_image_view():
+    data = bytearray(3 * 2 * 4 * 4)
+    pixels = PixelData(3, 2, ComponentFormat.RGBA, "f", data)
+
+    assert pixels.pitch == 3 * 4 * 4
+    assert bytes(pixels) == bytes(data)
+
+    image_data = pixels.to_image_data()
+    assert image_data._current_data is data  # noqa: SLF001
+    assert image_data.data_type == "f"
+    assert image_data.pitch == pixels.pitch

--- a/tests/integration/image/test_wic.py
+++ b/tests/integration/image/test_wic.py
@@ -1,0 +1,60 @@
+"""Windows Imaging Component integration tests."""
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+
+from tests.annotations import Platform, require_platform
+
+
+pytestmark = require_platform(Platform.WINDOWS)
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _assert_round_trip(encoded: bytes, expected: bytes) -> None:
+    from pyglet.image.codecs.wic import WICDecoder  # noqa: PLC0415
+
+    decoded = WICDecoder().decode("round_trip.png", BytesIO(encoded))
+    assert decoded.width == 2
+    assert decoded.height == 3
+    assert decoded.get_bytes("RGBA", 8) == expected
+
+
+def _assert_file_round_trip(filename, expected: bytes) -> None:
+    from pyglet.image.codecs.wic import WICDecoder  # noqa: PLC0415
+
+    decoded = WICDecoder().decode(str(filename), None)
+    assert decoded.width == 2
+    assert decoded.height == 3
+    assert decoded.get_bytes("RGBA", 8) == expected
+
+
+def test_wic_encodes_rgba_png_to_stream_and_filename(tmp_path):
+    """WIC preserves RGBA pixels when producing PNG bytes or a PNG file."""
+    from pyglet.image import ImageData  # noqa: PLC0415
+    from pyglet.image.codecs.wic import WICEncoder  # noqa: PLC0415
+
+    # Each row is deliberately distinct, which verifies that the negative
+    # pitch supplied to WIC is correctly restored by its decoder.
+    pixels = bytes((
+        255, 0, 0, 255, 0, 255, 0, 128,
+        0, 0, 255, 64, 255, 255, 0, 32,
+        255, 0, 255, 16, 0, 255, 255, 0,
+    ))
+    source = ImageData(2, 3, "RGBA", pixels, 8)
+    encoder = WICEncoder()
+
+    stream = BytesIO()
+    encoder.encode(source, "round_trip.png", stream)
+    stream_bytes = stream.getvalue()
+    assert stream_bytes.startswith(PNG_SIGNATURE)
+    _assert_round_trip(stream_bytes, pixels)
+
+    filename = tmp_path / "round_trip.png"
+    encoder.encode(source, str(filename), None)
+    file_bytes = filename.read_bytes()
+    assert file_bytes.startswith(PNG_SIGNATURE)
+    _assert_file_round_trip(filename, pixels)

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+# ruff: noqa: SLF001
+
+import argparse
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import pyglet
+import pyglet.info as info
+from pyglet.enums import GraphicsAPI
+
+
+def test_parse_version() -> None:
+    assert info._parse_version("3.1") == (3, 1)
+
+
+@pytest.mark.parametrize("value", ["3", "three.one", "3.1.2"])
+def test_parse_version_rejects_invalid_value(value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        info._parse_version(value)
+
+
+def test_parse_graphics_worker_output_uses_prefixed_result() -> None:
+    expected = {"backend": "gles3", "success": True}
+    output = "native library noise\n" + info._GRAPHICS_WORKER_PREFIX + json.dumps(expected) + "\n"
+
+    assert info._parse_graphics_worker_output(output) == expected
+
+
+def test_parse_graphics_worker_output_rejects_invalid_json() -> None:
+    assert info._parse_graphics_worker_output(info._GRAPHICS_WORKER_PREFIX + "not-json") is None
+
+
+def test_run_graphics_probe_sets_backend_in_clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "backend": "gles3",
+        "requested_version": [3, 1],
+        "success": True,
+        "actual_api": "gles3",
+        "actual_version": [3, 1],
+    }
+
+    def fake_run(command, **kwargs):
+        assert command[-3:] == ("--graphics-worker", "gles3", "3.1")
+        assert kwargs["env"]["PYGLET_BACKEND"] == "gles3"
+        assert kwargs["env"]["PYGLET_DEBUG_API"] == "false"
+        return SimpleNamespace(
+            stdout=info._GRAPHICS_WORKER_PREFIX + json.dumps(payload),
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(info.subprocess, "run", fake_run)
+
+    assert info._run_graphics_probe(GraphicsAPI.OPENGL_ES_3, (3, 1)) == payload
+
+
+def test_run_graphics_probe_uses_default_version_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"backend": "opengl", "requested_version": None, "success": True}
+
+    def fake_run(command, **_kwargs):
+        assert command[-3:] == ("--graphics-worker", "opengl", "default")
+        return SimpleNamespace(stdout=info._GRAPHICS_WORKER_PREFIX + json.dumps(payload), stderr="", returncode=0)
+
+    monkeypatch.setattr(info.subprocess, "run", fake_run)
+
+    assert info._run_graphics_probe(GraphicsAPI.OPENGL, None) == payload
+
+
+def test_run_graphics_probe_reports_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired("probe", 15)
+
+    monkeypatch.setattr(info.subprocess, "run", fake_run)
+
+    result = info._run_graphics_probe(GraphicsAPI.OPENGL, (3, 3))
+
+    assert result["success"] is False
+    assert result["error_type"] == "TimeoutExpired"
+
+
+def test_graphics_api_family_distinguishes_desktop_and_es() -> None:
+    assert info._graphics_api_family(GraphicsAPI.OPENGL) == "desktop"
+    assert info._graphics_api_family(GraphicsAPI.OPENGL_2) == "desktop"
+    assert info._graphics_api_family(GraphicsAPI.OPENGL_ES_3) == "es"
+    assert info._graphics_api_family(GraphicsAPI.OPENGL_ES_2) == "es"
+
+
+def test_graphics_probe_covers_supported_legacy_and_gles3_versions() -> None:
+    assert (GraphicsAPI.OPENGL, None) in info._GRAPHICS_PROBES
+    assert (GraphicsAPI.OPENGL, (3, 3)) in info._GRAPHICS_PROBES
+    assert (GraphicsAPI.OPENGL_2, (2, 0)) in info._GRAPHICS_PROBES
+    assert (GraphicsAPI.OPENGL_2, (2, 1)) in info._GRAPHICS_PROBES
+    assert (GraphicsAPI.OPENGL_ES_3, (3, 0)) in info._GRAPHICS_PROBES
+    assert (GraphicsAPI.OPENGL_ES_3, (3, 1)) in info._GRAPHICS_PROBES
+    assert (GraphicsAPI.OPENGL_ES_3, (3, 2)) in info._GRAPHICS_PROBES
+
+
+def test_gles31_is_preferred_to_legacy_desktop_gl() -> None:
+    gles3 = {"backend": "gles3", "requested_version": [3, 1]}
+    gl2 = {"backend": "gl2", "requested_version": [2, 1]}
+
+    assert info._graphics_probe_priority(gles3) > info._graphics_probe_priority(gl2)
+
+
+def test_default_desktop_request_is_preferred_to_explicit_desktop_minimum() -> None:
+    default = {"backend": "opengl", "requested_version": None}
+    minimum = {"backend": "opengl", "requested_version": [3, 3]}
+
+    assert info._graphics_probe_priority(default) > info._graphics_probe_priority(minimum)
+
+
+def test_failed_diagnostic_context_is_created_once_and_reported(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    attempts = 0
+
+    def fail_to_create_window(**_kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("context rejected")
+
+    requested = SimpleNamespace(major_version=3, minor_version=3)
+    config = SimpleNamespace(**{str(pyglet.options.backend): requested})
+    monkeypatch.setattr(pyglet.window, "Window", fail_to_create_window)
+    monkeypatch.setattr(info, "_first_heading", True)
+
+    info.dump_window_and_backend(config)
+
+    output = capsys.readouterr().out
+    assert attempts == 1
+    assert "status: context creation failed" in output
+    assert "requested version: 3.3" in output
+    assert "RuntimeError: context rejected" in output
+    assert "Traceback" not in output
+    assert "status: unavailable because diagnostic context creation failed" in output

--- a/tests/unit/test_win32_com.py
+++ b/tests/unit/test_win32_com.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows COM is available only on Windows")
+def test_guid_copy_is_independent() -> None:
+    from pyglet.libs.win32.com import GUID
+
+    original = GUID(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    copied = original.copy()
+
+    assert copied == original
+    assert copied is not original
+
+    copied.Data1 = 99
+    copied.Data4[0] = 88
+    assert original.Data1 == 1
+    assert original.Data4[0] == 4


### PR DESCRIPTION
Improve some backend behavior after going through the OpenGL ES docs and existing implementations.

* Update docs for minimum/recommended OpenGL information.
* Improve pyglet.info with more error handling.
* Improve pyglet.info to have a probe-graphics to test all of the backends on a system for better diagnostics.
* Implement a "SurfaceFeatures" and similar pixel support features that the backends can implement instead of lacing various extension, version, and backend checks together.
* Add a pixel format policy backends can change for image decoders. (Really only applies to Windows since it uses BGRA).
* Separate the gles fbo creation into a separate class lazily created by the backend instead of during surface info querying.
* Clarify texture.fetch is for getting normal image compatible image data.
* Added  texture.read_pixels, which returns a frozen `PixelData` object based on the parameters of the created texture. This keeps the normal usage for `fetch` from breaking compatibility. 
* Fix gl2 shape fragment shader using wrong verison.
* Cleanup WIC and implement the pixel format policy.
* Add some other tests like WIC