### PR TITLE
Camera optimizations

### DIFF
--- a/pyglet/graphics/api/base.py
+++ b/pyglet/graphics/api/base.py
@@ -295,6 +295,7 @@ class FrameSlotData:
 
     fence: Any | None = None
     ubo_ranges: list[BufferRange] = field(default_factory=list)
+    ubo_range_ids: set[int] = field(default_factory=set)
 
 
 class FrameResourceManager:
@@ -317,6 +318,7 @@ class FrameResourceManager:
             ubo_range.frame_use_count = max(0, ubo_range.frame_use_count - 1)
             ubo_range.in_use = ubo_range.frame_use_count > 0
         slot.ubo_ranges.clear()
+        slot.ubo_range_ids.clear()
 
     def frame_begin(self, frame_index: int) -> None:
         slot_index = frame_index % len(self.slots)
@@ -340,12 +342,14 @@ class FrameResourceManager:
         self.use_ubo(ubo_range)
 
     def use_ubo(self, ubo_range: BufferRange) -> None:
-        if any(active_range is ubo_range for active_range in self._active_slot.ubo_ranges):
+        ubo_range_id = id(ubo_range)
+        if ubo_range_id in self._active_slot.ubo_range_ids:
             return
 
         ubo_range.frame_use_count += 1
         ubo_range.in_use = True
         self._active_slot.ubo_ranges.append(ubo_range)
+        self._active_slot.ubo_range_ids.add(ubo_range_id)
 
     def frame_submit(self) -> None:
         if not self._active_slot.ubo_ranges:

--- a/pyglet/graphics/draw.py
+++ b/pyglet/graphics/draw.py
@@ -165,11 +165,14 @@ class Group:
                 begins and ends its drawing scope, and may provide a scissor
                 area for this group.
         """
-        self.set_state(CameraScopeState(camera))
         if isinstance(camera, CameraScissorProviderProtocol):
             scissor = camera.get_group_scissor_area()
-            if scissor is not None:
-                self.set_state(ScissorState(scissor, owned_by_camera=True))
+        else:
+            scissor = None
+
+        self.set_state(CameraScopeState(camera, scissor_managed=scissor is not None))
+        if scissor is not None:
+            self.set_state(ScissorState(scissor, owned_by_camera=True))
 
     def set_blend(self, blend_src: BlendFactor, blend_dst: BlendFactor, blend_op: BlendOp = BlendOp.ADD) -> None:
         """Set the blend state.
@@ -502,7 +505,7 @@ class DrawContext(Generic[SurfaceContextT, BackendContextT]):
             return self.scissor_stack[-1]
         return None
 
-    def apply_camera_scope(self, *, commit: bool = True) -> None:
+    def apply_camera_scope(self, *, commit: bool = True, apply_scissor: bool = True) -> None:
         if not self.camera_stack:
             return
         camera = self.active_camera
@@ -511,7 +514,8 @@ class DrawContext(Generic[SurfaceContextT, BackendContextT]):
         camera.begin(draw_context=self, commit=commit)
         self._applied_camera = camera
         self.apply_viewport()
-        self.apply_scissor()
+        if apply_scissor:
+            self.apply_scissor()
 
     def apply_viewport(self) -> None:
         viewport_state = self.active_viewport
@@ -994,32 +998,31 @@ class _BucketBatch(Batch):
             if not group.visible:
                 return draw_list
 
-            is_drawable = False
             for domain_key, domain in self._domain_registry.items():
-                if domain.is_empty or not domain.get_drawable_bucket(group):
+                if domain.is_empty:
                     self._empty_domains.add(domain_key)
                     continue
-                is_drawable = True
-                break
 
-            if not is_drawable and not self.group_children.get(group):
+                bucket = domain.get_drawable_bucket(group)
+                if bucket:
+                    draw_list.append((domain, domain_key.mode, group))
+                else:
+                    self._empty_domains.add(domain_key)
+
+            children = self.group_children.get(group, [])
+            if not draw_list and not children:
                 self._cleanup_groups(group)
                 return []
 
-            if is_drawable:
-                for domain_key, domain in self._domain_registry.items():
-                    bucket = domain.get_drawable_bucket(group)
-                    if not bucket:
-                        continue
-
-                    draw_list.append((domain, domain_key.mode, group))
-
-            children = self.group_children.get(group, [])
-            for child in sorted(children):
+            if len(children) <= 1:
+                ordered_children = children
+            else:
+                ordered_children = sorted(children)
+            for child in ordered_children:
                 if child.visible:
                     draw_list.extend(visit(child))
 
-            if children or is_drawable:
+            if draw_list:
                 return [(None, "set", group), *draw_list, (None, "unset", group)]
 
             return draw_list

--- a/pyglet/graphics/draw.py
+++ b/pyglet/graphics/draw.py
@@ -486,6 +486,7 @@ class DrawContext(Generic[SurfaceContextT, BackendContextT]):
 
     # Keep track of current camera to prevent double applies.
     _applied_camera: CameraScopeProtocol | None = None
+    _applied_viewport: tuple[int, int, int, int] | None = None
 
     def __post_init__(self) -> None:
         if not self.camera_stack and self.draw_pass.camera is not None:
@@ -530,7 +531,12 @@ class DrawContext(Generic[SurfaceContextT, BackendContextT]):
             return
 
         x, y, width, height = viewport
-        self.renderer.set_viewport(int(x), int(y), int(width), int(height))
+        resolved_viewport = int(x), int(y), int(width), int(height)
+        if resolved_viewport == self._applied_viewport:
+            return
+
+        self.renderer.set_viewport(*resolved_viewport)
+        self._applied_viewport = resolved_viewport
 
     def apply_scissor(self) -> None:
         scissor_state = self.active_scissor

--- a/pyglet/graphics/draw.py
+++ b/pyglet/graphics/draw.py
@@ -305,6 +305,8 @@ class Group:
 
     @visible.setter
     def visible(self, value: bool) -> None:
+        if self._visible == value:
+            return
         self._visible = value
 
         for batch in self._assigned_batches:

--- a/pyglet/graphics/state.py
+++ b/pyglet/graphics/state.py
@@ -125,13 +125,17 @@ class CameraScopeState(State):
     """State wrapper that applies camera state at draw scope entry."""
 
     camera: CameraScopeProtocol
+    scissor_managed: bool = False
     sets_state: bool = True
     unsets_state: bool = True
     enforced_state: bool = True
 
     def set_state(self, ctx: DrawContext) -> None:
         ctx.camera_stack.append(self.camera)
-        ctx.apply_camera_scope()
+        # Group.set_camera attaches a following camera-owned ScissorState when
+        # clipping is active. Let that state perform scissor
+        # update instead of setting the same area twice.
+        ctx.apply_camera_scope(apply_scissor=not self.scissor_managed)
 
     def unset_state(self, ctx: DrawContext) -> None:
         if ctx.camera_stack:

--- a/pyglet/window/camera/base.py
+++ b/pyglet/window/camera/base.py
@@ -520,7 +520,7 @@ class _CameraViewBase:
 
     def get_group_scissor_area(self) -> ScissorProtocol | None:
         """Resolve effective scissor object for group camera scopes."""
-        if self._camera._resolve_scissor_area(self) is None:  # noqa: SLF001
+        if not self._camera._has_scissor_in_chain(self):  # noqa: SLF001
             return None
         if self._group_scissor is None:
             self._group_scissor = _ResolvedGroupScissor(self)
@@ -804,6 +804,16 @@ class BaseCamera(Generic[ViewT]):
         for scoped_view in reversed(chain):
             scissor = self._intersect_scissor_areas(scissor, scoped_view.scissor_area)
         return scissor
+
+    @staticmethod
+    def _has_scissor_in_chain(view: _CameraViewBase) -> bool:
+        """Return whether a view or any ancestor supplies scissor clipping."""
+        current: _CameraViewBase | None = view
+        while current is not None:
+            if current.scissor is not None:
+                return True
+            current = current.parent
+        return False
 
     def _apply_cpu_data(
         self,

--- a/tests/integration/graphics/test_cameras.py
+++ b/tests/integration/graphics/test_cameras.py
@@ -290,6 +290,59 @@ def test_group_camera_viewport_is_applied_to_draw_context_stack(test_window, mon
     assert renderer.viewports[-1] == (30, 40, 160, 90)
 
 
+def test_group_camera_scissor_is_applied_once_on_scope_entry(test_window, monkeypatch):
+    _set_default_view_storage(monkeypatch, RecordingStorage())
+    camera = pyglet.window.camera.Camera2D(test_window)
+    child = camera.create_view(inherit=True)
+    child.set_scissor_area(10, 20, 300, 200)
+
+    group = pyglet.graphics.Group()
+    group.set_camera(child)
+    renderer = RecordingRenderer()
+    draw_context = DrawContext(
+        surface_ctx=test_window.context,
+        backend_ctx=None,
+        draw_pass=DrawPass(
+            framebuffer=None,
+            camera=camera,
+            viewport=camera.viewport,
+            scissor=None,
+            clear_color=(0.0, 0.0, 0.0, 1.0),
+        ),
+        renderer=renderer,
+    )
+
+    group.set_state_all(draw_context)
+
+    assert len(renderer.scissors) == 1
+    assert renderer.scissors[0].area == (10, 20, 300, 200)
+
+
+@pytest.mark.parametrize("hide_camera_group", [False, True])
+def test_hidden_camera_groups_do_not_apply_camera_or_scissor(
+    test_window,
+    monkeypatch,
+    hide_camera_group: bool,
+):
+    storage = RecordingStorage()
+    _set_default_view_storage(monkeypatch, storage)
+    camera = pyglet.window.camera.Camera2D(test_window)
+    view = camera.create_view(inherit=True)
+    view.set_scissor_area(10, 20, 300, 200)
+
+    camera_group = pyglet.graphics.Group()
+    camera_group.set_camera(view)
+    image = pyglet.image.ImageData(2, 2, "RGBA", bytes((255, 255, 255, 255)) * 4)
+    batch = pyglet.graphics.Batch(context=test_window.context)
+    sprite = pyglet.sprite.Sprite(image, batch=batch, group=camera_group)
+    (camera_group if hide_camera_group else sprite._group).visible = False  # noqa: SLF001
+
+    batch.draw()
+
+    assert view.storage.commit_count == 0
+    assert view.storage.bind_count == 0
+
+
 @require_graphics_api(GraphicsAPIGroups.GL3)
 def test_camera_ubo_views_do_not_overwrite_stable_parent_range(test_window, monkeypatch):
     test_window.switch_to()

--- a/tests/integration/graphics/test_cameras.py
+++ b/tests/integration/graphics/test_cameras.py
@@ -290,6 +290,34 @@ def test_group_camera_viewport_is_applied_to_draw_context_stack(test_window, mon
     assert renderer.viewports[-1] == (30, 40, 160, 90)
 
 
+def test_draw_context_skips_unchanged_viewports(test_window, monkeypatch):
+    _set_default_view_storage(monkeypatch, RecordingStorage())
+    camera = pyglet.window.camera.Camera2D(test_window)
+    camera.viewport = (10, 20, 300, 200)
+    renderer = RecordingRenderer()
+    draw_context = DrawContext(
+        surface_ctx=test_window.context,
+        backend_ctx=None,
+        draw_pass=DrawPass(
+            framebuffer=None,
+            camera=camera,
+            viewport=camera.viewport,
+            scissor=None,
+            clear_color=(0.0, 0.0, 0.0, 1.0),
+        ),
+        renderer=renderer,
+    )
+
+    draw_context.apply_viewport()
+    draw_context.apply_viewport()
+    assert renderer.viewports == [(10, 20, 300, 200)]
+
+    camera.viewport = (30, 40, 160, 90)
+    draw_context.apply_viewport()
+    assert renderer.viewports[-1] == (30, 40, 160, 90)
+    assert len(renderer.viewports) == 2
+
+
 def test_group_camera_scissor_is_applied_once_on_scope_entry(test_window, monkeypatch):
     _set_default_view_storage(monkeypatch, RecordingStorage())
     camera = pyglet.window.camera.Camera2D(test_window)


### PR DESCRIPTION
* No longer scan the entire ubo_range list for any matches whenever a ubo is set to in use. Use a key lookup instead.
* Remove redundant scissor applications when utilizing camera scissor calls.
* Setting a groups visible status no longer triggers invalidate if the group is already set to the specific value.
* Keep track of currently applied viewport in the draw context to avoid redundant glViewport calls.
* Avoid setting camera/scissor calls when no geometry will be affected.
* Scissor now checks ancestors until it finds any attached scissor instead of fully walk it.