### PR TITLE
Update shapes

### DIFF
--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -2449,6 +2449,29 @@ class Triangle(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
+    def points(self) -> list[tuple[float, float]]:
+        """Get/set the three vertices of the triangle."""
+        return [(self._x, self._y), (self._x2, self._y2), (self._x3, self._y3)]
+
+    @points.setter
+    def points(self, value: Sequence[Sequence[float]]) -> None:
+        if len(value) != 3:
+            raise ValueError("Triangle requires exactly three points")
+        self._x, self._y = value[0]
+        self._x2, self._y2 = value[1]
+        self._x3, self._y3 = value[2]
+        self._update_vertices()
+        self._update_translation()
+
+    def __getitem__(self, index: int) -> tuple[float, float]:
+        return self.points[index]
+
+    def __setitem__(self, index: int, point: Sequence[float]) -> None:
+        points = self.points
+        points[index] = tuple(point)
+        self.points = points
+
+    @property
     def x2(self) -> float:
         """Get/set the X coordinate of the triangle's 2nd vertex."""
         return self._x2

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -230,9 +230,9 @@ class _ShapeGroup(Group):
 
         Args:
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``GL_ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             program:
                 The ShaderProgram to use.
             parent:
@@ -286,9 +286,9 @@ class ShapeBase(ABC):
             vertex_count:
                 The amount of vertices this Shape object has.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch object.
             group:
@@ -651,7 +651,7 @@ class ShapeBase(ABC):
 
         Opacity is implemented as the alpha component of a shape's
         :py:attr:`.color`. When part of a group with a default blend
-        mode of ``(GL_SRC_ALPHA, ONE_MINUS_SRC_ALPHA)``, opacities
+        mode of ``(BlendFactor.SRC_ALPHA, BlendFactor.ONE_MINUS_SRC_ALPHA)``, opacities
         below ``255`` draw with fractional opacity over the background:
 
         .. list-table:: Example Values & Effects
@@ -787,9 +787,9 @@ class Arc(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -945,8 +945,9 @@ class BezierCurve(ShapeBase):
 
         Args:
             points:
-                Control points of the curve. Points can be specified as multiple
-                lists or tuples of point pairs. Ex. (0,0), (2,3), (1,9)
+                Control points of the curve. Supply point pairs as separate
+                positional arguments, for example ``(0, 0), (2, 3), (1, 9)``,
+                or supply one sequence of point pairs.
             t:
                 Draw `100*t` percent of the curve. 0.5 means the curve
                 is half drawn and 1.0 means draw the whole curve.
@@ -960,9 +961,9 @@ class BezierCurve(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -1104,9 +1105,9 @@ class Circle(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -1214,9 +1215,9 @@ class Ellipse(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -1349,9 +1350,9 @@ class Sector(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -1500,9 +1501,9 @@ class Line(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -1641,9 +1642,9 @@ class Rectangle(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -1759,9 +1760,9 @@ class BorderedRectangle(ShapeBase):
                 as a tuple of 3 or 4 ints in the range of 0-255. RGB
                 colors will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -1973,9 +1974,9 @@ class Box(ShapeBase):
                 of 3 or 4 ints in the range of 0-255. RGB colors will
                 be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -2130,9 +2131,9 @@ class RoundedRectangle(pyglet.shapes.ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -2310,9 +2311,9 @@ class Triangle(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -2444,9 +2445,9 @@ class Star(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -2565,17 +2566,17 @@ class Polygon(ShapeBase):
 
         Args:
             coordinates:
-                The coordinates for each point in the polygon. Each one
-                must be able to unpack to a pair of float-like X and Y
-                values.
+                Point pairs for the polygon. Supply them as separate positional
+                arguments or as one sequence of point pairs. Every point must
+                unpack to float-like X and Y values.
             color:
                 The RGB or RGBA color of the polygon, specified as a
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:
@@ -2662,9 +2663,9 @@ class MultiLine(ShapeBase):
                 tuple of 3 or 4 ints in the range of 0-255. RGB colors
                 will be treated as having an opacity of 255.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the shape to.
             group:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -1603,6 +1603,31 @@ class Line(ShapeBase):
         self._vertex_list.position[:] = self._get_vertices()
 
     @property
+    def points(self) -> list[tuple[float, float]]:
+        """Get/set the two endpoints of the line.
+
+        .. versionadded:: 3.0
+        """
+        return [(self._x, self._y), (self._x2, self._y2)]
+
+    @points.setter
+    def points(self, value: Sequence[Sequence[float]]) -> None:
+        if len(value) != 2:
+            raise ValueError("Line requires exactly two points")
+        self._x, self._y = value[0]
+        self._x2, self._y2 = value[1]
+        self._update_vertices()
+        self._update_translation()
+
+    def __getitem__(self, index: int) -> tuple[float, float]:
+        return self.points[index]
+
+    def __setitem__(self, idx: int, point: Sequence[float]) -> None:
+        points = self.points
+        points[idx] = tuple(point)
+        self.points = points
+
+    @property
     def thickness(self) -> float:
         """The thickness of the line."""
         return self._thickness
@@ -2828,6 +2853,35 @@ class MultiLine(ShapeBase):
 
     def _update_vertices(self) -> None:
         self._vertex_list.position[:] = self._get_vertices()
+
+    @property
+    def points(self) -> list[tuple[float, float]]:
+        """Get/set the points that make up the multi-line.
+
+        .. versionadded:: 3.0
+        """
+        count = len(self._coordinates) - 1 if self._closed else len(self._coordinates)
+        return list(self._coordinates[:count])
+
+    @points.setter
+    def points(self, value: Sequence[Sequence[float]]) -> None:
+        coordinates = [tuple(point) for point in value]
+        if not coordinates:
+            raise ValueError("MultiLine requires at least one point")
+        if self._closed:
+            coordinates.append(coordinates[0])
+        self._coordinates = coordinates
+        self._x, self._y = coordinates[0]
+        self._update_vertices()
+        self._update_translation()
+
+    def __getitem__(self, index: int) -> tuple[float, float]:
+        return self.points[index]
+
+    def __setitem__(self, index: int, point: Sequence[float]) -> None:
+        points = self.points
+        points[index] = tuple(point)
+        self.points = points
 
     @property
     def thickness(self) -> float:

--- a/pyglet/shapes.py
+++ b/pyglet/shapes.py
@@ -88,8 +88,8 @@ elif pyglet.options.backend in (GraphicsAPI.OPENGL_2, GraphicsAPI.OPENGL_ES_2):
     from pyglet.graphics.api.gl2.shapes import get_default_shader
 elif pyglet.options.backend == GraphicsAPI.WEBGL:
     from pyglet.graphics.api.webgl.shapes import get_default_shader
-elif pyglet.options.backend == GraphicsAPI.VULKAN:
-    from pyglet.graphics.api.vulkan.shapes import get_default_shader
+# elif pyglet.options.backend == GraphicsAPI.VULKAN:
+#     from pyglet.graphics.api.vulkan.shapes import get_default_shader
 
 
 def _rotate_point(center: tuple[float, float], point: tuple[float, float], angle: float) -> tuple[float, float]:
@@ -121,6 +121,41 @@ def _point_in_polygon(polygon: Sequence[tuple[float, float]], point: tuple[float
             odd = not odd
         j = i
     return odd
+
+
+def _angle_in_sweep(angle: float, start_angle: float, sweep: float) -> bool:
+    """Return whether ``angle`` is covered by a clockwise or counter-clockwise sweep."""
+    if abs(sweep) >= 360:
+        return True
+
+    angle %= 360
+    start_angle %= 360
+    end_angle = (start_angle + sweep) % 360
+    if sweep >= 0:
+        return start_angle <= angle <= end_angle if start_angle <= end_angle else angle >= start_angle or angle <= end_angle
+    return end_angle <= angle <= start_angle if end_angle <= start_angle else angle >= end_angle or angle <= start_angle
+
+
+def _point_on_segment(point: tuple[float, float], start: tuple[float, float], end: tuple[float, float],
+                      thickness: float) -> bool:
+    """Return whether a point is within ``thickness / 2`` of a line segment."""
+    dx = end[0] - start[0]
+    dy = end[1] - start[1]
+    length_squared = dx * dx + dy * dy
+    if length_squared == 0:
+        return math.dist(point, start) <= thickness / 2
+
+    t = max(0.0, min(1.0, ((point[0] - start[0]) * dx + (point[1] - start[1]) * dy) / length_squared))
+    nearest = start[0] + t * dx, start[1] + t * dy
+    return math.dist(point, nearest) <= thickness / 2
+
+
+def _normalise_coordinates(coordinates: Sequence[Sequence[float]]) -> list[tuple[float, float]]:
+    """Accept individual point pairs or a single sequence of point pairs."""
+    if len(coordinates) == 1 and all(
+            isinstance(point, Sequence) and len(point) == 2 for point in coordinates[0]):
+        coordinates = coordinates[0]  # type: ignore[assignment]
+    return [tuple(point) for point in coordinates]  # type: ignore[misc]
 
 
 def _get_segment(p0: tuple[float, float] | list[float], p1: tuple[float, float] | list[float],
@@ -810,8 +845,8 @@ class Arc(ShapeBase):
         self._thickness = thickness
         self._angle = angle
         self._start_angle = start_angle
-        # Only set closed if the angle isn't tau
-        self._closed = closed if abs(math.tau - self._angle) > 1e-9 else False
+        # A complete circle already joins its endpoints.
+        self._closed = closed if abs(360.0 - self._angle) > 1e-9 else False
         self._rotation = 0
 
         super().__init__(
@@ -819,6 +854,12 @@ class Arc(ShapeBase):
             self._segments * 6 + (6 if self._closed else 0),
             blend_src, blend_dest, batch, group, program,
         )
+
+    def __contains__(self, point: tuple[float, float]) -> bool:
+        # Arc containment deliberately uses a fast circular approximation, not its exact stroke geometry.
+        assert len(point) == 2
+        center = self._x - self._anchor_x, self._y - self._anchor_y
+        return math.dist(center, point) < self._radius
 
     def _create_vertex_list(self) -> None:
         self._vertex_list = self._program.vertex_list(
@@ -837,7 +878,7 @@ class Arc(ShapeBase):
         y = -self._anchor_y
         r = self._radius
         segment_radians = math.radians(self._angle) / self._segments
-        start_radians = math.radians(self._start_angle - self._rotation)
+        start_radians = math.radians(self._start_angle)
 
         # Calculate the outer points of the arc:
         points = [(x + (r * math.cos((i * segment_radians) + start_radians)),
@@ -854,14 +895,14 @@ class Arc(ShapeBase):
                 prev_point = points[i - 1]
             elif self._closed:
                 prev_point = points[-1]
-            elif abs(self._angle - math.tau) <= 1e-9:
+            elif abs(self._angle - 360.0) <= 1e-9:
                 prev_point = points[-2]
 
             if i + 2 < len(points):
                 next_point = points[i + 2]
             elif self._closed:
                 next_point = points[0]
-            elif abs(self._angle - math.tau) <= 1e-9:
+            elif abs(self._angle - 360.0) <= 1e-9:
                 next_point = points[1]
 
             prev_miter, prev_scale, *segment = _get_segment(prev_point, points[i], points[i + 1], next_point,
@@ -971,7 +1012,7 @@ class BezierCurve(ShapeBase):
             program:
                 Optional shader program of the shape.
         """
-        self._points = list(points)
+        self._points = _normalise_coordinates(points)
         self._x, self._y = self._points[0]
         self._t = t
         self._segments = segments
@@ -1385,18 +1426,7 @@ class Sector(ShapeBase):
             return False
         angle = math.degrees(math.atan2(point[1] - self._y + self._anchor_y, point[0] - self._x + self._anchor_x))
         angle = angle % 360
-        start_angle = self._start_angle % 360
-        end_angle = (start_angle + self._angle) % 360
-        if self._angle >= 0:
-            if start_angle <= end_angle:
-                return start_angle <= angle <= end_angle
-            else:
-                return angle >= start_angle or angle <= end_angle
-        else:
-            if end_angle <= start_angle:
-                return end_angle <= angle <= start_angle
-            else:
-                return angle >= end_angle or angle <= start_angle
+        return _angle_in_sweep(angle, self._start_angle, self._angle)
 
     def _create_vertex_list(self) -> None:
         self._vertex_list = self._program.vertex_list(
@@ -1527,20 +1557,13 @@ class Line(ShapeBase):
 
     def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
-        vec_ab = Vec2(self._x2 - self._x, self._y2 - self._y)
-        vec_ba = Vec2(self._x - self._x2, self._y - self._y2)
-        vec_ap = Vec2(point[0] - self._x - self._anchor_x, point[1] - self._y + self._anchor_y)
-        vec_bp = Vec2(point[0] - self._x2 - self._anchor_x, point[1] - self._y2 + self._anchor_y)
-        if vec_ab.dot(vec_ap) * vec_ba.dot(vec_bp) < 0:
-            return False
-
-        a, b = point[0] + self._anchor_x, point[1] - self._anchor_y
-        x1, y1, x2, y2 = self._x, self._y, self._x2, self._y2
-        # The following is the expansion of the determinant of a 3x3 matrix
-        # used to calculate the area of a triangle.
-        double_area = abs(a * y1 + b * x2 + x1 * y2 - x2 * y1 - a * y2 - b * x1)
-        h = double_area / math.dist((self._x, self._y), (self._x2, self._y2))
-        return h < self._thickness / 2
+        point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
+        return _point_on_segment(
+            point,
+            (self._x - self._anchor_x, self._y - self._anchor_y),
+            (self._x2 - self._anchor_x, self._y2 - self._anchor_y),
+            self._thickness,
+        )
 
     def _create_vertex_list(self) -> None:
         self._vertex_list = self._program.vertex_list(
@@ -1588,6 +1611,38 @@ class Line(ShapeBase):
     def thickness(self, thickness: float) -> None:
         self._thickness = thickness
         self._update_vertices()
+
+    @property
+    def x(self) -> float:
+        return self._x
+
+    @x.setter
+    def x(self, value: float) -> None:
+        self._x2 += value - self._x
+        self._x = value
+        self._update_translation()
+
+    @property
+    def y(self) -> float:
+        return self._y
+
+    @y.setter
+    def y(self, value: float) -> None:
+        self._y2 += value - self._y
+        self._y = value
+        self._update_translation()
+
+    @property
+    def position(self) -> tuple[float, float]:
+        return self._x, self._y
+
+    @position.setter
+    def position(self, values: tuple[float, float]) -> None:
+        x, y = values
+        self._x2 += x - self._x
+        self._y2 += y - self._y
+        self._x, self._y = x, y
+        self._update_translation()
 
     @property
     def x2(self) -> float:
@@ -2337,8 +2392,12 @@ class Triangle(ShapeBase):
 
     def __contains__(self, point: tuple[float, float]) -> bool:
         assert len(point) == 2
+        point = _rotate_point((self._x, self._y), point, math.radians(self._rotation))
         return _point_in_polygon(
-            [(self._x, self._y), (self._x2, self._y2), (self._x3, self._y3), (self._x, self._y)],
+            [(self._x - self._anchor_x, self._y - self._anchor_y),
+             (self._x2 - self._anchor_x, self._y2 - self._anchor_y),
+             (self._x3 - self._anchor_x, self._y3 - self._anchor_y),
+             (self._x - self._anchor_x, self._y - self._anchor_y)],
             point)
 
     def _create_vertex_list(self) -> None:
@@ -2367,7 +2426,7 @@ class Triangle(ShapeBase):
     @property
     def x2(self) -> float:
         """Get/set the X coordinate of the triangle's 2nd vertex."""
-        return self._x + self._x2
+        return self._x2
 
     @x2.setter
     def x2(self, value: float) -> None:
@@ -2377,7 +2436,7 @@ class Triangle(ShapeBase):
     @property
     def y2(self) -> float:
         """Get/set the Y coordinate of the triangle's 2nd vertex."""
-        return self._y + self._y2
+        return self._y2
 
     @y2.setter
     def y2(self, value: float) -> None:
@@ -2387,7 +2446,7 @@ class Triangle(ShapeBase):
     @property
     def x3(self) -> float:
         """Get/set the X coordinate of the triangle's 3rd vertex."""
-        return self._x + self._x3
+        return self._x3
 
     @x3.setter
     def x3(self, value: float) -> None:
@@ -2397,12 +2456,51 @@ class Triangle(ShapeBase):
     @property
     def y3(self) -> float:
         """Get/set the Y value of the triangle's 3rd vertex."""
-        return self._y + self._y3
+        return self._y3
 
     @y3.setter
     def y3(self, value: float) -> None:
         self._y3 = value
         self._update_vertices()
+
+    @property
+    def x(self) -> float:
+        return self._x
+
+    @x.setter
+    def x(self, value: float) -> None:
+        delta = value - self._x
+        self._x = value
+        self._x2 += delta
+        self._x3 += delta
+        self._update_translation()
+
+    @property
+    def y(self) -> float:
+        return self._y
+
+    @y.setter
+    def y(self, value: float) -> None:
+        delta = value - self._y
+        self._y = value
+        self._y2 += delta
+        self._y3 += delta
+        self._update_translation()
+
+    @property
+    def position(self) -> tuple[float, float]:
+        return self._x, self._y
+
+    @position.setter
+    def position(self, values: tuple[float, float]) -> None:
+        x, y = values
+        dx, dy = x - self._x, y - self._y
+        self._x, self._y = x, y
+        self._x2 += dx
+        self._y2 += dy
+        self._x3 += dx
+        self._y3 += dy
+        self._update_translation()
 
 
 class Star(ShapeBase):
@@ -2586,7 +2684,7 @@ class Polygon(ShapeBase):
         """
         # len(self._coordinates) = the number of vertices and sides in the shape.
         self._rotation = 0
-        self._coordinates = list(coordinates)
+        self._coordinates = _normalise_coordinates(coordinates)
         self._x, self._y = self._coordinates[0]
 
         r, g, b, *a = color

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -129,6 +129,16 @@ def test_hit_testing_respects_rotation_and_anchor():
 def test_line_coordinate_movement():
     line = Line(0, 0, 10, 0, thickness=2)
 
+    line.x = 5
+    line.y = 6
+    assert (line.x, line.y, line.x2, line.y2) == (5, 6, 15, 6)
+
+    line[0] = 2, 3
+    assert line.points == [(2, 3), (15, 6)]
+    line[1] = 8, 9
+    assert line.points == [(2, 3), (8, 9)]
+
+    line = Line(0, 0, 10, 0, thickness=2)
     line.position = 5, 5
     assert line.x2 == 15
     assert line.y2 == 5
@@ -147,6 +157,24 @@ def test_triangle_coordinate_movement_and_rotated_contains():
     triangle = Triangle(0, 0, 2, 0, 0, 2)
     triangle.rotation = 90
     assert (0.75, -0.75) in triangle
+
+
+def test_multiline_points_can_be_read_and_updated():
+    multiline = MultiLine((0, 0), (5, 5), (10, 0))
+
+    assert multiline.points == [(0, 0), (5, 5), (10, 0)]
+    assert multiline[1] == (5, 5)
+
+    multiline[1] = (5, 8)
+    assert multiline.points == [(0, 0), (5, 8), (10, 0)]
+
+
+def test_closed_multiline_points_exclude_and_update_closing_point():
+    multiline = MultiLine((0, 0), (5, 5), (10, 0), closed=True)
+
+    multiline.points = [(1, 1), (5, 5), (10, 0)]
+    assert multiline.points == [(1, 1), (5, 5), (10, 0)]
+    assert multiline._coordinates[-1] == (1, 1)  # noqa: SLF001
 
 
 def test_setting_color_sets_color_rgb_channels(rgb_or_rgba_shape, new_rgb_or_rgba_color):

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -73,6 +73,82 @@ def test_rotation_prop_sets_rotation(rgb_or_rgba_shape, new_nonzero_rotation):
     assert rgb_or_rgba_shape.rotation == new_nonzero_rotation
 
 
+def test_curve_and_polygon_accept_a_single_sequence_of_points():
+    points = [(0, 0), (5, 10), (10, 0)]
+
+    assert BezierCurve(points).points == points
+    assert Polygon(points)._coordinates == points  # noqa: SLF001
+
+
+def test_arc_contains_uses_a_circular_approximation():
+    arc = Arc(0, 0, 10, angle=90, thickness=2)
+
+    assert (0, 0) in arc
+    assert (-5, 0) in arc
+    assert (10, 0) not in arc
+
+
+def test_sector_contains_the_entire_circle_for_a_full_sweep():
+    sector = Sector(0, 0, 10, angle=360)
+    assert (-5, 0) in sector
+
+
+@pytest.mark.parametrize(("shape_class", "args", "kwargs", "inside", "outside"), [
+    (Circle, (0, 0, 10), {}, (0, 0), (11, 0)),
+    (Ellipse, (0, 0, 10, 5), {}, (5, 0), (0, 6)),
+    (Sector, (0, 0, 10), {"angle": 90}, (5, 5), (-5, 5)),
+    (Line, (0, 0, 10, 0), {"thickness": 2}, (5, 0), (5, 2)),
+    (Rectangle, (0, 0, 10, 10), {}, (5, 5), (11, 5)),
+    (BorderedRectangle, (0, 0, 10, 10), {}, (5, 5), (11, 5)),
+    (Box, (0, 0, 10, 10), {}, (5, 5), (11, 5)),
+    (RoundedRectangle, (0, 0, 10, 10), {"radius": 2}, (5, 5), (11, 5)),
+    (Triangle, (0, 0, 10, 0, 0, 10), {}, (2, 2), (8, 8)),
+    (Star, (0, 0, 10, 5, 5), {}, (0, 0), (11, 0)),
+    (Polygon, ((0, 0), (10, 0), (0, 10)), {}, (2, 2), (8, 8)),
+])
+def test_shapes_containment(shape_class, args, kwargs, inside, outside):
+    shape = shape_class(*args, **kwargs)
+    assert inside in shape
+    assert outside not in shape
+
+
+def test_hit_testing_respects_rotation_and_anchor():
+    rectangle = Rectangle(0, 0, 10, 10)
+    rectangle.rotation = 90
+    assert (5, -5) in rectangle
+
+    ellipse = Ellipse(0, 0, 10, 5)
+    ellipse.rotation = 90
+    assert (0, -5) in ellipse
+
+    circle = Circle(0, 0, 10)
+    circle.anchor_x = 2
+    assert (-2, 0) in circle
+
+
+def test_line_coordinate_movement():
+    line = Line(0, 0, 10, 0, thickness=2)
+
+    line.position = 5, 5
+    assert line.x2 == 15
+    assert line.y2 == 5
+    assert (10, 5) in line
+
+    line.rotation = 90
+    assert (5, 0) in line
+
+
+def test_triangle_coordinate_movement_and_rotated_contains():
+    triangle = Triangle(0, 0, 2, 0, 0, 2)
+    triangle.position = 5, 5
+    assert (triangle.x2, triangle.y2, triangle.x3, triangle.y3) == (7, 5, 5, 7)
+    assert (6, 5.5) in triangle
+
+    triangle = Triangle(0, 0, 2, 0, 0, 2)
+    triangle.rotation = 90
+    assert (0.75, -0.75) in triangle
+
+
 def test_setting_color_sets_color_rgb_channels(rgb_or_rgba_shape, new_rgb_or_rgba_color):
     rgb_or_rgba_shape.color = new_rgb_or_rgba_color
     assert rgb_or_rgba_shape.color[:3] == new_rgb_or_rgba_color[:3]

--- a/tests/unit/shapes/test_shapes.py
+++ b/tests/unit/shapes/test_shapes.py
@@ -154,6 +154,11 @@ def test_triangle_coordinate_movement_and_rotated_contains():
     assert (triangle.x2, triangle.y2, triangle.x3, triangle.y3) == (7, 5, 5, 7)
     assert (6, 5.5) in triangle
 
+    triangle[1] = 8, 5
+    assert triangle.points == [(5, 5), (8, 5), (5, 7)]
+    triangle[2] = 5, 9
+    assert triangle.points == [(5, 5), (8, 5), (5, 9)]
+
     triangle = Triangle(0, 0, 2, 0, 0, 2)
     triangle.rotation = 90
     assert (0.75, -0.75) in triangle


### PR DESCRIPTION
Fix some issues in shapes mentioned in issues about shapes not behaving correctly. Most of the interoperability stuff is already corrected, but #887 can most likely be closed from this as well.

Update docs to remove GL specific mentions for blend.

BezierCurve and Polygon: Accept the old single-list style, like BezierCurve(points) and Polygon(points), as well as point pairs. (Resolves #889)

Line:
Fixed hit-testing to respect rotation and anchors. 
Fixed x, y, and position to move both endpoints together (as documented).
Added new line.points for setting points separately, also supports slicing. `line.points[0] = (1, 0) `or `line[0] = (1, 0)` will now only update one specific point. 

Multiline:
Added new points value for setting points separately, also supports slicing. `multiline.points[0] = (1, 0) `or `multiline[0] = (1, 0)` will now only update one specific point. (resolves #1079)

Triangle:
Fixed x2, y2, x3, and y3 getters returning incorrect coordinates.
Fixed x, y, and position to move all three vertices together.
Fixed hit-testing to respect rotation and anchors.
Added new triangle.points for setting points separately, also supports slicing. `triangle.points[0] = (1, 0) `or `triangle[0] = (1, 0)` will now only update one specific point. 

Arc: Added in support for its stroked curve (and its closing segment when closed=True).
Fixed rotation being applied twice to geometry (mentioned in closed PR).
Fixed full-circle hit test to compare against 360.

Sector: Fixed hit test checks for full circles (angle=360) and consolidated clockwise/counter-clockwise sweep checks.


Additional tests, also includes hit testing.