### PR TITLE
Instance update

### DIFF
--- a/doc/modules/graphics/index.rst
+++ b/doc/modules/graphics/index.rst
@@ -10,6 +10,7 @@ pyglet.graphics
    atlas
    draw
    framebuffer
+   instance
    shader
    texture
    vertexbuffer

--- a/doc/modules/graphics/instance.rst
+++ b/doc/modules/graphics/instance.rst
@@ -1,0 +1,10 @@
+pyglet.graphics.instance
+========================
+
+``VertexInstance`` provides an object handle for one independently managed
+instance. For array-oriented workloads, ``InstanceCollection`` manages the
+entire contiguous instance range without allocating a Python object for every
+item. See :ref:`guide_instanced-rendering` for selection guidance and examples.
+
+.. automodule:: pyglet.graphics.instance
+  :members: VertexInstance, InstanceCollection

--- a/doc/programming_guide/rendering.rst
+++ b/doc/programming_guide/rendering.rst
@@ -416,6 +416,8 @@ Note that the first argument gives the number of vertices in the data, not the
 number of indices (which is implicit on the length of the index list given in
 the third argument).
 
+.. _guide_instanced-rendering:
+
 Instanced Rendering
 ~~~~~~~~~~~~~~~~~~~
 
@@ -448,6 +450,12 @@ the original vertex list mesh.
 
 Each created instance adds another row to the instance buffer and increases the
 instance count used for drawing.
+
+When several independently managed instances are needed at once, use
+``vlist.create_instances(count, **attributes)``. It allocates and uploads the
+instance data in bulk, then returns a list of individual ``VertexInstance``
+objects. Each attribute must contain flattened data for all ``count``
+instances.
 
 Example (indexed instancing)::
 
@@ -490,6 +498,66 @@ Instanced vertex lists also provide helper APIs for ordering:
 Groups control draw order between different vertex lists, but not between
 instances inside the same instanced vertex list. Use the ordering helpers above
 when you need explicit ordering among instances of a single mesh.
+
+Instance collections
+^^^^^^^^^^^^^^^^^^^^
+
+Individual :py:class:`~pyglet.graphics.instance.VertexInstance` objects are a
+good fit when each rendered object has its own lifetime and is updated
+independently. ``create_instances`` reduces upload overhead when creating many
+of these objects, but it still returns and tracks one Python object per
+instance.
+
+Use :py:class:`~pyglet.graphics.instance.InstanceCollection` when the instance
+data is naturally managed as arrays. Common examples include glyph runs,
+particle systems, tile maps, and vegetation. A collection avoids the Python
+object cost and supports whole-range attribute updates::
+
+    translations = (0, 0, 0,  32, 0, 0,  64, 0, 0)
+    colors = (1, 0, 0, 1,  0, 1, 0, 1,  0, 0, 1, 1)
+
+    instances = vlist.create_instance_collection(
+        3,
+        capacity=128,
+        translate=translations,
+        colors=colors,
+    )
+
+    # Replace one attribute for every active instance with one upload.
+    instances.set(translate=new_translations)
+
+Individual instances can also be updated by index. Pass ``start`` and
+``count=1`` to replace attributes for one instance; attributes that are not
+provided remain unchanged::
+
+    # Change only the translation of instance 5.
+    instances.set(start=5, count=1, translate=(100, 200, 0))
+
+The same arguments update any contiguous range when the attribute data contains
+one flattened row per selected instance::
+
+    instances.set(
+        start=5,
+        count=3,
+        translate=(100, 200, 0,  110, 200, 0,  120, 200, 0),
+    )
+
+The active ``count`` is separate from reserved ``capacity``. This is useful
+when data is regenerated frequently: reducing the count renders fewer
+instances without reallocating the buffers, and later growth can reuse the
+reserved slots::
+
+    instances.set_count(2)
+    instances.set_count(80)
+    instances.set(translate=translations_for_80, colors=colors_for_80)
+
+``insert`` and ``remove`` are available for occasional structural changes,
+but they shift following instance data. Replacing ranges with ``set`` and
+changing ``count`` is preferable for frequently rebuilt collections.
+
+An instanced vertex list uses either individual ``VertexInstance`` objects or
+one ``InstanceCollection``; the two ownership models cannot be mixed on the
+same vertex list.
 
 Resource Management
 ~~~~~~~~~~~~~~~~~~~

--- a/examples/graphics/instancing.py
+++ b/examples/graphics/instancing.py
@@ -68,6 +68,16 @@ def _get_triangle_vertices(size: int) -> list[int]:
             size, size, 0]
 
 
+def _get_instance_data(columns: int, rows: int, spacing: int, x: int = 0, y: int = 0) -> tuple[list[float], list[int]]:
+    colors = []
+    translations = []
+    for i in range(columns):
+        for j in range(rows):
+            colors.extend((random.random(), random.random(), random.random(), 1.0))
+            translations.extend((x + i * spacing, y + j * spacing, 0))
+    return colors, translations
+
+
 background_group = pyglet.graphics.ShaderGroup(program, order=0)
 BORDER = 25
 
@@ -100,10 +110,8 @@ vlist_1 = program.vertex_list_instanced_indexed(4, mode=GeometryMode.TRIANGLES, 
                                                 colors=(1, 0, 0, 1),
                                                 translate=(0, 0, 0))
 
-for i in range(40):
-    for j in range(40):
-        f = vlist_1.create_instance(colors=(random.random(), random.random(), random.random(), 1),
-                                    translate=(i * vlist_1_size, j * vlist_1_size, 0))
+colors, translations = _get_instance_data(40, 40, vlist_1_size)
+vlist_1.create_instances(40 * 40, colors=colors, translate=translations)
 
 vlist_2_size = 5
 vlist_2 = program.vertex_list_instanced_indexed(4, mode=GeometryMode.TRIANGLES, indices=[0, 1, 2, 0, 2, 3],
@@ -112,10 +120,12 @@ vlist_2 = program.vertex_list_instanced_indexed(4, mode=GeometryMode.TRIANGLES, 
                                                 position=_get_quad_vertices(vlist_2_size),
                                                 colors=(1, 0, 0, 1),
                                                 translate=(0, 0, 0))
-for i in range(40):
-    for j in range(40):
-        m = vlist_2.create_instance(colors=(random.random(), random.random(), random.random(), 1),
-                                    translate=(i * vlist_2_size, j * vlist_2_size, 0))
+colors, translations = _get_instance_data(40, 40, vlist_2_size)
+
+# Use create_instances when the full set of instance data is already known.
+vlist_2.create_instances(40 * 40 - 1, colors=colors[:-4], translate=translations[:-3])
+# Use create_instance when adding a single instance to an existing vertex list.
+vlist_2.create_instance(colors=colors[-4:], translate=translations[-3:])
 
 vlist_2_1_size = 50
 vlist_2_1 = program.vertex_list_instanced_indexed(4, mode=GeometryMode.TRIANGLES, indices=[0, 1, 2, 0, 2, 3],
@@ -124,10 +134,8 @@ vlist_2_1 = program.vertex_list_instanced_indexed(4, mode=GeometryMode.TRIANGLES
                                                   position=_get_quad_vertices(vlist_2_1_size),
                                                   colors=(1, 0, 0, 1),
                                                   translate=(300, 300, 0))
-for i in range(4):
-    for j in range(4):
-        m = vlist_2_1.create_instance(colors=(random.random(), random.random(), random.random(), 1),
-                                      translate=(300 + i * vlist_2_1_size, 300 + j * vlist_2_1_size, 0))
+colors, translations = _get_instance_data(4, 4, vlist_2_1_size, 300, 300)
+vlist_2_1.create_instances(4 * 4, colors=colors, translate=translations)
 
 vlist_3_size = 15
 vlist_3 = program.vertex_list_instanced(3, mode=GeometryMode.TRIANGLES,
@@ -136,11 +144,8 @@ vlist_3 = program.vertex_list_instanced(3, mode=GeometryMode.TRIANGLES,
                                         position=_get_triangle_vertices(vlist_3_size),
                                         colors=(1, 0, 0, 1),
                                         translate=(0, 0, 0))
-for i in range(20):
-    for j in range(20):
-        m = vlist_3.create_instance(colors=(random.random(), random.random(), random.random(), 1),
-                                    translate=(250 + i * vlist_3_size,
-                                               0 + j * vlist_3_size, 0))
+colors, translations = _get_instance_data(20, 20, vlist_3_size, 250)
+vlist_3.create_instances(20 * 20, colors=colors, translate=translations)
 
 
 @window.event

--- a/pyglet/graphics/api/gl/vertexdomain.py
+++ b/pyglet/graphics/api/gl/vertexdomain.py
@@ -62,6 +62,8 @@ from pyglet.graphics.vertexdomain import (
     IndexedVertexDomain,
     VertexList,
     IndexedVertexList,
+    InstanceIndexedVertexList,
+    InstanceVertexList,
     InstancedVertexDomain,
     InstancedIndexedVertexDomain,
 )
@@ -207,107 +209,9 @@ class GLVertexList(VertexList):
 
 
 
-class GLInstanceVertexList(GLVertexList):
+class GLInstanceVertexList(InstanceVertexList, GLVertexList):
     """A list of vertices within an :py:class:`InstancedVertexDomain` that are not indexed."""
-    instanced: bool = True
-
-    def __init__(self, domain: GLVertexDomain, group: Group, start: int, count: int, bucket: InstanceBucket) -> None:  # noqa: D107
-        super().__init__(domain, group, start, count)
-        self.instance_bucket = bucket
-
-    def delete(self) -> None:
-        """Delete this vertex list and its instance storage."""
-        key = (self.start, self.count)
-        self.instance_bucket.clear()
-        super().delete()
-        self.domain._instance_map.pop(key, None)
-
-    def create_instance(self, **attributes: Any) -> VertexInstance:
-        return self.instance_bucket.create_instance(**attributes)
-
-    def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
-        """Create several instances with a single instance-buffer upload."""
-        return self.instance_bucket.create_instances(count, **attributes)
-
-    def create_instance_collection(
-        self, count: int, capacity: int | None = None, **attributes: Any,
-    ) -> InstanceCollection:
-        """Create a bulk-managed collection without individual instance objects."""
-        return self.instance_bucket.create_instance_collection(count, capacity, **attributes)
-
-    def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
-        """Replace one attribute over a contiguous range of instances."""
-        self.instance_bucket.set_instance_attribute_data(name, data, start, count)
-
-    @property
-    def instance_count(self) -> int:
-        """Number of active instances in this vertex list."""
-        return self.instance_bucket.instance_count
-
-    def get_instance_by_index(self, index: int) -> VertexInstance | None:
-        """Get an instance by its current slot index."""
-        return self.instance_bucket.get_instance_by_index(index)
-
-    def get_instance_index(self, instance: VertexInstance) -> int | None:
-        """Get the current slot index for an instance."""
-        return self.instance_bucket.get_instance_index(instance)
-
-    def swap_instances(self, first: VertexInstance, second: VertexInstance) -> None:
-        """Swap two instances in-place.
-
-        Useful when changing draw order without rebuilding all instance data.
-        This can still be expensive if instance attributes are large.
-        """
-        self.instance_bucket.swap_instances(first, second)
-
-    def move_instance_to_index(self, instance: VertexInstance, index: int) -> None:
-        """Move one instance to a target slot index.
-
-        Other instances shift as needed to keep slots contiguous.
-
-        This may be expensive when moving across many slots.
-        """
-        self.instance_bucket.move_instance_to_index(instance, index)
-
-    def set_instance_order(self, order: Sequence[VertexInstance]) -> None:
-        """Set the exact full order of all active instances.
-
-        This can be expensive for large lists.
-        """
-        self.instance_bucket.set_instance_order(order)
-
-    def move_to_back(self, instances: Sequence[VertexInstance]) -> None:
-        """Move a subset of instances to the back in the given order.
-
-        Back means lower indices (drawn earlier). Unspecified instances remain
-        after the moved prefix. This can be expensive for large lists.
-        """
-        self.instance_bucket.move_to_back(instances)
-
-    def move_to_top(self, instances: Sequence[VertexInstance]) -> None:
-        """Move a subset of instances to the top in the given order.
-
-        Top means higher indices (drawn later). Unspecified instances remain
-        before the moved suffix. This can be expensive for large lists.
-        """
-        self.instance_bucket.move_to_top(instances)
-
-    def set_attribute_data(self, name: str, data: Any) -> None:
-        if self.initial_attribs[name].fmt.is_instanced:
-            stream = self.instance_bucket.stream
-            count = 1
-            start = 0
-        else:
-            stream = self.domain.attrib_name_buffers[name]
-            count = self.count
-            start = self.start
-        buffer = stream.attrib_name_buffers[name]
-
-        try:
-            buffer.set_region(start, count, data)
-        except ValueError:
-            msg = f"Invalid data size for '{buffer}'. Expected {buffer.element_count * count}, got {len(data)}."
-            raise ValueError(msg) from None
+    pass
 
 
 
@@ -327,146 +231,12 @@ class GLIndexedVertexList(IndexedVertexList):
         super().__init__(domain, group, start, count, index_start, index_count)
 
 
-class GLInstanceIndexedVertexList(GLVertexList):
+class GLInstanceIndexedVertexList(InstanceIndexedVertexList, GLVertexList):
     """A list of vertices within an :py:class:`IndexedVertexDomain` that are indexed.
 
     Use :py:meth:`IndexedVertexDomain.create` to construct this list.
     """
-    domain: GLInstancedIndexedVertexDomain
-    indexed: bool = True
-    instanced: bool = True
-
-    index_count: int
-    index_start: int
-
-    instance_bucket: InstanceBucket
-    supports_base_vertex: bool
-
-    def __init__(self, domain: GLInstancedIndexedVertexDomain, group: Group, start: int, count: int,
-                 index_start: int, index_count: int, index_type: DataTypes, base_vertex: int,
-                 instance_bucket: InstanceBucket) -> None:
-        self.index_start = index_start
-        self.index_count = index_count
-        self.index_type = index_type
-        self.base_vertex = base_vertex
-        self.instance_bucket = instance_bucket
-        self.start_base_vertex = start if self.supports_base_vertex else 0
-        super().__init__(domain, group, start, count)
-
-    def delete(self) -> None:
-        """Delete this group."""
-        key = (self.index_start, self.index_count)
-
-        self.instance_bucket.clear()
-
-        super().delete()
-        self.domain.index_stream.dealloc(self.index_start, self.index_count)
-        self.domain._instance_map.pop(key, None)
-
-    def migrate(self, domain: GLInstancedIndexedVertexDomain) -> None:
-        old_domain = self.domain
-
-        # Moved vertex data here.
-        super().migrate(domain)
-
-        # Remove from bucket and enter into new bucket.
-        new_bucket = domain.instance_domain.get_elements_bucket(mode=0,
-                                                    first_index=self.index_start,
-                                                   index_count=self.index_count,
-                                                   index_type="I")
-
-        # Move instance data.
-        old_domain.instance_domain.move_all(self.instance_bucket, new_bucket)
-
-    def create_instance(self, **attributes: Any) -> VertexInstance:
-        return self.instance_bucket.create_instance(**attributes)
-
-    def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
-        """Create several instances with a single instance-buffer upload."""
-        return self.instance_bucket.create_instances(count, **attributes)
-
-    def create_instance_collection(
-        self, count: int, capacity: int | None = None, **attributes: Any,
-    ) -> InstanceCollection:
-        """Create a bulk-managed collection without individual instance objects."""
-        return self.instance_bucket.create_instance_collection(count, capacity, **attributes)
-
-    def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
-        """Replace one attribute over a contiguous range of instances."""
-        self.instance_bucket.set_instance_attribute_data(name, data, start, count)
-
-    @property
-    def instance_count(self) -> int:
-        """Number of active instances in this vertex list."""
-        return self.instance_bucket.instance_count
-
-    def get_instance_by_index(self, index: int) -> VertexInstance | None:
-        """Get an instance by its current slot index."""
-        return self.instance_bucket.get_instance_by_index(index)
-
-    def get_instance_index(self, instance: VertexInstance) -> int | None:
-        """Get the current slot index for an instance."""
-        return self.instance_bucket.get_instance_index(instance)
-
-    def swap_instances(self, first: VertexInstance, second: VertexInstance) -> None:
-        """Swap two instances in-place.
-
-        Useful when changing draw order without rebuilding all instance data.
-        This can still be expensive if instance attributes are large.
-        """
-        self.instance_bucket.swap_instances(first, second)
-
-    def move_instance_to_index(self, instance: VertexInstance, index: int) -> None:
-        """Move one instance to a target slot index.
-
-        Other instances shift as needed to keep slots contiguous.
-        This may be expensive when moving across many slots.
-        """
-        self.instance_bucket.move_instance_to_index(instance, index)
-
-    def set_instance_order(self, order: Sequence[VertexInstance]) -> None:
-        """Set the exact full order of all active instances.
-
-        This can be expensive for large lists.
-        """
-        self.instance_bucket.set_instance_order(order)
-
-    def move_to_back(self, instances: Sequence[VertexInstance]) -> None:
-        """Move a subset of instances to the back in the given order.
-
-        Back means lower indices (drawn earlier). Unspecified instances remain
-        after the moved prefix. This can be expensive for large lists.
-        """
-        self.instance_bucket.move_to_back(instances)
-
-    def move_to_top(self, instances: Sequence[VertexInstance]) -> None:
-        """Move a subset of instances to the top in the given order.
-
-        Top means higher indices (drawn later). Unspecified instances remain
-        before the moved suffix. This can be expensive for large lists.
-        """
-        self.instance_bucket.move_to_top(instances)
-
-    def set_attribute_data(self, name: str, data: Any) -> None:
-        if self.initial_attribs[name].fmt.is_instanced:
-            stream = self.instance_bucket.stream
-            count = 1
-            start = 0
-        else:
-            stream = self.domain.attrib_name_buffers[name]
-            count = self.count
-            start = self.start
-        buffer = stream.attrib_name_buffers[name]
-
-        try:
-            buffer.set_region(start, count, data)
-        except ValueError:
-            msg = f"Invalid data size for '{buffer}'. Expected {buffer.element_count * count}, got {len(data)}."
-            raise ValueError(msg) from None
-
-    def dealloc_from_group(self, vertex_list):
-        """Removes a vertex list from a specific state in this domain."""
-        vertex_list.bucket.remove_vertex_list(vertex_list)
+    pass
 
 class GLVertexDomain(VertexDomain):
     """Management of a set of vertex lists.
@@ -599,7 +369,7 @@ class GLInstanceDomainArrays(InstanceDomain):
 
     def draw_subset(self, mode: int, vertex_list: GLInstanceVertexList):
         """Draw a specific VertexList in the domain."""
-        bucket = vertex_list.bucket
+        bucket = vertex_list.instance_bucket
         bucket.vao.bind()
         bucket.stream.commit()
         self._ctx.glDrawArraysInstanced(mode, vertex_list.start, vertex_list.count, bucket.instance_count)
@@ -624,6 +394,9 @@ class GLInstanceDomainElements(InstanceDomain):
 
     def draw_subset(self, mode: GeometryMode, vertex_list: GLInstanceIndexedVertexList) -> None:
         """Draw a specific VertexList in the domain."""
+        bucket = vertex_list.instance_bucket
+        bucket.vao.bind()
+        bucket.stream.commit()
         byte_offset = vertex_list.index_start * self._elem_size
         if vertex_list.start:
             self._ctx.glDrawElementsInstancedBaseVertex(
@@ -631,7 +404,7 @@ class GLInstanceDomainElements(InstanceDomain):
                 vertex_list.index_count,
                 self._index_gl_type,
                 byte_offset,
-                vertex_list.bucket.instance_count,
+                bucket.instance_count,
                 vertex_list.start,
             )
         else:
@@ -640,7 +413,7 @@ class GLInstanceDomainElements(InstanceDomain):
                 vertex_list.index_count,
                 self._index_gl_type,
                 byte_offset,
-                vertex_list.bucket.instance_count,
+                bucket.instance_count,
             )
 
     def draw_bucket(self, mode: int, bucket: InstanceBucket) -> None:

--- a/pyglet/graphics/api/gl/vertexdomain.py
+++ b/pyglet/graphics/api/gl/vertexdomain.py
@@ -218,6 +218,14 @@ class GLInstanceVertexList(GLVertexList):
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
 
+    def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
+        """Create several instances with a single instance-buffer upload."""
+        return self.instance_bucket.create_instances(count, **attributes)
+
+    def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
+        """Replace one attribute over a contiguous range of instances."""
+        self.instance_bucket.set_instance_attribute_data(name, data, start, count)
+
     @property
     def instance_count(self) -> int:
         """Number of active instances in this vertex list."""
@@ -362,6 +370,14 @@ class GLInstanceIndexedVertexList(GLVertexList):
 
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
+
+    def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
+        """Create several instances with a single instance-buffer upload."""
+        return self.instance_bucket.create_instances(count, **attributes)
+
+    def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
+        """Replace one attribute over a contiguous range of instances."""
+        self.instance_bucket.set_instance_attribute_data(name, data, start, count)
 
     @property
     def instance_count(self) -> int:

--- a/pyglet/graphics/api/gl/vertexdomain.py
+++ b/pyglet/graphics/api/gl/vertexdomain.py
@@ -49,7 +49,7 @@ from pyglet.graphics.api.gl.enums import geometry_map
 from pyglet.graphics.api.gl.lib import GLException, MissingFunctionException
 from pyglet.graphics.api.gl.shader import GLAttribute
 from pyglet.graphics.buffer import _data_type_size
-from pyglet.graphics.instance import InstanceBucket, InstanceDomain, VertexInstance
+from pyglet.graphics.instance import InstanceBucket, InstanceCollection, InstanceDomain, VertexInstance
 from pyglet.graphics.vertexdomain import (
     VertexStream,
     VertexArrayBinding,
@@ -215,12 +215,25 @@ class GLInstanceVertexList(GLVertexList):
         super().__init__(domain, group, start, count)
         self.instance_bucket = bucket
 
+    def delete(self) -> None:
+        """Delete this vertex list and its instance storage."""
+        key = (self.start, self.count)
+        self.instance_bucket.clear()
+        super().delete()
+        self.domain._instance_map.pop(key, None)
+
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
 
     def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
         """Create several instances with a single instance-buffer upload."""
         return self.instance_bucket.create_instances(count, **attributes)
+
+    def create_instance_collection(
+        self, count: int, capacity: int | None = None, **attributes: Any,
+    ) -> InstanceCollection:
+        """Create a bulk-managed collection without individual instance objects."""
+        return self.instance_bucket.create_instance_collection(count, capacity, **attributes)
 
     def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
         """Replace one attribute over a contiguous range of instances."""
@@ -344,10 +357,7 @@ class GLInstanceIndexedVertexList(GLVertexList):
         """Delete this group."""
         key = (self.index_start, self.index_count)
 
-        # Invalidate all instance handles associated with this list.
-        for instance in list(self.instance_bucket.allocator.slot_to_inst.values()):
-            instance.slot = -1
-        self.instance_bucket.allocator.clear()
+        self.instance_bucket.clear()
 
         super().delete()
         self.domain.index_stream.dealloc(self.index_start, self.index_count)
@@ -374,6 +384,12 @@ class GLInstanceIndexedVertexList(GLVertexList):
     def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
         """Create several instances with a single instance-buffer upload."""
         return self.instance_bucket.create_instances(count, **attributes)
+
+    def create_instance_collection(
+        self, count: int, capacity: int | None = None, **attributes: Any,
+    ) -> InstanceCollection:
+        """Create a bulk-managed collection without individual instance objects."""
+        return self.instance_bucket.create_instance_collection(count, capacity, **attributes)
 
     def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
         """Replace one attribute over a contiguous range of instances."""

--- a/pyglet/graphics/api/webgl/vertexdomain.py
+++ b/pyglet/graphics/api/webgl/vertexdomain.py
@@ -320,7 +320,7 @@ class GLInstanceDomainArrays(InstanceDomain):  # noqa: D101
 
     def draw_subset(self, mode: int, vertex_list: WebGLInstanceVertexList):
         """Draw a specific VertexList in the domain."""
-        bucket = vertex_list.bucket
+        bucket = vertex_list.instance_bucket
         bucket.vao.bind()
         bucket.stream.commit()
         self._gl.drawArraysInstanced(mode, vertex_list.start, vertex_list.count, bucket.instance_count)
@@ -358,10 +358,13 @@ class GLInstanceDomainElements(InstanceDomain):  # noqa: D101
 
     def draw_subset(self, mode: GeometryMode, vertex_list: WebGLInstanceIndexedVertexList) -> None:
         """Draw a specific VertexList in the domain."""
+        bucket = vertex_list.instance_bucket
+        bucket.vao.bind()
+        bucket.stream.commit()
         byte_offset = vertex_list.index_start * self._elem_size
         self._gl.drawElementsInstanced(
             mode, vertex_list.index_count, self._index_gl_type, byte_offset,
-            vertex_list.bucket.instance_count,
+            bucket.instance_count,
         )
 
     def draw(self, mode: int) -> None:
@@ -417,7 +420,7 @@ class WebGLInstancedVertexDomain(InstancedVertexDomain):  # noqa: D101
 
         """
         self.vertex_buffers.commit()
-        self.instance_buckets.draw(mode)
+        self.instance_domain.draw(mode)
 
     def draw_subset(self, mode: GeometryMode, vertex_list: WebGLInstanceVertexList) -> None:
         """Draw a specific VertexList in the domain.
@@ -432,7 +435,7 @@ class WebGLInstancedVertexDomain(InstancedVertexDomain):  # noqa: D101
                 Vertex list to draw.
         """
         self.vertex_buffers.commit()
-        self.instance_buckets.draw_subset(geometry_map[mode], vertex_list)
+        self.instance_domain.draw_subset(geometry_map[mode], vertex_list)
 
 
 

--- a/pyglet/graphics/instance.py
+++ b/pyglet/graphics/instance.py
@@ -111,6 +111,31 @@ class InstanceBucket:
             self.stream.set_region(slot, 1, attributes)
         return v_instance
 
+    def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
+        """Create several instances with a single instance-buffer upload."""
+        if count < 0:
+            msg = f"Instance count must be non-negative. Received: {count}"
+            raise ValueError(msg)
+        if count == 0:
+            return []
+
+        start = self.allocator.count
+        instances = []
+        for _ in range(count):
+            instance = self._InstanceCls(weakref.ref(self), slot=-1)
+            instance.slot = self.allocator.add(instance)
+            instances.append(instance)
+
+        self.stream.alloc(count)
+        if attributes:
+            self.stream.set_region(start, count, attributes)
+        return instances
+
+    def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
+        """Replace one attribute over a contiguous range of instances."""
+        count = self.allocator.count - start if count is None else count
+        self.stream.set_attribute_region(name, start, count, data)
+
     def get_instance_by_index(self, index: int) -> VertexInstance | None:
         """Return the instance currently stored at ``index`` or ``None``."""
         return self.allocator.slot_to_inst.get(index)

--- a/pyglet/graphics/instance.py
+++ b/pyglet/graphics/instance.py
@@ -88,12 +88,212 @@ def _make_inst_attr_prop(attr_name: str):
 
     return property(_get, _set)
 
+
+class InstanceCollection:
+    """Manage contiguous instance data without per-instance Python objects.
+
+    Create collections with ``vertex_list.create_instance_collection``.
+
+    .. versionadded: 3.0
+    """
+
+    __slots__ = ("_bucket_ref", "_capacity", "_count", "_deleted")
+
+    def __init__(
+        self,
+        bucket_ref: ReferenceType[InstanceBucket],
+        capacity: int,
+        count: int,
+    ) -> None:
+        """Create an instance collection.
+
+        Args:
+            bucket_ref:
+                Weak reference to the instance bucket that owns the collection.
+            capacity:
+                Number of instance slots reserved in the stream.
+            count:
+                Number of active instances submitted by draw calls.
+        """
+        self._bucket_ref = bucket_ref
+        self._capacity = capacity
+        self._count = count
+        self._deleted = False
+
+    @property
+    def bucket(self) -> InstanceBucket:
+        bucket = self._bucket_ref()
+        if self._deleted or bucket is None:
+            msg = "Instance collection no longer exists."
+            raise RuntimeError(msg)
+        return bucket
+
+    @property
+    def count(self) -> int:
+        """Number of active instances submitted by instanced draw calls."""
+        return self._count
+
+    @property
+    def capacity(self) -> int:
+        """Number of reserved instance slots, including inactive slots."""
+        return self._capacity
+
+    def __len__(self) -> int:
+        return self._count
+
+    def _validate_region(self, start: int, count: int) -> None:
+        if start < 0 or count < 0 or start + count > self._count:
+            msg = f"Instance range [{start}, {start + count}) exceeds active count {self._count}."
+            raise IndexError(msg)
+
+    def reserve(self, capacity: int) -> None:
+        """Reserve storage without changing the active instance count.
+
+        Existing data and the current draw count are preserved. Requests no
+        larger than the current capacity do nothing.
+
+        Args:
+            capacity:
+                Minimum number of instance slots to reserve.
+        """
+        if capacity < self._count:
+            msg = f"Capacity {capacity} cannot be smaller than active count {self._count}."
+            raise ValueError(msg)
+        if capacity <= self._capacity:
+            return
+
+        stream = self.bucket.stream
+        start = stream.alloc(capacity) if self._capacity == 0 else stream.realloc(0, self._capacity, capacity)
+        if start != 0:
+            msg = "Bulk instance storage must begin at slot 0."
+            raise RuntimeError(msg)
+        self._capacity = capacity
+
+    def set_count(self, count: int) -> None:
+        """Set the number of drawn instances while retaining capacity.
+
+        Growing beyond the current capacity automatically reserves enough
+        storage. Newly activated slots are not initialized.
+
+        Args:
+            count:
+                New active instance count.
+        """
+        if count < 0:
+            msg = f"Instance count must be non-negative. Received: {count}"
+            raise ValueError(msg)
+        if count > self._capacity:
+            self.reserve(count)
+        self._count = count
+
+    def set(self, start: int = 0, count: int | None = None, **attributes: Any) -> None:
+        """Update one or more attributes over a contiguous active range.
+
+        Attribute values are flattened sequences sized for ``count`` rows.
+        Attributes not supplied are left unchanged.
+
+        Args:
+            start:
+                First active instance to update.
+            count:
+                Number of instances to update. Defaults to all active
+                instances from ``start`` onward.
+            **attributes:
+                Instanced attribute names and flattened data sequences.
+        """
+        count = self._count - start if count is None else count
+        self._validate_region(start, count)
+        for name, data in attributes.items():
+            self.bucket.stream.set_attribute_region(name, start, count, data)
+
+    def get(self, name: str, start: int = 0, count: int | None = None) -> Any:
+        """Return one attribute over a contiguous active range.
+
+        Args:
+            name:
+                Instanced attribute name.
+            start:
+                First active instance to read.
+            count:
+                Number of instances to read. Defaults to all active instances
+                from ``start`` onward.
+        """
+        count = self._count - start if count is None else count
+        self._validate_region(start, count)
+        return self.bucket.stream.get_attribute_region(name, start, count)
+
+    def insert(self, index: int, count: int = 1, **attributes: Any) -> None:
+        """Insert instance slots, shifting following data to the right.
+
+        This is convenient for occasional structural edits, but shifting large
+        ranges is more expensive than replacing attributes with :meth:`set`.
+
+        Args:
+            index:
+                Active instance index at which to insert.
+            count:
+                Number of slots to insert.
+            **attributes:
+                Initial data for the inserted slots.
+        """
+        if index < 0 or index > self._count:
+            msg = f"Insertion index {index} is outside [0, {self._count}]."
+            raise IndexError(msg)
+        if count < 0:
+            msg = f"Instance count must be non-negative. Received: {count}"
+            raise ValueError(msg)
+        if count == 0:
+            return
+
+        old_count = self._count
+        self.set_count(old_count + count)
+        trailing_count = old_count - index
+        if trailing_count:
+            for buffer in self.bucket.stream.attrib_name_buffers.values():
+                data = tuple(buffer.get_region(index, trailing_count))
+                buffer.set_region(index + count, trailing_count, data)
+        self.set(index, count, **attributes)
+
+    def remove(self, start: int, count: int = 1) -> None:
+        """Remove active slots while retaining the collection's capacity.
+
+        Following instance data is shifted left to keep the active range
+        contiguous.
+
+        Args:
+            start:
+                First active instance to remove.
+            count:
+                Number of instances to remove.
+        """
+        self._validate_region(start, count)
+        trailing_count = self._count - start - count
+        if trailing_count:
+            for buffer in self.bucket.stream.attrib_name_buffers.values():
+                data = tuple(buffer.get_region(start + count, trailing_count))
+                buffer.set_region(start, trailing_count, data)
+        self._count -= count
+
+    def delete(self) -> None:
+        """Release the collection's reserved instance storage."""
+        if self._deleted:
+            return
+        bucket = self.bucket
+        if self._capacity:
+            bucket.stream.dealloc(0, self._capacity)
+        bucket._collection = None
+        self._capacity = 0
+        self._count = 0
+        self._deleted = True
+
+
 class InstanceBucket:
     """Manages the relationship between the instance buffer data and the instance objects."""
     def __init__(self, instance_stream: InstanceStream, vao: VertexArrayBinding) -> None:
         self.stream = instance_stream
         self.vao = vao
         self.allocator = InstanceAllocator()
+        self._collection: InstanceCollection | None = None
 
         # Build a VertexInstance class with properties for each instanced attribute:
         props = {name: _make_inst_attr_prop(name) for name in self.stream.attrib_name_buffers.keys()}
@@ -101,6 +301,9 @@ class InstanceBucket:
         self._InstanceCls = type("VertexInstance", (VertexInstance,), props)
 
     def create_instance(self, **attributes: Any) -> VertexInstance:
+        if self._collection is not None:
+            msg = "Individual instances cannot be mixed with an instance collection in the same vertex list."
+            raise RuntimeError(msg)
         v_instance = self._InstanceCls(weakref.ref(self), slot=-1)
         slot = self.allocator.add(v_instance)
         v_instance.slot = slot
@@ -113,9 +316,9 @@ class InstanceBucket:
 
     def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
         """Create several instances with a single instance-buffer upload."""
-        if count < 0:
-            msg = f"Instance count must be non-negative. Received: {count}"
-            raise ValueError(msg)
+        if self._collection is not None:
+            msg = "Individual instances cannot be mixed with an instance collection in the same vertex list."
+            raise RuntimeError(msg)
         if count == 0:
             return []
 
@@ -131,9 +334,55 @@ class InstanceBucket:
             self.stream.set_region(start, count, attributes)
         return instances
 
+    def create_instance_collection(
+        self,
+        count: int,
+        capacity: int | None = None,
+        **attributes: Any,
+    ) -> InstanceCollection:
+        """Create a bulk-managed collection without per-instance objects.
+
+        Use this instead of :meth:`create_instances` when instance data is
+        generated and updated as complete arrays and individual object handles
+        are unnecessary. The collection exclusively owns this bucket's
+        instance slots.
+
+        Args:
+            count:
+                Initial number of active instances.
+            capacity:
+                Number of slots to reserve. Defaults to ``count`` and must not
+                be smaller than it.
+            **attributes:
+                Initial flattened data for each instanced attribute.
+
+        Returns:
+            An :class:`InstanceCollection` controlling the instance data and
+            active draw count.
+        """
+        if self.allocator.count or self._collection is not None:
+            msg = "An instance collection requires an empty vertex list."
+            raise RuntimeError(msg)
+
+        capacity = count if capacity is None else capacity
+        if capacity < count:
+            msg = f"Capacity {capacity} cannot be smaller than active count {count}."
+            raise ValueError(msg)
+
+        collection = InstanceCollection(weakref.ref(self), capacity, count)
+        self._collection = collection
+        if capacity:
+            start = self.stream.alloc(capacity)
+            if start != 0:
+                msg = "Bulk instance storage must begin at slot 0."
+                raise RuntimeError(msg)
+        if attributes and count:
+            collection.set(**attributes)
+        return collection
+
     def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
         """Replace one attribute over a contiguous range of instances."""
-        count = self.allocator.count - start if count is None else count
+        count = self.instance_count - start if count is None else count
         self.stream.set_attribute_region(name, start, count, data)
 
     def get_instance_by_index(self, index: int) -> VertexInstance | None:
@@ -296,10 +545,24 @@ class InstanceBucket:
             dst, src, moved = swap
             self.stream.copy_data(dst, self.stream, src, count=1)
             moved.slot = dst
+        self.stream.dealloc(self.allocator.count, 1)
+
+    def clear(self) -> None:
+        """Release all instance storage and invalidate individual handles."""
+        if self._collection is not None:
+            self._collection.delete()
+            return
+
+        count = self.allocator.count
+        for instance in self.allocator.slot_to_inst.values():
+            instance.slot = -1
+        self.allocator.clear()
+        if count:
+            self.stream.dealloc(0, count)
 
     @property
     def instance_count(self) -> int:
-        return self.allocator.count
+        return self._collection.count if self._collection is not None else self.allocator.count
 
 class InstanceDomain(ABC):
     """Base class for managing instance domains and the buckets associated with each."""
@@ -316,6 +579,24 @@ class InstanceDomain(ABC):
         assert src_bucket in self._buckets.values(), "Bucket does not belong to this instance domain."
         if dst_bucket is src_bucket:
             return
+        collection = src_bucket._collection
+        if collection is not None:
+            if dst_bucket.instance_count:
+                msg = "An instance collection cannot migrate into a non-empty instance bucket."
+                raise RuntimeError(msg)
+            if collection.capacity:
+                start = dst_bucket.stream.alloc(collection.capacity)
+                if start != 0:
+                    msg = "Bulk instance storage must begin at slot 0."
+                    raise RuntimeError(msg)
+                if collection.count:
+                    src_bucket.stream.copy_data(0, dst_bucket.stream, 0, collection.count)
+                src_bucket.stream.dealloc(0, collection.capacity)
+            src_bucket._collection = None
+            dst_bucket._collection = collection
+            collection._bucket_ref = weakref.ref(dst_bucket)
+            return
+
         n = src_bucket.allocator.count
         if n == 0:
             # Nothing to move.
@@ -331,6 +612,7 @@ class InstanceDomain(ABC):
         dst_bucket.stream.alloc(n)
         src_bucket.stream.copy_data(dst_slot=start_dst, dst_stream=dst_bucket.stream, src_slot=0, count=n)
 
+        src_bucket.stream.dealloc(0, n)
         src_bucket.allocator.clear()
 
     def get_arrays_bucket(self, *, mode: int, first_vertex: int, vertex_count: int) -> InstanceBucket:

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -205,6 +205,24 @@ class InstanceVertexList(VertexList):
         super().delete()
         self.domain._instance_map.pop(key, None)
 
+    def migrate(self, domain: InstancedVertexDomain, group: Group) -> None:
+        """Move the geometry and its instance data to another domain."""
+        old_domain = self.domain
+        old_key = (self.start, self.count)
+        old_bucket = self.instance_bucket
+
+        super().migrate(domain, group)
+
+        new_bucket = domain.instance_domain.get_arrays_bucket(
+            mode=0,
+            first_vertex=self.start,
+            vertex_count=self.count,
+        )
+        old_domain._instance_map.pop(old_key, None)
+        old_domain.instance_domain.move_all(old_bucket, new_bucket)
+        self.instance_bucket = new_bucket
+        domain._instance_map[(self.start, self.count)] = new_bucket
+
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
 
@@ -405,7 +423,8 @@ class _InstancedIndexSupport:
     base_vertex: int
 
     def _migrate_instance_bucket(self, old_domain: InstancedIndexedVertexDomain,
-                                 new_domain: InstancedIndexedVertexDomain) -> None:
+                                 new_domain: InstancedIndexedVertexDomain,
+                                 old_key: tuple[int, int]) -> None:
         base_vertex = self.start if self.supports_base_vertex else 0
         self.base_vertex = base_vertex
         new_bucket = new_domain.instance_domain.get_elements_bucket(
@@ -417,20 +436,24 @@ class _InstancedIndexSupport:
         )
         old_domain.instance_domain.move_all(self.instance_bucket, new_bucket)
         self.instance_bucket = new_bucket
+        old_domain._instance_map.pop(old_key, None)
+        new_domain._instance_map[(self.index_start, self.index_count)] = new_bucket
 
 
 class _InstancedLocalIndexSupport(_LocalIndexSupport, _InstancedIndexSupport):
     def migrate(self, domain: InstancedIndexedVertexDomain, group: Group) -> None:
         old_domain = self.domain
+        old_key = (self.index_start, self.index_count)
         super().migrate(domain, group)
-        self._migrate_instance_bucket(old_domain, domain)
+        self._migrate_instance_bucket(old_domain, domain, old_key)
 
 
 class _InstancedRunningIndexSupport(_RunningIndexSupport, _InstancedIndexSupport):
     def migrate(self, domain: InstancedIndexedVertexDomain, group: Group) -> None:
         old_domain = self.domain
+        old_key = (self.index_start, self.index_count)
         super().migrate(domain, group)
-        self._migrate_instance_bucket(old_domain, domain)
+        self._migrate_instance_bucket(old_domain, domain, old_key)
 
 
 class IndexedVertexList(VertexList):

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -201,6 +201,14 @@ class InstanceVertexList(VertexList):
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
 
+    def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
+        """Create several instances with a single instance-buffer upload."""
+        return self.instance_bucket.create_instances(count, **attributes)
+
+    def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
+        """Replace one attribute over a contiguous range of instances."""
+        self.instance_bucket.set_instance_attribute_data(name, data, start, count)
+
     @property
     def instance_count(self) -> int:
         """Number of active instances in this vertex list."""
@@ -503,6 +511,14 @@ class InstanceIndexedVertexList(VertexList):
 
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
+
+    def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
+        """Create several instances with a single instance-buffer upload."""
+        return self.instance_bucket.create_instances(count, **attributes)
+
+    def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
+        """Replace one attribute over a contiguous range of instances."""
+        self.instance_bucket.set_instance_attribute_data(name, data, start, count)
 
     @property
     def instance_count(self) -> int:

--- a/pyglet/graphics/vertexdomain.py
+++ b/pyglet/graphics/vertexdomain.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from ctypes import Array
     from pyglet.customtypes import DataTypes
     from pyglet.graphics.api.base import SurfaceContext
-    from pyglet.graphics.instance import InstanceBucket, VertexInstance, InstanceDomain
+    from pyglet.graphics.instance import InstanceBucket, InstanceCollection, VertexInstance, InstanceDomain
     from pyglet.graphics.buffer import AttributeBufferObject, IndexedBufferObject
     from pyglet.graphics import Group
     from pyglet.enums import GeometryMode
@@ -198,12 +198,25 @@ class InstanceVertexList(VertexList):
         super().__init__(domain, group, start, count)
         self.instance_bucket = bucket
 
+    def delete(self) -> None:
+        """Delete this vertex list and its instance storage."""
+        key = (self.start, self.count)
+        self.instance_bucket.clear()
+        super().delete()
+        self.domain._instance_map.pop(key, None)
+
     def create_instance(self, **attributes: Any) -> VertexInstance:
         return self.instance_bucket.create_instance(**attributes)
 
     def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
         """Create several instances with a single instance-buffer upload."""
         return self.instance_bucket.create_instances(count, **attributes)
+
+    def create_instance_collection(
+        self, count: int, capacity: int | None = None, **attributes: Any,
+    ) -> InstanceCollection:
+        """Create a bulk-managed collection without individual instance objects."""
+        return self.instance_bucket.create_instance_collection(count, capacity, **attributes)
 
     def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
         """Replace one attribute over a contiguous range of instances."""
@@ -484,10 +497,7 @@ class InstanceIndexedVertexList(VertexList):
         """Delete this group."""
         key = (self.index_start, self.index_count)
 
-        # Invalidate all instance handles associated with this list.
-        for instance in list(self.instance_bucket.allocator.slot_to_inst.values()):
-            instance.slot = -1
-        self.instance_bucket.allocator.clear()
+        self.instance_bucket.clear()
 
         super().delete()
         self.domain.index_stream.dealloc(self.index_start, self.index_count)
@@ -515,6 +525,12 @@ class InstanceIndexedVertexList(VertexList):
     def create_instances(self, count: int, **attributes: Any) -> list[VertexInstance]:
         """Create several instances with a single instance-buffer upload."""
         return self.instance_bucket.create_instances(count, **attributes)
+
+    def create_instance_collection(
+        self, count: int, capacity: int | None = None, **attributes: Any,
+    ) -> InstanceCollection:
+        """Create a bulk-managed collection without individual instance objects."""
+        return self.instance_bucket.create_instance_collection(count, capacity, **attributes)
 
     def set_instance_attribute_data(self, name: str, data: Any, start: int = 0, count: int | None = None) -> None:
         """Replace one attribute over a contiguous range of instances."""

--- a/tests/integration/graphics/opengl/test_instancing.py
+++ b/tests/integration/graphics/opengl/test_instancing.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import ctypes
 import random
 
 import pytest
-import ctypes
 
-from tests.annotations import skip_graphics_api, GraphicsAPIGroups
+from pyglet.enums import GeometryMode
+from tests.annotations import GraphicsAPIGroups, skip_graphics_api
 
 
 pytestmark = [skip_graphics_api(GraphicsAPIGroups.GL2)]
@@ -122,7 +123,66 @@ def test_instancing_count(vlist_factory):
     assert vlist.instance_bucket.instance_count == instance_count  # the initial list
 
 
+def test_bulk_instance_collection(vlist_factory):
+    """Ensure bulk collections manage their data, count, and storage lifetime."""
+    vlist = vlist_factory((0.0,) * 12)
+    collection = vlist.create_instance_collection(
+        3,
+        capacity=8,
+        colors=(1.0, 0.0, 0.0, 1.0) * 3,
+        translate=(0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 20.0, 0.0, 0.0),
+    )
+
+    assert vlist.instance_bucket.stream.allocator.get_allocated_regions() == ([0], [8])
+    assert collection.count == 3
+    assert collection.capacity == 8
+    assert len(collection) == 3
+    assert vlist.instance_count == 3
+
+    collection.set_count(1)
+    assert vlist.instance_count == 1
+    assert collection.capacity == 8
+
+    collection.set_count(3)
+    collection.set(
+        start=1,
+        count=2,
+        translate=(11.0, 0.0, 0.0, 21.0, 0.0, 0.0),
+    )
+    assert tuple(collection.get("translate")) == (0.0, 0.0, 0.0, 11.0, 0.0, 0.0, 21.0, 0.0, 0.0)
+
+    collection.insert(
+        1,
+        colors=(0.0, 1.0, 0.0, 1.0),
+        translate=(5.0, 0.0, 0.0),
+    )
+    assert collection.count == 4
+    assert tuple(collection.get("translate")) == (
+        0.0, 0.0, 0.0,
+        5.0, 0.0, 0.0,
+        11.0, 0.0, 0.0,
+        21.0, 0.0, 0.0,
+    )
+
+    collection.remove(2)
+    assert collection.count == 3
+    assert tuple(collection.get("translate")) == (
+        0.0, 0.0, 0.0,
+        5.0, 0.0, 0.0,
+        21.0, 0.0, 0.0,
+    )
+    vlist.draw(GeometryMode.TRIANGLES)
+
+    with pytest.raises(RuntimeError):
+        vlist.create_instance(colors=(1.0, 1.0, 1.0, 1.0), translate=(0.0, 0.0, 0.0))
+
+    collection.delete()
+    assert vlist.instance_count == 0
+    assert vlist.instance_bucket.stream.allocator.get_allocated_regions() == ([], [])
+
+
 def test_get_instance_by_index_non_indexed(vlist_non_indexed_factory):
+    """Ensure non-indexed lists maintain instance lookup after deletion."""
     vlist = vlist_non_indexed_factory(
         (
             0.0, 0.0, 0.0,
@@ -155,6 +215,7 @@ def test_get_instance_by_index_non_indexed(vlist_non_indexed_factory):
 
 
 def test_get_instance_by_index_indexed(vlist_factory):
+    """Ensure indexed lists maintain instance lookup after deletion."""
     vlist = vlist_factory((0.0,) * 12)
 
     inst0 = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
@@ -188,6 +249,7 @@ def _assert_instance_order(vlist, expected) -> None:
 
 
 def test_instance_reorder_helpers_non_indexed(vlist_non_indexed_factory):
+    """Ensure non-indexed instance ordering helpers preserve requested order."""
     vlist = vlist_non_indexed_factory(
         (
             0.0, 0.0, 0.0,
@@ -226,6 +288,7 @@ def test_instance_reorder_helpers_non_indexed(vlist_non_indexed_factory):
 
 
 def test_instance_reorder_helpers_indexed(vlist_factory):
+    """Ensure indexed instance ordering helpers preserve requested order."""
     vlist = vlist_factory((0.0,) * 12)
 
     inst_a = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
@@ -251,15 +314,23 @@ def test_instance_reorder_helpers_indexed(vlist_factory):
     _assert_instance_order(vlist, [inst_b, inst_a, inst_d, inst_c])
 
 
-def test_instanced_indexed_migrate_moves_instances(shader_program, vlist_factory):
+def test_batch_migrate_instanced_indexed_vertex_list(shader_program, vlist_factory):
+    """Ensure batch migration preserves indexed geometry and instance data."""
     from pyglet.graphics import Batch, ShaderGroup
 
     source_batch = Batch()
     target_batch = Batch()
     source_group = ShaderGroup(program=shader_program)
     target_group = ShaderGroup(program=shader_program)
+    source_vertices = (
+        0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0,
+        1.0, 1.0, 0.0,
+        0.0, 1.0, 0.0,
+    )
+    source_indices = (0, 1, 2, 0, 2, 3)
 
-    source = vlist_factory((0.0,) * 12, batch=source_batch, group=source_group)
+    source = vlist_factory(source_vertices, source_indices, batch=source_batch, group=source_group)
     target = vlist_factory((1.0,) * 12, batch=target_batch, group=target_group)
 
     old_domain = source.domain
@@ -268,26 +339,39 @@ def test_instanced_indexed_migrate_moves_instances(shader_program, vlist_factory
     inst0 = source.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
     inst1 = source.create_instance(colors=(0, 1, 0, 1), translate=(5, 0, 0))
 
-    source.migrate(target.domain, target.group)
+    source_batch.migrate(source, GeometryMode.TRIANGLES, target_group, target_batch)
 
     assert source.domain is target.domain
+    assert source.group is target_group
+    assert tuple(source.position[:]) == pytest.approx(source_vertices)
+    assert tuple(source.indices) == source_indices
     assert source.instance_bucket is not old_bucket
     assert source.instance_bucket.instance_count == 2
     assert old_bucket.instance_count == 0
+    assert old_bucket.stream.allocator.get_allocated_regions() == ([], [])
+    assert source.instance_bucket.stream.allocator.get_allocated_regions() == ([0], [2])
     assert source.get_instance_by_index(0) is inst0
     assert source.get_instance_by_index(1) is inst1
     assert inst0.bucket is source.instance_bucket
     assert inst1.bucket is source.instance_bucket
+    assert tuple(inst0.colors[:]) == pytest.approx((1, 0, 0, 1))
+    assert tuple(inst0.translate[:]) == pytest.approx((0, 0, 0))
+    assert tuple(inst1.colors[:]) == pytest.approx((0, 1, 0, 1))
+    assert tuple(inst1.translate[:]) == pytest.approx((5, 0, 0))
     assert source.domain is not old_domain
+    assert source.domain._instance_map[(source.index_start, source.index_count)] is source.instance_bucket
+    source.draw(GeometryMode.TRIANGLES)
 
 
 def test_instanced_indexed_vertex_list_delete_clears_instances(vlist_factory):
+    """Ensure deleting an indexed list releases all of its instance storage."""
     vlist = vlist_factory((0.0,) * 12)
 
     inst0 = vlist.create_instance(colors=(1, 0, 0, 1), translate=(0, 0, 0))
     inst1 = vlist.create_instance(colors=(0, 1, 0, 1), translate=(10, 0, 0))
 
     assert vlist.instance_bucket.instance_count == 2
+    assert vlist.instance_bucket.stream.allocator.get_allocated_regions() == ([0], [2])
 
     vlist.delete()
 
@@ -297,9 +381,29 @@ def test_instanced_indexed_vertex_list_delete_clears_instances(vlist_factory):
     assert vlist.get_instance_index(inst1) is None
     assert inst0.slot == -1
     assert inst1.slot == -1
+    assert vlist.instance_bucket.stream.allocator.get_allocated_regions() == ([], [])
+
+
+def test_instanced_nonindexed_vertex_list_delete_releases_instance_range(vlist_non_indexed_factory):
+    """Ensure deleting a non-indexed list releases its instance stream range."""
+    vlist = vlist_non_indexed_factory((0.0,) * 9)
+    vlist.create_instances(
+        3,
+        colors=(1.0, 1.0, 1.0, 1.0) * 3,
+        translate=(0.0, 0.0, 0.0) * 3,
+    )
+
+    allocator = vlist.instance_bucket.stream.allocator
+    assert allocator.get_allocated_regions() == ([0], [3])
+    vlist.draw(GeometryMode.TRIANGLES)
+
+    vlist.delete()
+
+    assert allocator.get_allocated_regions() == ([], [])
 
 
 def test_instanced_vertex_list_migrate_new_domain_and_group(shader_program, vlist_non_indexed_factory):
+    """Ensure migration moves non-indexed geometry and instances to a new domain."""
     from pyglet.enums import GeometryMode
     from pyglet.graphics import Batch, ShaderGroup
 
@@ -317,6 +421,8 @@ def test_instanced_vertex_list_migrate_new_domain_and_group(shader_program, vlis
     target = vlist_non_indexed_factory(verts, batch=target_batch, group=target_group)
 
     old_domain = source.domain
+    old_instance_bucket = source.instance_bucket
+    instance = source.create_instance(colors=(1.0, 0.0, 0.0, 1.0), translate=(5.0, 0.0, 0.0))
 
     source_batch.migrate(source, GeometryMode.TRIANGLES, target_group, target_batch)
 
@@ -326,9 +432,16 @@ def test_instanced_vertex_list_migrate_new_domain_and_group(shader_program, vlis
     assert source.bucket is source.domain.get_drawable_bucket(target_group)
     assert (source.start, source.count) in source.bucket.ranges
     assert old_domain.get_drawable_bucket(source_group) is None
+    assert source.instance_bucket is not old_instance_bucket
+    assert old_instance_bucket.stream.allocator.get_allocated_regions() == ([], [])
+    assert source.instance_bucket.stream.allocator.get_allocated_regions() == ([0], [1])
+    assert instance.bucket is source.instance_bucket
+    assert source.domain._instance_map[(source.start, source.count)] is source.instance_bucket
+    source.draw(GeometryMode.TRIANGLES)
 
 
 def test_instanced_vertex_list_migrate_new_group_same_domain(shader_program, vlist_non_indexed_factory):
+    """Ensure changing groups retains non-indexed instance storage in its domain."""
     from pyglet.enums import GeometryMode
     from pyglet.graphics import Batch, ShaderGroup
 
@@ -395,6 +508,7 @@ def test_instance_deletion(shader_program, vlist_factory):
         instances.append(vlist.create_instance(colors=(1, 1, 1, 1), translate=(100 * i, 100, 0)))
 
     assert [inst.slot for inst in instances] == list(range(10))
+    assert vlist.instance_bucket.stream.allocator.get_allocated_regions() == ([0], [10])
 
     last_instance = instances[-1]
 
@@ -408,3 +522,4 @@ def test_instance_deletion(shader_program, vlist_factory):
 
     # Last instance should move to fill the spot.
     assert last_instance.slot == 5
+    assert vlist.instance_bucket.stream.allocator.get_allocated_regions() == ([0], [9])

--- a/tests/integration/graphics/webgl/test_buffers.py
+++ b/tests/integration/graphics/webgl/test_buffers.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pyglet.graphics.api.webgl.buffer import WebGLBufferObject, WebGLIndexedBufferObject
+
+
+def test_ctypes_backed_buffer_uploads_direct_memoryview(webgl_window):
+    buffer = WebGLIndexedBufferObject(webgl_window.context, size=8, data_type="I", stride=4, count=1)
+    try:
+        buffer.set_region(0, 2, (5, 9))
+        buffer.commit()
+        assert WebGLBufferObject.get_bytes(buffer) == buffer.get_bytes()
+
+        buffer.set_region(1, 1, (12,))
+        buffer.commit()
+        assert WebGLBufferObject.get_bytes(buffer) == buffer.get_bytes()
+    finally:
+        buffer.delete()

--- a/tests/integration/graphics/webgl/test_instancing.py
+++ b/tests/integration/graphics/webgl/test_instancing.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import pytest
+
+import pyglet
+from pyglet.enums import GeometryMode
+
+
+VERTEX_SOURCE = """#version 300 es
+in vec2 position;
+in vec2 translation;
+in vec4 colors;
+out vec4 vertex_colors;
+void main() {
+    gl_Position = vec4(position + translation, 0.0, 1.0);
+    vertex_colors = colors;
+}
+"""
+
+FRAGMENT_SOURCE = """#version 300 es
+precision mediump float;
+in vec4 vertex_colors;
+out vec4 final_color;
+void main() {
+    final_color = vertex_colors;
+}
+"""
+
+
+def _create_program():
+    vertex_shader = pyglet.graphics.Shader(VERTEX_SOURCE, "vertex")
+    fragment_shader = pyglet.graphics.Shader(FRAGMENT_SOURCE, "fragment")
+    program = pyglet.graphics.ShaderProgram(vertex_shader, fragment_shader)
+    program.set_instance_attributes(translation=1, colors=1)
+    return program, vertex_shader, fragment_shader
+
+
+def test_instance_collection(webgl_window):
+    """Ensure an indexed instance collection renders and releases its storage."""
+    program, vertex_shader, fragment_shader = _create_program()
+    vertex_list = program.vertex_list_instanced_indexed(
+        4,
+        mode=GeometryMode.TRIANGLES,
+        indices=(0, 1, 2, 0, 2, 3),
+        position=(-0.1, -0.1, 0.1, -0.1, 0.1, 0.1, -0.1, 0.1),
+        translation=(0.0, 0.0),
+        colors=(1.0, 1.0, 1.0, 1.0),
+    )
+
+    collection = vertex_list.create_instance_collection(
+        3,
+        capacity=8,
+        translation=(-0.5, 0.0, 0.0, 0.0, 0.5, 0.0),
+        colors=(1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0),
+    )
+    allocator = vertex_list.instance_bucket.stream.allocator
+
+    try:
+        assert collection.count == vertex_list.instance_count == 3
+        assert collection.capacity == 8
+
+        collection.set_count(2)
+        assert vertex_list.instance_count == 2
+        collection.set(translation=(-0.25, 0.0, 0.25, 0.0))
+
+        webgl_window.clear()
+        vertex_list.draw(GeometryMode.TRIANGLES)
+    finally:
+        vertex_list.delete()
+        program.delete()
+        vertex_shader.delete()
+        fragment_shader.delete()
+
+    with pytest.raises(RuntimeError):
+        collection.set_count(1)
+    assert allocator.get_allocated_regions() == ([], [])
+
+
+def test_create_instances(webgl_window):
+    """Ensure bulk-created WebGL instances upload data and render."""
+    program, vertex_shader, fragment_shader = _create_program()
+    vertex_list = program.vertex_list_instanced(
+        3,
+        mode=GeometryMode.TRIANGLES,
+        position=(-0.1, -0.1, 0.1, -0.1, 0.0, 0.1),
+        translation=(0.0, 0.0),
+        colors=(1.0, 1.0, 1.0, 1.0),
+    )
+
+    try:
+        instances = vertex_list.create_instances(
+            2,
+            translation=(-0.25, 0.0, 0.25, 0.0),
+            colors=(1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0),
+        )
+
+        assert vertex_list.instance_count == 2
+        assert tuple(instances[0].translation[:]) == pytest.approx((-0.25, 0.0))
+        assert tuple(instances[1].colors[:]) == pytest.approx((0.0, 0.0, 1.0, 1.0))
+
+        webgl_window.clear()
+        vertex_list.draw(GeometryMode.TRIANGLES)
+    finally:
+        vertex_list.delete()
+        program.delete()
+        vertex_shader.delete()
+        fragment_shader.delete()
+
+
+def test_nonindexed_instance_collection_migration(webgl_window):
+    """Ensure migrating a collection updates its WebGL instance bucket."""
+    program, vertex_shader, fragment_shader = _create_program()
+    source_batch = pyglet.graphics.Batch()
+    target_batch = pyglet.graphics.Batch()
+    source_group = pyglet.graphics.ShaderGroup(program)
+    target_group = pyglet.graphics.ShaderGroup(program)
+    positions = (-0.1, -0.1, 0.1, -0.1, 0.0, 0.1)
+
+    source = program.vertex_list_instanced(
+        3,
+        mode=GeometryMode.TRIANGLES,
+        batch=source_batch,
+        group=source_group,
+        position=positions,
+        translation=(0.0, 0.0),
+        colors=(1.0, 1.0, 1.0, 1.0),
+    )
+    target = program.vertex_list_instanced(
+        3,
+        mode=GeometryMode.TRIANGLES,
+        batch=target_batch,
+        group=target_group,
+        position=positions,
+        translation=(0.0, 0.0),
+        colors=(1.0, 1.0, 1.0, 1.0),
+    )
+    collection = source.create_instance_collection(
+        2,
+        capacity=4,
+        translation=(-0.25, 0.0, 0.25, 0.0),
+        colors=(1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0),
+    )
+    old_domain = source.domain
+    old_instance_bucket = source.instance_bucket
+
+    try:
+        source_batch.migrate(source, GeometryMode.TRIANGLES, target_group, target_batch)
+
+        assert source.domain is target.domain
+        assert source.instance_bucket is not old_instance_bucket
+        assert old_instance_bucket.stream.allocator.get_allocated_regions() == ([], [])
+        assert source.instance_bucket.stream.allocator.get_allocated_regions() == ([0], [4])
+        assert collection.bucket is source.instance_bucket
+        assert source.domain._instance_map[(source.start, source.count)] is source.instance_bucket
+        assert old_domain is not source.domain
+
+        webgl_window.clear()
+        source.draw(GeometryMode.TRIANGLES)
+    finally:
+        source.delete()
+        target.delete()
+        program.delete()
+        vertex_shader.delete()
+        fragment_shader.delete()


### PR DESCRIPTION
Added `vertex_list.create_instances` for faster creation of many normal VertexInstance objects rather than 1 by 1.

Added `vertex_list.create_instance_collection` and `InstanceCollection` for array-style instance management without per-instance Python objects.

Some fixes:
Deleting a vertex list or collection releases its stream allocation for reuse.
Moving instances during deletion, migration, or ordering updates retains correct slots and buffer data.
Migrating a list now moves its instance bucket as well as its geometry/index data and updates instance-bucket maps.
Desktop GL and WebGL direct subset draws use the correct instance bucket, VAO, and committed stream.
Add instance module in graphics module
Add some more instancing tests for WebGL.

Updated docs, tests, and examples.
