### PR TITLE
Add depth test support for text

### DIFF
--- a/pyglet/graphics/api/gl/text.py
+++ b/pyglet/graphics/api/gl/text.py
@@ -10,7 +10,7 @@ scrollable_layout_vertex_source = """#version 330 core
     in vec3 position;
     in vec4 colors;
     in vec3 tex_coords;
-    in vec3 translation;
+    in vec4 translation;
     in vec3 view_translation;
     in vec2 anchor;
     in float rotation;
@@ -44,8 +44,9 @@ scrollable_layout_vertex_source = """#version 330 core
 
         gl_Position = window.projection * window.view * m_translate * m_anchor * m_rotation * vec4(position + 
         view_translation + v_anchor, 1.0) * visible;
+        gl_Position.z -= translation.w * gl_Position.w;
 
-        vert_position = vec4(position + translation + view_translation + v_anchor, 1.0);
+        vert_position = vec4(position + translation.xyz + view_translation + v_anchor, 1.0);
         text_colors = colors;
         texture_coords = tex_coords.xy;
     }
@@ -56,7 +57,7 @@ layout_vertex_source = scrollable_layout_vertex_source.replace(
 ).replace(
     "position + \n        view_translation + v_anchor", "position + v_anchor",
 ).replace(
-    "position + translation + view_translation + v_anchor", "position + translation + v_anchor",
+    "position + translation.xyz + view_translation + v_anchor", "position + translation.xyz + v_anchor",
 )
 
 layout_fragment_source = """#version 330 core
@@ -73,6 +74,7 @@ layout_fragment_source = """#version 330 core
     void main()
     {
         final_colors = texture(text, texture_coords) * text_colors;
+        if (final_colors.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom
@@ -96,6 +98,7 @@ layout_fragment_image_source = """#version 330 core
     void main()
     {
         final_colors = texture(image_texture, texture_coords.xy);
+        if (final_colors.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom
@@ -107,7 +110,7 @@ layout_fragment_image_source = """#version 330 core
 decoration_vertex_source = """#version 330 core
     in vec3 position;
     in vec4 colors;
-    in vec3 translation;
+    in vec4 translation;
     in vec3 view_translation;
     in vec2 anchor;
     in float rotation;
@@ -140,8 +143,9 @@ decoration_vertex_source = """#version 330 core
 
         gl_Position = window.projection * window.view * m_translate * m_anchor * m_rotation * vec4(position + 
         view_translation + v_anchor, 1.0) * visible;
+        gl_Position.z -= translation.w * gl_Position.w;
 
-        vert_position = vec4(position + translation + view_translation + v_anchor, 1.0);
+        vert_position = vec4(position + translation.xyz + view_translation + v_anchor, 1.0);
         vert_colors = colors;
     }
 """
@@ -157,6 +161,7 @@ decoration_fragment_source = """#version 330 core
     void main()
     {
         final_colors = vert_colors;
+        if (final_colors.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom

--- a/pyglet/graphics/api/gl2/text.py
+++ b/pyglet/graphics/api/gl2/text.py
@@ -11,7 +11,7 @@ scrollable_layout_vertex_source = """#version 110
     attribute vec3 position;
     attribute vec4 colors;
     attribute vec3 tex_coords;
-    attribute vec3 translation;
+    attribute vec4 translation;
     attribute vec3 view_translation;
     attribute vec2 anchor;
     attribute float rotation;
@@ -42,8 +42,9 @@ scrollable_layout_vertex_source = """#version 110
 
         gl_Position = u_projection * u_view * m_translate * m_anchor * m_rotation * vec4(position + 
         view_translation + v_anchor, 1.0) * visible;
+        gl_Position.z -= translation.w * gl_Position.w;
 
-        vert_position = vec4(position + translation + view_translation + v_anchor, 1.0);
+        vert_position = vec4(position + translation.xyz + view_translation + v_anchor, 1.0);
         text_colors = colors;
         texture_coords = tex_coords.xy;
     }
@@ -54,7 +55,7 @@ layout_vertex_source = scrollable_layout_vertex_source.replace(
 ).replace(
     "position + \n        view_translation + v_anchor", "position + v_anchor",
 ).replace(
-    "position + translation + view_translation + v_anchor", "position + translation + v_anchor",
+    "position + translation.xyz + view_translation + v_anchor", "position + translation.xyz + v_anchor",
 )
 
 layout_fragment_source = """#version 110
@@ -69,6 +70,7 @@ layout_fragment_source = """#version 110
     void main()
     {
         gl_FragColor = vec4(text_colors.rgb, texture2D(text, texture_coords).a * text_colors.a);
+        if (gl_FragColor.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom
@@ -90,6 +92,7 @@ layout_fragment_image_source = """#version 110
     void main()
     {
         gl_FragColor = texture2D(image_texture, texture_coords.xy);
+        if (gl_FragColor.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom
@@ -101,7 +104,7 @@ layout_fragment_image_source = """#version 110
 decoration_vertex_source = """#version 110
     attribute vec3 position;
     attribute vec4 colors;
-    attribute vec3 translation;
+    attribute vec4 translation;
     attribute vec3 view_translation;
     attribute vec2 anchor;
     attribute float rotation;
@@ -131,8 +134,9 @@ decoration_vertex_source = """#version 110
 
         gl_Position = u_projection * u_view * m_translate * m_anchor * m_rotation * vec4(position + 
         view_translation + v_anchor, 1.0) * visible;
+        gl_Position.z -= translation.w * gl_Position.w;
 
-        vert_position = vec4(position + translation + view_translation + v_anchor, 1.0);
+        vert_position = vec4(position + translation.xyz + view_translation + v_anchor, 1.0);
         vert_colors = colors;
     }
 """
@@ -146,6 +150,7 @@ decoration_fragment_source = """#version 110
     void main()
     {
         gl_FragColor = vert_colors;
+        if (gl_FragColor.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom

--- a/pyglet/graphics/api/webgl/text.py
+++ b/pyglet/graphics/api/webgl/text.py
@@ -11,7 +11,7 @@ scrollable_layout_vertex_source = """#version 330 core
     in vec3 position;
     in vec4 colors;
     in vec3 tex_coords;
-    in vec3 translation;
+    in vec4 translation;
     in vec3 view_translation;
     in vec2 anchor;
     in float rotation;
@@ -45,8 +45,9 @@ scrollable_layout_vertex_source = """#version 330 core
 
         gl_Position = window.projection * window.view * m_translate * m_anchor * m_rotation * vec4(position + 
         view_translation + v_anchor, 1.0) * visible;
+        gl_Position.z -= translation.w * gl_Position.w;
 
-        vert_position = vec4(position + translation + view_translation + v_anchor, 1.0);
+        vert_position = vec4(position + translation.xyz + view_translation + v_anchor, 1.0);
         text_colors = colors;
         texture_coords = tex_coords.xy;
     }
@@ -57,7 +58,7 @@ layout_vertex_source = scrollable_layout_vertex_source.replace(
 ).replace(
     "position + \n        view_translation + v_anchor", "position + v_anchor",
 ).replace(
-    "position + translation + view_translation + v_anchor", "position + translation + v_anchor",
+    "position + translation.xyz + view_translation + v_anchor", "position + translation.xyz + v_anchor",
 )
 
 layout_fragment_source = """#version 330 core
@@ -74,6 +75,7 @@ layout_fragment_source = """#version 330 core
     void main()
     {
         final_colors = texture(text, texture_coords) * text_colors;
+        if (final_colors.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom
@@ -97,6 +99,7 @@ layout_fragment_image_source = """#version 330 core
     void main()
     {
         final_colors = texture(image_texture, texture_coords.xy);
+        if (final_colors.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom
@@ -108,7 +111,7 @@ layout_fragment_image_source = """#version 330 core
 decoration_vertex_source = """#version 330 core
     in vec3 position;
     in vec4 colors;
-    in vec3 translation;
+    in vec4 translation;
     in vec3 view_translation;
     in vec2 anchor;
     in float rotation;
@@ -141,8 +144,9 @@ decoration_vertex_source = """#version 330 core
 
         gl_Position = window.projection * window.view * m_translate * m_anchor * m_rotation * vec4(position + 
         view_translation + v_anchor, 1.0) * visible;
+        gl_Position.z -= translation.w * gl_Position.w;
 
-        vert_position = vec4(position + translation + view_translation + v_anchor, 1.0);
+        vert_position = vec4(position + translation.xyz + view_translation + v_anchor, 1.0);
         vert_colors = colors;
     }
 """
@@ -158,6 +162,7 @@ decoration_fragment_source = """#version 330 core
     void main()
     {
         final_colors = vert_colors;
+        if (final_colors.a < 0.01) discard;
         if (scissor == true) {
             if (vert_position.x < scissor_area[0]) discard;                     // left
             if (vert_position.y < scissor_area[1]) discard;                     // bottom

--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -246,6 +246,7 @@ class DocumentLabel(layout.TextLayout):
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
+            Added the *depth_sorting* parameter.
         """
         super().__init__(document, x, y, z, width, height, anchor_x, anchor_y, rotation,
                          multiline, dpi, batch, group, program, decoration_shader, effect_shader,
@@ -512,6 +513,7 @@ class Label(DocumentLabel):
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
+            Added the *depth_sorting* parameter.
         """
         doc = decode_text(text)
         if isinstance(color, LinearGradient):
@@ -625,6 +627,7 @@ class HTMLLabel(DocumentLabel):
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
+            Added the *depth_sorting* parameter.
         """
         self._text = text
         self._location = location

--- a/pyglet/text/__init__.py
+++ b/pyglet/text/__init__.py
@@ -202,6 +202,7 @@ class DocumentLabel(layout.TextLayout):
             decoration_shader: ShaderProgram | None = None, effect_shader: ShaderProgram | None = None,
             shaping: bool = True,
             init_document: bool = True,
+            depth_sorting: bool = False,
     ) -> None:
         """Create a label for a given document.
 
@@ -239,13 +240,16 @@ class DocumentLabel(layout.TextLayout):
                 If ``True``, the document will be initialized. If you
                 are passing an already-initialized document, then you can
                 avoid duplicating work by setting this to ``False``.
+            depth_sorting:
+                Whether to enable depth testing and depth-safe ordering of the
+                label's background, effects, glyphs, and decorations.
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
         """
         super().__init__(document, x, y, z, width, height, anchor_x, anchor_y, rotation,
                          multiline, dpi, batch, group, program, decoration_shader, effect_shader,
-                         shaping=shaping, init_document=init_document)
+                         shaping=shaping, init_document=init_document, depth_sorting=depth_sorting)
 
     @property
     def text(self) -> str:
@@ -431,6 +435,7 @@ class Label(DocumentLabel):
             program: ShaderProgram | None = None,
             decoration_shader: ShaderProgram | None = None, effect_shader: ShaderProgram | None = None,
             shaping: bool = True,
+            depth_sorting: bool = False,
     ) -> None:
         """Create a plain text label.
 
@@ -501,6 +506,9 @@ class Label(DocumentLabel):
             shaping:
                 Whether this label should use text shaping. The shaping backend is selected globally with
                 ``pyglet.options.text_shaping``. If ``False``, glyph positions are based on their unshaped metrics.
+            depth_sorting:
+                Whether to enable depth testing and depth-safe ordering of the
+                label's background, effects, glyphs, and decorations.
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
@@ -545,6 +553,7 @@ class Label(DocumentLabel):
             effect_shader,
             shaping=shaping,
             init_document=True,
+            depth_sorting=depth_sorting,
         )
 
 
@@ -563,7 +572,7 @@ class HTMLLabel(DocumentLabel):
                  batch: Batch | None = None, group: Group | None = None,
                  program: ShaderProgram | None = None,
                  decoration_shader: ShaderProgram | None = None, effect_shader: ShaderProgram | None = None,
-                 shaping: bool = True) -> None:
+                 shaping: bool = True, depth_sorting: bool = False) -> None:
         """Create a label with an HTML string.
 
         Args:
@@ -610,6 +619,9 @@ class HTMLLabel(DocumentLabel):
             shaping:
                 Whether this label should use text shaping. The shaping backend is selected globally with
                 ``pyglet.options.text_shaping``. If ``False``, glyph positions are based on their unshaped metrics.
+            depth_sorting:
+                Whether to enable depth testing and depth-safe ordering of the
+                label's background, effects, glyphs, and decorations.
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
@@ -619,7 +631,7 @@ class HTMLLabel(DocumentLabel):
         doc = decode_html(text, location)
         super().__init__(doc, x, y, z, width, height, anchor_x, anchor_y, rotation,
                          multiline, dpi, batch, group, program, decoration_shader, effect_shader,
-                         shaping=shaping, init_document=True)
+                         shaping=shaping, init_document=True, depth_sorting=depth_sorting)
 
     @property
     def text(self) -> str:

--- a/pyglet/text/formats/structured.py
+++ b/pyglet/text/formats/structured.py
@@ -46,7 +46,8 @@ class ImageElement(pyglet.text.document.InlineElement):
     def place(self, layout: TextLayout, x: float, y: float, z: float, line_x: float, line_y: float, rotation: float,
               visible: bool, anchor_x: float, anchor_y: float) -> None:
         program = pyglet.text.layout.get_default_image_layout_shader()
-        group = _InlineElementGroup(self.image.get_texture(), program, 0, layout.group)
+        group = _InlineElementGroup(self.image.get_texture(), program, 3 if layout.depth_sorting else 0, layout.group)
+        layout._set_depth_test(group)  # noqa: SLF001
         x1 = line_x
         y1 = line_y + self.descent
         x2 = line_x + self.width
@@ -55,7 +56,7 @@ class ImageElement(pyglet.text.document.InlineElement):
         vertex_list = program.vertex_list_indexed(4, GeometryMode.TRIANGLES, [0, 1, 2, 0, 2, 3],
                                                   layout.batch, group,
                                                   position=(x1, y1, z, x2, y1, z, x2, y2, z, x1, y2, z),
-                                                  translation=(x, y, z) * 4,
+                                                  translation=(x, y, z, layout.get_depth_offset(0)) * 4,
                                                   tex_coords=self.image.tex_coords,
                                                   visible=(visible,) * 4,
                                                   rotation=(rotation,) * 4,
@@ -67,9 +68,9 @@ class ImageElement(pyglet.text.document.InlineElement):
         self.vertex_lists[layout] = vertex_list
 
     def update_translation(self, x: float, y: float, z: float) -> None:
-        translation = (x, y, z)
         for _vertex_list in self.vertex_lists.values():
-            _vertex_list.translation[:] = translation * _vertex_list.count
+            depth_offset = _vertex_list.translation[3]
+            _vertex_list.translation[:] = (x, y, z, depth_offset) * _vertex_list.count
 
     def update_color(self, color: list[int]) -> None:
         # No color blending in shader. Optional.
@@ -119,7 +120,7 @@ class HorizontalRuleElement(pyglet.text.document.InlineElement):
             layout.batch,
             layout.foreground_decoration_group,
             position=(line_x, line_y, z, right, line_y, z),
-            translation=(x, y, z) * 2,
+            translation=(x, y, z, layout.get_depth_offset(1)) * 2,
             colors=self.color * 2,
             visible=(visible,) * 2,
             rotation=(rotation,) * 2,
@@ -128,9 +129,9 @@ class HorizontalRuleElement(pyglet.text.document.InlineElement):
         self.vertex_lists[layout] = vertex_list
 
     def update_translation(self, x: float, y: float, z: float) -> None:
-        translation = (x, y, z)
         for vertex_list in self.vertex_lists.values():
-            vertex_list.translation[:] = translation * vertex_list.count
+            depth_offset = vertex_list.translation[3]
+            vertex_list.translation[:] = (x, y, z, depth_offset) * vertex_list.count
 
     def update_color(self, color: list[int]) -> None:
         self.color = tuple(color[:4])

--- a/pyglet/text/layout/base.py
+++ b/pyglet/text/layout/base.py
@@ -227,6 +227,9 @@ class TextLayout(_FlowLayoutBase):
     #: Clip-space depth distance between text layers when ``depth_sorting`` is enabled.
     _depth_layer_offset: ClassVar[float] = 1e-5
 
+    #: Depth comparison used when ``depth_sorting`` is enabled.
+    depth_test_compare_op: ClassVar[CompareOp] = CompareOp.LESS
+
     def __init__(
         self,
         document: AbstractDocument,
@@ -307,12 +310,11 @@ class TextLayout(_FlowLayoutBase):
                 If True, enable depth testing and preserve the text layer order
                 using small clip-space depth offsets. This keeps backgrounds,
                 shadows, strokes, glyphs, and decorations reliably ordered when
-                multiple labels overlap. Custom shaders must provide a
-                ``vec4 translation`` vertex attribute and apply its ``w`` component to
-                ``gl_Position.z`` after projection.
+                multiple labels overlap.
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
+            Added the *depth_sorting* parameter.
         """
         self._x = x
         self._y = y
@@ -381,7 +383,7 @@ class TextLayout(_FlowLayoutBase):
 
     def _set_depth_test(self, group: Group) -> None:
         if self._depth_sorting:
-            group.set_depth_test(CompareOp.LESS)
+            group.set_depth_test(self.depth_test_compare_op)
 
     def get_depth_offset(self, layer: int) -> float:
         """Return the clip-space depth offset for a text rendering layer."""

--- a/pyglet/text/layout/base.py
+++ b/pyglet/text/layout/base.py
@@ -10,7 +10,7 @@ from typing import (
 import pyglet
 
 from pyglet import graphics
-from pyglet.enums import BlendFactor, GraphicsAPI
+from pyglet.enums import BlendFactor, CompareOp, GraphicsAPI
 from pyglet.graphics import Group, ShaderProgram
 from pyglet.text.effects import LinearGradient
 from pyglet.text.layout.boxes import (
@@ -224,6 +224,9 @@ class TextLayout(_FlowLayoutBase):
     _multiline: bool = False
     _visible: bool = True
 
+    #: Clip-space depth distance between text layers when ``depth_sorting`` is enabled.
+    _depth_layer_offset: ClassVar[float] = 1e-5
+
     def __init__(
         self,
         document: AbstractDocument,
@@ -245,6 +248,7 @@ class TextLayout(_FlowLayoutBase):
         wrap_lines: bool = True,
         shaping: bool = True,
         init_document: bool = True,
+        depth_sorting: bool = False,
     ) -> None:
         """Create a text layout.
 
@@ -299,6 +303,13 @@ class TextLayout(_FlowLayoutBase):
             init_document:
                 If True the document will be initialized. If subclassing then
                 you may want to avoid duplicate initializations by changing to False.
+            depth_sorting:
+                If True, enable depth testing and preserve the text layer order
+                using small clip-space depth offsets. This keeps backgrounds,
+                shadows, strokes, glyphs, and decorations reliably ordered when
+                multiple labels overlap. Custom shaders must provide a
+                ``vec4 translation`` vertex attribute and apply its ``w`` component to
+                ``gl_Position.z`` after projection.
 
         .. versionchanged:: 3.0
             Added the *shaping* parameter.
@@ -314,6 +325,7 @@ class TextLayout(_FlowLayoutBase):
         self._multiline = multiline
         self._dpi = dpi or 96
         self._shaping = shaping
+        self._depth_sorting = depth_sorting
 
         self._content_width = 0
         self._content_height = 0
@@ -357,13 +369,23 @@ class TextLayout(_FlowLayoutBase):
         self._foreground_decoration_group = None
         self.effect_group_cache = {}
 
-    def get_effect_group(self, texture: Texture) -> TextLayoutGroup:
+    def get_effect_group(self, texture: Texture, order: int = 0) -> TextLayoutGroup:
+        cache_key = texture, order
         try:
-            return self.effect_group_cache[texture]
+            return self.effect_group_cache[cache_key]
         except KeyError:
-            group = self.effect_group_class(texture, self.effect_shader, order=0, parent=self._user_group)
-            self.effect_group_cache[texture] = group
+            group = self.effect_group_class(texture, self.effect_shader, order=order, parent=self._user_group)
+            self._set_depth_test(group)
+            self.effect_group_cache[cache_key] = group
             return group
+
+    def _set_depth_test(self, group: Group) -> None:
+        if self._depth_sorting:
+            group.set_depth_test(CompareOp.LESS)
+
+    def get_depth_offset(self, layer: int) -> float:
+        """Return the clip-space depth offset for a text rendering layer."""
+        return layer * self._depth_layer_offset if self._depth_sorting else 0.0
 
     @property
     def background_decoration_group(self) -> TextDecorationGroup:
@@ -373,6 +395,7 @@ class TextLayout(_FlowLayoutBase):
                 order=0,
                 parent=self._user_group,
             )
+            self._set_depth_test(self._background_decoration_group)
         return self._background_decoration_group
 
     @background_decoration_group.setter
@@ -384,9 +407,10 @@ class TextLayout(_FlowLayoutBase):
         if self._foreground_decoration_group is None:
             self._foreground_decoration_group = self.decoration_class(
                 self.decoration_shader,
-                order=2,
+                order=4 if self._depth_sorting else 2,
                 parent=self._user_group,
             )
+            self._set_depth_test(self._foreground_decoration_group)
         return self._foreground_decoration_group
 
     @foreground_decoration_group.setter
@@ -441,6 +465,21 @@ class TextLayout(_FlowLayoutBase):
             return
         self._effect_shader = shader
         self.effect_group_cache.clear()
+        self._update()
+
+    @property
+    def depth_sorting(self) -> bool:
+        """Whether this layout uses depth testing and depth-safe text layers."""
+        return self._depth_sorting
+
+    @depth_sorting.setter
+    def depth_sorting(self, enabled: bool) -> None:
+        enabled = bool(enabled)
+        if self._depth_sorting == enabled:
+            return
+        self._depth_sorting = enabled
+        self._initialize_groups()
+        self.group_cache.clear()
         self._update()
 
     @property

--- a/pyglet/text/layout/boxes.py
+++ b/pyglet/text/layout/boxes.py
@@ -737,6 +737,7 @@ class _GlyphBox(_AbstractBox):
             return
 
         if geometry.background.vertices:
+            bg_layer = layout.get_depth_offset(_BACKGROUND_DEPTH_LAYER)
             bg_count = len(geometry.background.vertices) // 3
             # Needs this split for text highlighting in incremental layer.
             background_indices = [
@@ -752,7 +753,7 @@ class _GlyphBox(_AbstractBox):
                 layout.batch,
                 layout.background_decoration_group,
                 position=geometry.background.vertices,
-                translation=(*translation, layout.get_depth_offset(_BACKGROUND_DEPTH_LAYER)) * bg_count,
+                translation=(*translation, bg_layer) * bg_count,
                 view_translation=(0, 0, 0) * bg_count,
                 colors=geometry.background.colors,
                 rotation=(rotation,) * bg_count,
@@ -761,6 +762,7 @@ class _GlyphBox(_AbstractBox):
             )
             self._add_vertex_list(background_list, context)
 
+        fg_layer = layout.get_depth_offset(_FOREGROUND_DECORATION_DEPTH_LAYER)
         if geometry.underline.vertices:
             ul_count = len(geometry.underline.vertices) // 3
             decoration_program = layout.decoration_shader
@@ -770,7 +772,7 @@ class _GlyphBox(_AbstractBox):
                 layout.batch,
                 layout.foreground_decoration_group,
                 position=geometry.underline.vertices,
-                translation=(*translation, layout.get_depth_offset(_FOREGROUND_DECORATION_DEPTH_LAYER)) * ul_count,
+                translation=(*translation, fg_layer) * ul_count,
                 view_translation=(0, 0, 0) * ul_count,
                 colors=geometry.underline.colors,
                 rotation=(rotation,) * ul_count,
@@ -788,7 +790,7 @@ class _GlyphBox(_AbstractBox):
                 layout.batch,
                 layout.foreground_decoration_group,
                 position=geometry.strikethrough.vertices,
-                translation=(*translation, layout.get_depth_offset(_FOREGROUND_DECORATION_DEPTH_LAYER)) * st_count,
+                translation=(*translation, fg_layer) * st_count,
                 view_translation=(0, 0, 0) * st_count,
                 colors=geometry.strikethrough.colors,
                 rotation=(rotation,) * st_count,

--- a/pyglet/text/layout/boxes.py
+++ b/pyglet/text/layout/boxes.py
@@ -14,6 +14,12 @@ from pyglet.text.effects import LinearGradient
 
 _VertexData = dict[str, Sequence[float | int | bool]]
 
+_BACKGROUND_DEPTH_LAYER = -3
+_SHADOW_DEPTH_LAYER = -2
+_STROKE_DEPTH_LAYER = -1
+_GLYPH_DEPTH_LAYER = 0
+_FOREGROUND_DECORATION_DEPTH_LAYER = 1
+
 
 class _DecorationData(NamedTuple):
     vertices: list[float]
@@ -414,7 +420,7 @@ class _GlyphBox(_AbstractBox):
     ) -> _VertexData:
         vertex_data: _VertexData = {
             "position": vertices,
-            "translation": translation * vertex_count,
+            "translation": (*translation, layout.get_depth_offset(_GLYPH_DEPTH_LAYER)) * vertex_count,
             "colors": colors,
             "tex_coords": tex_coords,
             "rotation": (rotation,) * vertex_count,
@@ -424,6 +430,16 @@ class _GlyphBox(_AbstractBox):
         if "view_translation" in layout.program.attributes:
             vertex_data["view_translation"] = (0, 0, 0) * vertex_count
         return vertex_data
+
+    @staticmethod
+    def _set_depth_layer(
+        layout: TextLayout,
+        vertex_data: _VertexData,
+        vertex_count: int,
+        layer: int,
+    ) -> _VertexData:
+        translation = vertex_data["translation"]
+        return vertex_data | {"translation": (*translation[:3], layout.get_depth_offset(layer)) * vertex_count}
 
     def _place_shadow(
         self,
@@ -465,13 +481,18 @@ class _GlyphBox(_AbstractBox):
             return
 
         assert shadow_vertices is not None
-        shadow_data = vertex_data | {"position": shadow_vertices, "colors": shadow_colors}
+        shadow_data = self._set_depth_layer(
+            layout,
+            vertex_data | {"position": shadow_vertices, "colors": shadow_colors},
+            self.length * 4,
+            _SHADOW_DEPTH_LAYER,
+        )
         shadow_list = layout.program.vertex_list_indexed(
             self.length * 4,
             GeometryMode.TRIANGLES,
             indices,
             layout.batch,
-            layout.get_effect_group(self.owner),
+            layout.get_effect_group(self.owner, order=1 if layout.depth_sorting else 0),
             **shadow_data,
         )
         self._add_vertex_list(shadow_list, context)
@@ -558,12 +579,18 @@ class _GlyphBox(_AbstractBox):
                         anchor_y,
                         4,
                     )
+                    stroke_data = self._set_depth_layer(
+                        layout,
+                        stroke_data,
+                        4,
+                        _STROKE_DEPTH_LAYER,
+                    )
                     stroke_list = layout.program.vertex_list_indexed(
                         4,
                         GeometryMode.TRIANGLES,
                         (0, 1, 2, 0, 2, 3),
                         layout.batch,
-                        layout.get_effect_group(stroke_glyph.owner),
+                        layout.get_effect_group(stroke_glyph.owner, order=2 if layout.depth_sorting else 0),
                         **stroke_data,
                     )
                     self._add_vertex_list(stroke_list, context)
@@ -725,7 +752,7 @@ class _GlyphBox(_AbstractBox):
                 layout.batch,
                 layout.background_decoration_group,
                 position=geometry.background.vertices,
-                translation=translation * bg_count,
+                translation=(*translation, layout.get_depth_offset(_BACKGROUND_DEPTH_LAYER)) * bg_count,
                 view_translation=(0, 0, 0) * bg_count,
                 colors=geometry.background.colors,
                 rotation=(rotation,) * bg_count,
@@ -743,7 +770,7 @@ class _GlyphBox(_AbstractBox):
                 layout.batch,
                 layout.foreground_decoration_group,
                 position=geometry.underline.vertices,
-                translation=translation * ul_count,
+                translation=(*translation, layout.get_depth_offset(_FOREGROUND_DECORATION_DEPTH_LAYER)) * ul_count,
                 view_translation=(0, 0, 0) * ul_count,
                 colors=geometry.underline.colors,
                 rotation=(rotation,) * ul_count,
@@ -761,7 +788,7 @@ class _GlyphBox(_AbstractBox):
                 layout.batch,
                 layout.foreground_decoration_group,
                 position=geometry.strikethrough.vertices,
-                translation=translation * st_count,
+                translation=(*translation, layout.get_depth_offset(_FOREGROUND_DECORATION_DEPTH_LAYER)) * st_count,
                 view_translation=(0, 0, 0) * st_count,
                 colors=geometry.strikethrough.colors,
                 rotation=(rotation,) * st_count,
@@ -792,7 +819,8 @@ class _GlyphBox(_AbstractBox):
         try:
             group = layout.group_cache[self.owner]
         except KeyError:
-            group = layout.group_class(self.owner, layout.program, order=1, parent=layout.group)
+            group = layout.group_class(self.owner, layout.program, order=3 if layout.depth_sorting else 1, parent=layout.group)
+            layout._set_depth_test(group)  # noqa: SLF001
             layout.group_cache[self.owner] = group
 
         vertices, tex_coords, baseline = self._create_glyph_geometry(layout, i, line_x, line_y, context)
@@ -854,9 +882,9 @@ class _GlyphBox(_AbstractBox):
         )
 
     def update_translation(self, x: float, y: float, z: float) -> None:
-        translation = (x, y, z)
         for _vertex_list in self.vertex_lists:
-            _vertex_list.translation[:] = translation * _vertex_list.count
+            depth_offset = _vertex_list.translation[3]
+            _vertex_list.translation[:] = (x, y, z, depth_offset) * _vertex_list.count
 
     def update_colors(self, colors: list[int], start: int, end: int) -> None:
         """Update the glyph colors only when specified by a single color attribute in set_style.

--- a/pyglet/text/layout/incremental.py
+++ b/pyglet/text/layout/incremental.py
@@ -129,7 +129,8 @@ class IncrementalTextLayout(TextLayout, EventDispatcher):
                  anchor_x: AnchorX = 'left', anchor_y: AnchorY = 'bottom', rotation: float = 0, multiline: bool = False,
                  dpi: float | None = None, batch: Batch | None = None, group: Group | None = None,
                  program: ShaderProgram | None = None, decoration_shader: ShaderProgram | None = None,
-                 effect_shader: ShaderProgram | None = None, wrap_lines: bool = True) -> None:
+                 effect_shader: ShaderProgram | None = None, wrap_lines: bool = True,
+                 depth_sorting: bool = False) -> None:
 
         if width is None or height is None:
             msg = "Invalid size. IncrementalTextLayout width or height cannot be None."
@@ -156,7 +157,7 @@ class IncrementalTextLayout(TextLayout, EventDispatcher):
 
         super().__init__(document, x, y, z, width, height, anchor_x, anchor_y, rotation, multiline, dpi, batch, group,
                          program or get_default_scrollable_layout_shader(), decoration_shader, effect_shader,
-                         wrap_lines=wrap_lines)
+                         wrap_lines=wrap_lines, depth_sorting=depth_sorting)
 
     def _update_scissor_area(self) -> None:
         area = (self.left, self.bottom, self._width, self._height)

--- a/pyglet/text/layout/scrolling.py
+++ b/pyglet/text/layout/scrolling.py
@@ -47,7 +47,8 @@ class ScrollableTextLayout(TextLayout):
                  anchor_x: AnchorX = 'left', anchor_y: AnchorY = 'bottom', rotation: float = 0, multiline: bool = False,
                  dpi: float | None = None, batch: Batch | None = None, group: Group | None = None,
                  program: ShaderProgram | None = None, decoration_shader: ShaderProgram | None = None,
-                 effect_shader: ShaderProgram | None = None, wrap_lines: bool = True) -> None:
+                 effect_shader: ShaderProgram | None = None, wrap_lines: bool = True,
+                 depth_sorting: bool = False) -> None:
 
         if width is None or height is None:
             msg = "Invalid size. ScrollableTextLayout width or height cannot be None."
@@ -55,7 +56,7 @@ class ScrollableTextLayout(TextLayout):
 
         super().__init__(document, x, y, z, width, height, anchor_x, anchor_y, rotation, multiline, dpi, batch, group,
                          program or get_default_scrollable_layout_shader(), decoration_shader, effect_shader,
-                         wrap_lines=wrap_lines)
+                         wrap_lines=wrap_lines, depth_sorting=depth_sorting)
 
     def _update_scissor_area(self) -> None:
         if not self.document.text:


### PR DESCRIPTION
Follow up to #1387 and #1302.

This adds an option to enable depth testing for Labels. With the introduction of text effects it has become increasingly difficult for users to manage the various layers of the label themselves. From background, to foreground, the glyph, and now the effect layer. Having to keep track of the different layers can be a hassle, and difficult to override without manually editing pyglet's code.

This changes translation to vec4 and uses the last slot for the depth offset for each layer. This way it helps maintain the depth range people set. There are a couple classvars for tweaking in extreme situations:
`TextLayout. _depth_layer_offset` and `depth_test_compare_op`, by default the compare operation is `CompareOp.LESS`.