### PR TITLE
Sprite anchoring

### DIFF
--- a/doc/programming_guide/image.rst
+++ b/doc/programming_guide/image.rst
@@ -169,14 +169,10 @@ All loaded images have the following attributes:
     The width of the image, in pixels.
 `height`
     The height of the image, in pixels.
-`anchor_x`
-    Distance of the anchor point from the left edge of the image, in pixels.
-`anchor_y`
-    Distance of the anchor point from the bottom edge of the image, in pixels.
 
-The anchor point defaults to (0, 0), though some image formats may contain an
-intrinsic anchor point.  The anchor point is used to align the image to a
-point in space when drawing it.
+Positioning state belongs to the object displaying the image. For example,
+:class:`~pyglet.sprite.Sprite` provides ``anchor_x``, ``anchor_y``, and
+``anchor_position`` properties.
 
 You may only want to use a portion of an image. You can use
 :py:meth:`~pyglet.image.ImageData.get_region` to return a region::

--- a/pyglet/enums.py
+++ b/pyglet/enums.py
@@ -3,6 +3,44 @@ from __future__ import annotations
 from enum import Enum, auto
 
 
+class Anchor(str, Enum):
+    """Named two-dimensional anchor positions for display objects."""
+
+    BOTTOM_LEFT = "bottom_left"
+    BOTTOM_CENTER = "bottom_center"
+    BOTTOM_RIGHT = "bottom_right"
+    CENTER_LEFT = "center_left"
+    CENTER = "center"
+    CENTER_RIGHT = "center_right"
+    TOP_LEFT = "top_left"
+    TOP_CENTER = "top_center"
+    TOP_RIGHT = "top_right"
+
+    BOTTOM = "bottom"
+    LEFT = "left"
+    RIGHT = "right"
+    TOP = "top"
+
+    def get_position(self, width: float, height: float) -> tuple[float, float]:
+        """Return this anchor's offset for an image of the given dimensions."""
+        positions = {
+            Anchor.BOTTOM_LEFT: (0, 0),
+            Anchor.BOTTOM_CENTER: (width / 2, 0),
+            Anchor.BOTTOM_RIGHT: (width, 0),
+            Anchor.CENTER_LEFT: (0, height / 2),
+            Anchor.CENTER: (width / 2, height / 2),
+            Anchor.CENTER_RIGHT: (width, height / 2),
+            Anchor.TOP_LEFT: (0, height),
+            Anchor.TOP_CENTER: (width / 2, height),
+            Anchor.TOP_RIGHT: (width, height),
+            Anchor.BOTTOM: (width / 2, 0),
+            Anchor.LEFT: (0, height / 2),
+            Anchor.RIGHT: (width, height / 2),
+            Anchor.TOP: (width / 2, height),
+        }
+        return positions[self]
+
+
 class GraphicsAPI(str, Enum):
     """Supported graphics backends."""
     OPENGL = "opengl"

--- a/pyglet/experimental/geoshader_sprite.py
+++ b/pyglet/experimental/geoshader_sprite.py
@@ -4,9 +4,9 @@ import sys
 
 import pyglet
 from pyglet import clock, event, graphics, image
-from pyglet.enums import Anchor
-from pyglet.enums import GeometryMode
-from pyglet.graphics.api.gl import *
+from pyglet.enums import Anchor, BlendFactor, GeometryMode
+from pyglet.graphics import Group
+from pyglet.graphics.draw import DrawContext, BatchDrawOptions
 
 _is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
 
@@ -162,7 +162,7 @@ def get_default_array_shader():
     return program.get_attribute_view(color="Bn")
 
 
-class SpriteGroup(graphics.Group):
+class SpriteGroup(Group):
     """Shared sprite rendering group.
 
     The group is automatically coalesced with other sprite groups sharing the
@@ -193,39 +193,9 @@ class SpriteGroup(graphics.Group):
         """
         super().__init__(parent=parent)
         self.texture = texture
-        self.blend_src = blend_src
-        self.blend_dest = blend_dest
-        self.program = program
-
-    def set_state(self):
-        self.program.use()
-
-        glActiveTexture(GL_TEXTURE0)
-        glBindTexture(self.texture.target, self.texture.handle)
-
-        glEnable(GL_BLEND)
-        glBlendFunc(self.blend_src, self.blend_dest)
-
-    def unset_state(self):
-        glDisable(GL_BLEND)
-        self.program.stop()
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self.texture})"
-
-    def __eq__(self, other):
-        return (other.__class__ is self.__class__ and
-                self.program is other.program and
-                self.parent == other.parent and
-                self.texture.target == other.texture.target and
-                self.texture.key == other.texture.key and
-                self.blend_src == other.blend_src and
-                self.blend_dest == other.blend_dest)
-
-    def __hash__(self):
-        return hash((self.program, self.parent,
-                     self.texture.key, self.texture.target,
-                     self.blend_src, self.blend_dest))
+        self.set_shader_program(program)
+        self.set_blend(blend_src, blend_dest)
+        self.set_texture(texture, 0)
 
 
 class Sprite(event.EventDispatcher):
@@ -247,7 +217,7 @@ class Sprite(event.EventDispatcher):
     def __init__(self,
                  img, x=0, y=0, z=0,
                  anchor: Anchor | str | tuple[float, float] | None = None,
-                 blend_src=GL_SRC_ALPHA, blend_dest=GL_ONE_MINUS_SRC_ALPHA,
+                 blend_src=BlendFactor.SRC_ALPHA, blend_dest=BlendFactor.ONE_MINUS_SRC_ALPHA,
                  batch=None, group=None, subpixel=False, program=None):
         """Create a sprite.
 
@@ -317,9 +287,11 @@ class Sprite(event.EventDispatcher):
         else:
             self._program = program
 
-        self._batch = batch or graphics.get_default_batch()
+        self._batch = batch
+        self._blend_src = blend_src
+        self._blend_dest = blend_dest
         self._user_group = group
-        self._group = self.group_class(self._texture, blend_src, blend_dest, self.program, group)
+        self._group = self.get_sprite_group()
         self._subpixel = subpixel
 
         self._create_vertex_list()
@@ -327,7 +299,7 @@ class Sprite(event.EventDispatcher):
     def _create_vertex_list(self):
         texture = self._texture
         self._vertex_list = self.program.vertex_list(
-            1, GL_POINTS, self._batch, self._group,
+            1, GeometryMode.POINTS, self._batch, self._group,
             position=(self._x, self._y, self._z),
             size=(texture.width, texture.height, self._anchor_x, self._anchor_y),
             scale=(self._scale_x, self._scale_y),
@@ -343,13 +315,10 @@ class Sprite(event.EventDispatcher):
     def program(self, program):
         if self._program == program:
             return
-        self._group = self.group_class(self._texture,
-                                       self._group.blend_src,
-                                       self._group.blend_dest,
-                                       program,
-                                       self._user_group)
+        self._program = program
+        self._group = self.get_sprite_group()
         if (self._batch and
-                self._batch.update_shader(self._vertex_list, GL_POINTS, self._group, program)):
+                self._batch.update_shader(self._vertex_list, GeometryMode.POINTS, self._group, program)):
             # Exit early if changing domain is not needed.
             return
 
@@ -371,6 +340,9 @@ class Sprite(event.EventDispatcher):
         self._texture = None
         self._group = None
 
+    def get_sprite_group(self):
+        return self.group_class(self._texture, self._blend_src, self._blend_dest, self._program, self._user_group)
+
     def _animate(self, dt):
         self._frame_index += 1
         if self._frame_index >= len(self._animation.frames):
@@ -391,6 +363,23 @@ class Sprite(event.EventDispatcher):
             self.dispatch_event('on_animation_end')
 
     @property
+    def blend_mode(self):
+        """The current blend factors applied to this sprite."""
+        return self._blend_src, self._blend_dest
+
+    @blend_mode.setter
+    def blend_mode(self, modes):
+        src, dst = modes
+        if src == self._blend_src and dst == self._blend_dest:
+            return
+
+        self._blend_src = src
+        self._blend_dest = dst
+        self._group = self.get_sprite_group()
+        if self._batch is not None:
+            self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, self._batch)
+
+    @property
     def batch(self):
         """Graphics batch.
 
@@ -408,7 +397,7 @@ class Sprite(event.EventDispatcher):
             return
 
         if batch is not None and self._batch is not None:
-            self._batch.migrate(self._vertex_list, GL_POINTS, self._group, batch)
+            self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, batch)
             self._batch = batch
         else:
             self._vertex_list.delete()
@@ -424,18 +413,16 @@ class Sprite(event.EventDispatcher):
 
         :type: :py:class:`pyglet.graphics.Group`
         """
-        return self._group.parent
+        return self._user_group
 
     @group.setter
     def group(self, group):
-        if self._group.parent == group:
+        if self._user_group == group:
             return
-        self._group = self.group_class(self._texture,
-                                       self._group.blend_src,
-                                       self._group.blend_dest,
-                                       self._group.program,
-                                       group)
-        self._batch.migrate(self._vertex_list, GL_POINTS, self._group, self._batch)
+        self._user_group = group
+        self._group = self.get_sprite_group()
+        if self._batch is not None:
+            self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, self._batch)
 
     @property
     def image(self):
@@ -462,22 +449,22 @@ class Sprite(event.EventDispatcher):
 
     def _set_texture(self, texture):
         previous_size = self._texture.width, self._texture.height
-        if texture.key != self._texture.key:
-            self._group = self._group.__class__(texture,
-                                                self._group.blend_src,
-                                                self._group.blend_dest,
-                                                self._group.program,
-                                                self._group.parent)
-            self._vertex_list.delete()
-            self._texture = texture
-            self._resolve_anchor()
-            self._create_vertex_list()
-        else:
-            self._texture = texture
-            self._vertex_list.texture_uv[:] = texture.uv
-            self._resolve_anchor()
-            if self._anchor is not None or (texture.width, texture.height) != previous_size:
-                self._update_anchor()
+        texture_changed = texture.key != self._texture.key
+        self._texture = texture
+        self._resolve_anchor()
+
+        if texture_changed:
+            self._group = self.get_sprite_group()
+            if self._batch is not None:
+                self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, self._batch)
+            else:
+                self._vertex_list.delete()
+                self._create_vertex_list()
+                return
+
+        self._vertex_list.texture_uv[:] = texture.uv
+        if self._anchor is not None or (texture.width, texture.height) != previous_size:
+            self._update_anchor()
 
     def _resolve_anchor(self):
         if self._anchor is not None:
@@ -845,10 +832,10 @@ class Sprite(event.EventDispatcher):
         efficiently.
         """
         ctx = pyglet.graphics.api.core.current_context
-        draw_ctx = pyglet.graphics.draw.DrawContext(
+        draw_ctx = DrawContext(
             surface_ctx=ctx,
             backend_ctx=None,
-            draw_pass=pyglet.graphics.draw.BatchDrawOptions().resolve(ctx),
+            draw_pass=BatchDrawOptions().resolve(ctx),
             renderer=ctx.renderer,
         )
         draw_ctx.begin()

--- a/pyglet/experimental/geoshader_sprite.py
+++ b/pyglet/experimental/geoshader_sprite.py
@@ -170,27 +170,6 @@ class SpriteGroup(Group):
     """
 
     def __init__(self, texture, blend_src, blend_dest, program, parent=None):
-        """Create a sprite group.
-
-        The group is created internally when a :py:class:`~pyglet.sprite.Sprite`
-        is created; applications usually do not need to explicitly create it.
-
-        :Parameters:
-            `texture` : `~pyglet.graphics.Texture`
-                The (top-level) texture containing the sprite image.
-            `blend_src` : int
-                OpenGL blend source mode; for example,
-                ``GL_SRC_ALPHA``.
-            `blend_dest` : int
-                OpenGL blend destination mode; for example,
-                ``GL_ONE_MINUS_SRC_ALPHA``.
-            `program` : `~pyglet.graphics.ShaderProgram`
-                A custom ShaderProgram.
-            `order` : int
-                Change the order to render above or below other Groups.
-            `parent` : `~pyglet.graphics.Group`
-                Optional parent group.
-        """
         super().__init__(parent=parent)
         self.texture = texture
         self.set_shader_program(program)
@@ -221,34 +200,34 @@ class Sprite(event.EventDispatcher):
                  batch=None, group=None, subpixel=False, program=None):
         """Create a sprite.
 
-        :Parameters:
-            `img` :
+        Args:
+            img:
                 Image or animation to display.
-            `x` : int
+            x:
                 X coordinate of the sprite.
-            `y` : int
+            y:
                 Y coordinate of the sprite.
-            `z` : int
+            z:
                 Z coordinate of the sprite.
-            `anchor` : tuple[float, float] | str | Anchor | None
+            anchor:
                 Anchor offset relative to the image's lower-left corner. Pass
                 a numeric ``(x, y)`` tuple for an explicit offset, or a named
                 anchor such as ``"bottom_center"``. Named anchors are
                 recalculated when the image or animation frame changes.
-            `blend_src` : int
-                OpenGL blend source mode.  The default is suitable for
+            blend_src:
+                Source :class:`~pyglet.enums.BlendFactor`. The default is suitable for
                 compositing sprites drawn from back-to-front.
-            `blend_dest` : int
-                OpenGL blend destination mode.  The default is suitable for
+            blend_dest:
+                Destination :class:`~pyglet.enums.BlendFactor`. The default is suitable for
                 compositing sprites drawn from back-to-front.
-            `batch` : `~pyglet.graphics.Batch`
+            batch:
                 Optional batch to add the sprite to.
-            `group` : `~pyglet.graphics.Group`
+            group:
                 Optional parent group of the sprite.
-            `subpixel` : bool
+            subpixel:
                 Allow floating-point coordinates for the sprite. By default,
                 coordinates are restricted to integer values.
-            `program` : `~pyglet.graphics.ShaderProgram`
+            program:
                 A custom shader to use. This shader program must contain the
                 exact same attribute names and types as the default shader.
                 The class methods and properties depend on this, and will
@@ -520,16 +499,7 @@ class Sprite(event.EventDispatcher):
 
     @property
     def position(self):
-        """The (x, y, z) coordinates of the sprite, as a tuple.
-
-        :Parameters:
-            `x` : int
-                X coordinate of the sprite.
-            `y` : int
-                Y coordinate of the sprite.
-            `z` : int
-                Z coordinate of the sprite.
-        """
+        """The ``(x, y, z)`` coordinates of the sprite."""
         return self._x, self._y, self._z
 
     @position.setter
@@ -645,20 +615,20 @@ class Sprite(event.EventDispatcher):
         This method is provided for convenience. There is not much
         performance benefit to updating multiple Sprite attributes at once.
 
-        :Parameters:
-            `x` : int
+        Args:
+            x:
                 X coordinate of the sprite.
-            `y` : int
+            y:
                 Y coordinate of the sprite.
-            `z` : int
+            z:
                 Z coordinate of the sprite.
-            `rotation` : float
+            rotation:
                 Clockwise rotation of the sprite, in degrees.
-            `scale` : float
+            scale:
                 Scaling factor.
-            `scale_x` : float
+            scale_x:
                 Horizontal scaling factor.
-            `scale_y` : float
+            scale_y:
                 Vertical scaling factor.
         """
         translations_outdated = False

--- a/pyglet/experimental/geoshader_sprite.py
+++ b/pyglet/experimental/geoshader_sprite.py
@@ -4,6 +4,7 @@ import sys
 
 import pyglet
 from pyglet import clock, event, graphics, image
+from pyglet.enums import Anchor
 from pyglet.enums import GeometryMode
 from pyglet.graphics.api.gl import *
 
@@ -230,6 +231,9 @@ class SpriteGroup(graphics.Group):
 class Sprite(event.EventDispatcher):
     _batch = None
     _animation = None
+    _anchor_x = 0.0
+    _anchor_y = 0.0
+    _anchor = None
     _frame_index = 0
     _paused = False
     _rotation = 0
@@ -242,6 +246,7 @@ class Sprite(event.EventDispatcher):
 
     def __init__(self,
                  img, x=0, y=0, z=0,
+                 anchor: Anchor | str | tuple[float, float] | None = None,
                  blend_src=GL_SRC_ALPHA, blend_dest=GL_ONE_MINUS_SRC_ALPHA,
                  batch=None, group=None, subpixel=False, program=None):
         """Create a sprite.
@@ -255,6 +260,11 @@ class Sprite(event.EventDispatcher):
                 Y coordinate of the sprite.
             `z` : int
                 Z coordinate of the sprite.
+            `anchor` : tuple[float, float] | str | Anchor | None
+                Anchor offset relative to the image's lower-left corner. Pass
+                a numeric ``(x, y)`` tuple for an explicit offset, or a named
+                anchor such as ``"bottom_center"``. Named anchors are
+                recalculated when the image or animation frame changes.
             `blend_src` : int
                 OpenGL blend source mode.  The default is suitable for
                 compositing sprites drawn from back-to-front.
@@ -278,6 +288,13 @@ class Sprite(event.EventDispatcher):
         self._y = y
         self._z = z
         self._img = img
+        self._anchor_x = 0.0
+        self._anchor_y = 0.0
+        self._anchor = None
+        if isinstance(anchor, tuple):
+            self._anchor_x, self._anchor_y = anchor
+        elif anchor is not None:
+            self._anchor = Anchor(anchor)
 
         self._rgba = [255, 255, 255, 255]
 
@@ -289,6 +306,8 @@ class Sprite(event.EventDispatcher):
                 clock.schedule_once(self._animate, self._next_dt)
         else:
             self._texture = img.get_texture()
+
+        self._resolve_anchor()
 
         if not program:
             if isinstance(img, image.TextureArrayRegion):
@@ -310,7 +329,7 @@ class Sprite(event.EventDispatcher):
         self._vertex_list = self.program.vertex_list(
             1, GL_POINTS, self._batch, self._group,
             position=(self._x, self._y, self._z),
-            size=(texture.width, texture.height, texture.anchor_x, texture.anchor_y),
+            size=(texture.width, texture.height, self._anchor_x, self._anchor_y),
             scale=(self._scale_x, self._scale_y),
             color=self._rgba,
             texture_uv=texture.uv,
@@ -442,6 +461,7 @@ class Sprite(event.EventDispatcher):
             self._set_texture(img.get_texture())
 
     def _set_texture(self, texture):
+        previous_size = self._texture.width, self._texture.height
         if texture.key != self._texture.key:
             self._group = self._group.__class__(texture,
                                                 self._group.blend_src,
@@ -450,10 +470,66 @@ class Sprite(event.EventDispatcher):
                                                 self._group.parent)
             self._vertex_list.delete()
             self._texture = texture
+            self._resolve_anchor()
             self._create_vertex_list()
         else:
+            self._texture = texture
             self._vertex_list.texture_uv[:] = texture.uv
-        self._texture = texture
+            self._resolve_anchor()
+            if self._anchor is not None or (texture.width, texture.height) != previous_size:
+                self._update_anchor()
+
+    def _resolve_anchor(self):
+        if self._anchor is not None:
+            self._anchor_x, self._anchor_y = self._anchor.get_position(self._texture.width, self._texture.height)
+
+    def _update_anchor(self):
+        texture = self._texture
+        self._vertex_list.size[:] = texture.width, texture.height, self._anchor_x, self._anchor_y
+
+    @property
+    def anchor(self):
+        """The named anchor position, or ``None`` when using a numeric anchor."""
+        return self._anchor
+
+    @anchor.setter
+    def anchor(self, anchor):
+        self._anchor = Anchor(anchor) if anchor is not None else None
+        self._resolve_anchor()
+        self._update_anchor()
+
+    @property
+    def anchor_x(self):
+        """X coordinate of the anchor, relative to the image's left edge."""
+        return self._anchor_x
+
+    @anchor_x.setter
+    def anchor_x(self, anchor_x):
+        self._anchor = None
+        self._anchor_x = anchor_x
+        self._update_anchor()
+
+    @property
+    def anchor_y(self):
+        """Y coordinate of the anchor, relative to the image's bottom edge."""
+        return self._anchor_y
+
+    @anchor_y.setter
+    def anchor_y(self, anchor_y):
+        self._anchor = None
+        self._anchor_y = anchor_y
+        self._update_anchor()
+
+    @property
+    def anchor_position(self):
+        """The anchor's ``(x, y)`` offset from the sprite's lower-left corner."""
+        return self._anchor_x, self._anchor_y
+
+    @anchor_position.setter
+    def anchor_position(self, position):
+        self._anchor = None
+        self._anchor_x, self._anchor_y = position
+        self._update_anchor()
 
     @property
     def position(self):
@@ -517,8 +593,7 @@ class Sprite(event.EventDispatcher):
     def rotation(self):
         """Clockwise rotation of the sprite, in degrees.
 
-        The sprite image will be rotated about its image's (anchor_x, anchor_y)
-        position.
+        The sprite image is rotated around its lower-left corner.
 
         :type: float
         """

--- a/pyglet/experimental/particles.py
+++ b/pyglet/experimental/particles.py
@@ -7,7 +7,7 @@ import time
 
 import pyglet
 from pyglet import clock, event, graphics, image
-from pyglet.enums import BlendFactor, GeometryMode
+from pyglet.enums import Anchor, BlendFactor, GeometryMode
 
 _is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
 
@@ -205,6 +205,9 @@ class Emitter(event.EventDispatcher):
     _batch = None
     _animation = None
     _frame_index = 0
+    _anchor_x = 0.0
+    _anchor_y = 0.0
+    _anchor = None
     _paused = False
     _visible = True
     _vertex_list = None
@@ -214,7 +217,8 @@ class Emitter(event.EventDispatcher):
                  color_start=(255, 255, 255, 255), color_end=(255, 255, 255, 255),
                  scale_start=(1.0, 1.0), scale_end=(1.0, 1.0), rotation=0.0,
                  blend_src=BlendFactor.SRC_ALPHA, blend_dest=BlendFactor.ONE_MINUS_SRC_ALPHA,
-                 batch=None, group=None, program=None):
+                 batch=None, group=None, program=None,
+                 anchor: Anchor | str | tuple[float, float] | None = None):
 
         self._img = img
         self._x = x
@@ -222,6 +226,13 @@ class Emitter(event.EventDispatcher):
         self._z = z
         self._count = count
         self._velocity = velocity + spread
+        self._anchor_x = 0.0
+        self._anchor_y = 0.0
+        self._anchor = None
+        if isinstance(anchor, tuple):
+            self._anchor_x, self._anchor_y = anchor
+        elif anchor is not None:
+            self._anchor = Anchor(anchor)
 
         self._color_start = color_start
         self._color_end = color_end
@@ -238,6 +249,8 @@ class Emitter(event.EventDispatcher):
         else:
             self._texture = img.get_texture()
 
+        self._resolve_anchor()
+
         self._program = program or get_default_shader()
         self._batch = batch or graphics.get_default_batch()
         self._user_group = group
@@ -251,7 +264,7 @@ class Emitter(event.EventDispatcher):
             count, GeometryMode.POINTS, self._batch, self._group,
             position=(self._x, self._y, self._z) * count,
 
-            size=(texture.width, texture.height, texture.anchor_x, texture.anchor_y) * count,
+            size=(texture.width, texture.height, self._anchor_x, self._anchor_y) * count,
             scale=(self._scale_start + self._scale_end) * count,
 
             velocity=self._velocity * count,
@@ -319,6 +332,7 @@ class Emitter(event.EventDispatcher):
             self.dispatch_event('on_animation_end')
 
     def _set_texture(self, texture):
+        previous_size = self._texture.width, self._texture.height
         if texture.key != self._texture.key:
             self._group = self._group.__class__(texture,
                                                 self._group.blend_src,
@@ -327,10 +341,68 @@ class Emitter(event.EventDispatcher):
                                                 self._group.parent)
             self._vertex_list.delete()
             self._texture = texture
+            self._resolve_anchor()
             self._create_vertex_list()
         else:
+            self._texture = texture
             self._vertex_list.texture_uv[:] = texture.uv
-        self._texture = texture
+            self._resolve_anchor()
+            if self._anchor is not None or (texture.width, texture.height) != previous_size:
+                self._update_anchor()
+
+    def _update_anchor(self):
+        texture = self._texture
+        self._vertex_list.size[:] = (texture.width, texture.height, self._anchor_x, self._anchor_y) * self._count
+
+    def _resolve_anchor(self):
+        if self._anchor is None:
+            return
+
+        self._anchor_x, self._anchor_y = self._anchor.get_position(self._texture.width, self._texture.height)
+
+    @property
+    def anchor(self):
+        """The named anchor position, or ``None`` when using a numeric anchor."""
+        return self._anchor
+
+    @anchor.setter
+    def anchor(self, anchor):
+        self._anchor = Anchor(anchor) if anchor is not None else None
+        self._resolve_anchor()
+        self._update_anchor()
+
+    @property
+    def anchor_x(self):
+        """X coordinate of the particle anchor, relative to the image's left edge."""
+        return self._anchor_x
+
+    @anchor_x.setter
+    def anchor_x(self, anchor_x):
+        self._anchor = None
+        self._anchor_x = anchor_x
+        self._update_anchor()
+
+    @property
+    def anchor_y(self):
+        """Y coordinate of the particle anchor, relative to the image's bottom edge."""
+        return self._anchor_y
+
+    @anchor_y.setter
+    def anchor_y(self, anchor_y):
+        self._anchor = None
+        self._anchor_y = anchor_y
+        self._update_anchor()
+
+    @property
+    def anchor_position(self):
+        """The particle anchor's ``(x, y)`` offset from the image's lower-left corner."""
+        return self._anchor_x, self._anchor_y
+
+    @anchor_position.setter
+    def anchor_position(self, position):
+        self._anchor = None
+        self._anchor_x, self._anchor_y = position
+        self._update_anchor()
 
     @property
     def position(self) -> tuple[int | float, int | float, int | float]:
@@ -362,7 +434,8 @@ class ParticleManager:
                  spread=(10.0, 10.0),
                  color_start=(255, 255, 255, 255), color_end=(255, 255, 255, 255),
                  scale_start=(1.0, 1.0), scale_end=(1.0, 1.0), rotation=0.0,
-                 batch=None, group=None):
+                 batch=None, group=None,
+                 anchor: Anchor | str | tuple[float, float] | None = None):
 
         self._img = img
         self.lifespan = lifespan
@@ -374,6 +447,13 @@ class ParticleManager:
         self.scale_start = scale_start
         self.scale_end = scale_end
         self.rotation = rotation
+        self._anchor_x = 0.0
+        self._anchor_y = 0.0
+        self._anchor = None
+        if isinstance(anchor, tuple):
+            self._anchor_x, self._anchor_y = anchor
+        elif anchor is not None:
+            self._anchor = Anchor(anchor)
 
         self._batch = batch
         self._group = group
@@ -383,6 +463,45 @@ class ParticleManager:
     def _update_shader_time(self, dt):
         self._program['time'] = time.perf_counter()
 
+    @property
+    def anchor(self):
+        """The named anchor position, or ``None`` when using a numeric anchor."""
+        return self._anchor
+
+    @anchor.setter
+    def anchor(self, anchor):
+        self._anchor = Anchor(anchor) if anchor is not None else None
+
+    @property
+    def anchor_x(self):
+        """X coordinate of the particle anchor, relative to the image's left edge."""
+        return self._anchor_x
+
+    @anchor_x.setter
+    def anchor_x(self, anchor_x):
+        self._anchor = None
+        self._anchor_x = anchor_x
+
+    @property
+    def anchor_y(self):
+        """Y coordinate of the particle anchor, relative to the image's bottom edge."""
+        return self._anchor_y
+
+    @anchor_y.setter
+    def anchor_y(self, anchor_y):
+        self._anchor = None
+        self._anchor_y = anchor_y
+
+    @property
+    def anchor_position(self):
+        """The particle anchor's ``(x, y)`` offset from the image's lower-left corner."""
+        return self._anchor_x, self._anchor_y
+
+    @anchor_position.setter
+    def anchor_position(self, position):
+        self._anchor = None
+        self._anchor_x, self._anchor_y = position
+
     @staticmethod
     def _delete_callback(dt, emitter):
         emitter.delete()
@@ -391,7 +510,8 @@ class ParticleManager:
         emitter = Emitter(self._img, x, y, z, self.count, self.velocity, self.spread,
                           color_start=self.color_start, color_end=self.color_end,
                           scale_start=self.scale_start, scale_end=self.scale_end, rotation=self.rotation,
-                          batch=self._batch, group=self._group)
+                          batch=self._batch, group=self._group,
+                          anchor=self._anchor if self._anchor is not None else self.anchor_position)
         pyglet.clock.schedule_once(self._delete_callback, self.lifespan, emitter)
         return emitter
 

--- a/pyglet/experimental/particles.py
+++ b/pyglet/experimental/particles.py
@@ -8,6 +8,8 @@ import time
 import pyglet
 from pyglet import clock, event, graphics, image
 from pyglet.enums import Anchor, BlendFactor, GeometryMode
+from pyglet.graphics import Group
+from pyglet.graphics.draw import DrawContext, BatchDrawOptions
 
 _is_pyglet_doc_run = hasattr(sys, "is_pyglet_doc_run") and sys.is_pyglet_doc_run
 
@@ -82,7 +84,7 @@ geometry_source = """#version 150
         vec2 anchor = geo_size[0].zw;
         vec2 scale_start = geo_scale[0].xy;
         vec2 scale_end = geo_scale[0].zw;
-        
+
         vec2 velocity = geo_velocity[0].xy;
         vec2 spread = geo_velocity[0].zw;
 
@@ -101,11 +103,11 @@ geometry_source = """#version 150
             vec3 center = gl_in[0].gl_Position.xyz;
             center.x += time_scale * velocity.x * (spread.x * cos(vert_id + 1) * sin(i + 1));
             center.y += time_scale * velocity.y * (spread.y * sin(vert_id + 1) * cos(i + 1));
-            
+
             // Interpolate between the start and end colors, based on the lifetime 
             // (end - start) * step + start
             frag_color = (geo_color_end[0] - geo_color_start[0]) * time_scale + geo_color_start[0]; 
-    
+
             // Interpolate between the start and end scale, based on the lifetime 
             // (end - start) * step + start
             mat4 m_scale = mat4(1.0);
@@ -119,17 +121,17 @@ geometry_source = """#version 150
             m_translate[3][2] = center.z;
 
             mat4 m_rotation = mat4(1.0);
-            m_rotation[0][0] =  cos(radians(-rotation)); 
+            m_rotation[0][0] =  cos(radians(-rotation));
             m_rotation[0][1] =  sin(radians(-rotation));
             m_rotation[1][0] = -sin(radians(-rotation));
-            m_rotation[1][1] =  cos(radians(-rotation));    
-    
+            m_rotation[1][1] =  cos(radians(-rotation));
+
             // Final UV coords (left, bottom, right, top):
             float uv_l = geo_tex_coords[0].s;
             float uv_b = geo_tex_coords[0].t;
             float uv_r = geo_tex_coords[0].p;
             float uv_t = geo_tex_coords[0].q;
-    
+
             // Emit a triangle strip to create a quad (4 vertices).
             // Prepare and reuse the transformation matrix and fragment color:
             mat4 m_pv = window.projection * window.view * m_translate * m_rotation * m_scale;
@@ -138,24 +140,24 @@ geometry_source = """#version 150
             gl_Position = m_pv * vec4(vec2(0.0, size.y) - anchor, 0.0, 1.0);
             uv = vec2(uv_l, uv_t);
             EmitVertex();
-    
+
             // lower left
             gl_Position = m_pv * vec4(vec2(0.0, 0.0) - anchor, 0.0, 1.0);
             uv = vec2(uv_l, uv_b);
             EmitVertex();
-    
+
             // upper right
             gl_Position = m_pv * vec4(vec2(size.x, size.y) - anchor, 0.0, 1.0);
             uv = vec2(uv_r, uv_t);
             EmitVertex();
-    
+
             // lower right
             gl_Position = m_pv * vec4(vec2(size.x, 0.0) - anchor, 0.0, 1.0);
             uv = vec2(uv_r, uv_b);
             EmitVertex();
 
             // We are done with this triangle strip now
-            EndPrimitive();    
+            EndPrimitive();
 
         }
     }
@@ -185,17 +187,14 @@ def get_default_shader():
     return program.get_attribute_view(color_start="Bn", color_end="Bn")
 
 
-class EmitterGroup(graphics.Group):
-    blend_src: BlendFactor
-    blend_dest: BlendFactor
+class EmitterGroup(Group):
 
     def __init__(self, texture, blend_src, blend_dest, program, parent=None):
         super().__init__(parent=parent)
         self.texture = texture
         self.set_shader_program(program)
-        self.set_texture(texture)
+        self.set_texture(texture, 0)
         self.set_blend(blend_src, blend_dest)
-        self.program = program
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.texture})"
@@ -252,9 +251,11 @@ class Emitter(event.EventDispatcher):
         self._resolve_anchor()
 
         self._program = program or get_default_shader()
-        self._batch = batch or graphics.get_default_batch()
+        self._batch = batch
+        self._blend_src = blend_src
+        self._blend_dest = blend_dest
         self._user_group = group
-        self._group = self.group_class(self._texture, blend_src, blend_dest, self.program, group)
+        self._group = self.get_emitter_group()
         self._create_vertex_list()
 
     def _create_vertex_list(self):
@@ -284,11 +285,8 @@ class Emitter(event.EventDispatcher):
     def program(self, program):
         if self._program == program:
             return
-        self._group = self.group_class(self._texture,
-                                       self._group.blend_src,
-                                       self._group.blend_dest,
-                                       program,
-                                       self._user_group)
+        self._program = program
+        self._group = self.get_emitter_group()
         if (self._batch and
                 self._batch.update_shader(self._vertex_list, GeometryMode.POINTS, self._group, program)):
             # Exit early if changing domain is not needed.
@@ -312,6 +310,9 @@ class Emitter(event.EventDispatcher):
         self._texture = None
         self._group = None
 
+    def get_emitter_group(self):
+        return self.group_class(self._texture, self._blend_src, self._blend_dest, self._program, self._user_group)
+
     def _animate(self, dt):
         self._frame_index += 1
         if self._frame_index >= len(self._animation.frames):
@@ -333,22 +334,22 @@ class Emitter(event.EventDispatcher):
 
     def _set_texture(self, texture):
         previous_size = self._texture.width, self._texture.height
-        if texture.key != self._texture.key:
-            self._group = self._group.__class__(texture,
-                                                self._group.blend_src,
-                                                self._group.blend_dest,
-                                                self._group.program,
-                                                self._group.parent)
-            self._vertex_list.delete()
-            self._texture = texture
-            self._resolve_anchor()
-            self._create_vertex_list()
-        else:
-            self._texture = texture
-            self._vertex_list.texture_uv[:] = texture.uv
-            self._resolve_anchor()
-            if self._anchor is not None or (texture.width, texture.height) != previous_size:
-                self._update_anchor()
+        texture_changed = texture.key != self._texture.key
+        self._texture = texture
+        self._resolve_anchor()
+
+        if texture_changed:
+            self._group = self.get_emitter_group()
+            if self._batch is not None:
+                self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, self._batch)
+            else:
+                self._vertex_list.delete()
+                self._create_vertex_list()
+                return
+
+        self._vertex_list.texture_uv[:] = texture.uv
+        if self._anchor is not None or (texture.width, texture.height) != previous_size:
+            self._update_anchor()
 
     def _update_anchor(self):
         texture = self._texture
@@ -359,6 +360,56 @@ class Emitter(event.EventDispatcher):
             return
 
         self._anchor_x, self._anchor_y = self._anchor.get_position(self._texture.width, self._texture.height)
+
+    @property
+    def blend_mode(self):
+        """The current blend factors applied to this emitter."""
+        return self._blend_src, self._blend_dest
+
+    @blend_mode.setter
+    def blend_mode(self, modes):
+        src, dst = modes
+        if src == self._blend_src and dst == self._blend_dest:
+            return
+
+        self._blend_src = src
+        self._blend_dest = dst
+        self._group = self.get_emitter_group()
+        if self._batch is not None:
+            self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, self._batch)
+
+    @property
+    def batch(self):
+        """The batch that owns this emitter's vertex list."""
+        return self._batch
+
+    @batch.setter
+    def batch(self, batch):
+        if self._batch == batch:
+            return
+
+        if batch is not None and self._batch is not None:
+            self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, batch)
+            self._batch = batch
+        else:
+            self._vertex_list.delete()
+            self._batch = batch
+            self._create_vertex_list()
+
+    @property
+    def group(self):
+        """The user-supplied parent group."""
+        return self._user_group
+
+    @group.setter
+    def group(self, group):
+        if self._user_group == group:
+            return
+
+        self._user_group = group
+        self._group = self.get_emitter_group()
+        if self._batch is not None:
+            self._batch.migrate(self._vertex_list, GeometryMode.POINTS, self._group, self._batch)
 
     @property
     def anchor(self):
@@ -412,6 +463,20 @@ class Emitter(event.EventDispatcher):
     def position(self, position: tuple[int | float, int | float, int | float]):
         self._x, self._y, self._z = position
         self._vertex_list.position[:] = position
+
+    def draw(self):
+        """Draw the emitter without a batch."""
+        ctx = pyglet.graphics.api.core.current_context
+        draw_ctx = DrawContext(
+            surface_ctx=ctx,
+            backend_ctx=None,
+            draw_pass=BatchDrawOptions().resolve(ctx),
+            renderer=ctx.renderer,
+        )
+        draw_ctx.begin()
+        self._group.set_state_recursive(draw_ctx)
+        self._vertex_list.draw(GeometryMode.POINTS)
+        self._group.unset_state_recursive(draw_ctx)
 
     if _is_pyglet_doc_run:
         def on_animation_end(self):
@@ -510,7 +575,7 @@ class ParticleManager:
         emitter = Emitter(self._img, x, y, z, self.count, self.velocity, self.spread,
                           color_start=self.color_start, color_end=self.color_end,
                           scale_start=self.scale_start, scale_end=self.scale_end, rotation=self.rotation,
-                          batch=self._batch, group=self._group,
+                          batch=self._batch, group=self._group, program=self._program,
                           anchor=self._anchor if self._anchor is not None else self.anchor_position)
         pyglet.clock.schedule_once(self._delete_callback, self.lifespan, emitter)
         return emitter

--- a/pyglet/graphics/api/gl/texture.py
+++ b/pyglet/graphics/api/gl/texture.py
@@ -831,11 +831,6 @@ class GLTexture3D(_Texture3DShared[GLTextureRegion], GLTexture, UniformTextureSe
         ctx.glTexParameteri(target, GL_TEXTURE_MIN_FILTER, texture._gl_min_filter)
         ctx.glTexParameteri(target, GL_TEXTURE_MAG_FILTER, texture._gl_mag_filter)
 
-        base_image = images[0]
-        if base_image.anchor_x or base_image.anchor_y:
-            texture.anchor_x = base_image.anchor_x
-            texture.anchor_y = base_image.anchor_y
-
         texture.images = len(images)
 
         size = texture.width * texture.height * texture.images * len(internal_format)
@@ -849,7 +844,7 @@ class GLTexture3D(_Texture3DShared[GLTextureRegion], GLTexture, UniformTextureSe
         for i, image in enumerate(images):
             item = cls.region_class(0, 0, i, item_width, item_height, texture)
             items.append(item)
-            texture.upload(image, image.anchor_x, image.anchor_y, z=i)
+            texture.upload(image, 0, 0, z=i)
         ctx.glFlush()
 
         texture.items = items
@@ -997,7 +992,7 @@ class GLTextureArray(_TextureArrayShared[GLTextureArrayRegion], GLTexture, Unifo
         self._context.glBindTexture(self.target, self._handle)
 
     def _allocate_image(self, image: ImageData, layer: int) -> None:
-        self.upload(image, image.anchor_x, image.anchor_y, layer)
+        self.upload(image, 0, 0, layer)
 
     @classmethod
     def create_for_images(cls, images: Sequence[ImageData],
@@ -1029,11 +1024,6 @@ class GLTextureArray(_TextureArrayShared[GLTextureArrayRegion], GLTexture, Unifo
         ctx.glTexParameteri(target, GL_TEXTURE_MIN_FILTER, texture._gl_min_filter)
         ctx.glTexParameteri(target, GL_TEXTURE_MAG_FILTER, texture._gl_mag_filter)
 
-        base_image = images[0]
-        if base_image.anchor_x or base_image.anchor_y:
-            texture.anchor_x = base_image.anchor_x
-            texture.anchor_y = base_image.anchor_y
-
         texture.images = len(images)
 
         size = (texture.width * texture.height * texture.images * len(internal_format))
@@ -1045,7 +1035,7 @@ class GLTextureArray(_TextureArrayShared[GLTextureArrayRegion], GLTexture, Unifo
         for i, image in enumerate(images):
             item = cls.region_class(0, 0, i, item_width, item_height, texture)
             items.append(item)
-            texture.upload(image, image.anchor_x, image.anchor_y, z=i)
+            texture.upload(image, 0, 0, z=i)
         ctx.glFlush()
 
         texture.items = items

--- a/pyglet/graphics/api/webgl/texture.py
+++ b/pyglet/graphics/api/webgl/texture.py
@@ -756,11 +756,6 @@ class WebGLTexture3D(_Texture3DShared[WebGLTextureRegion], WebGLTexture, Uniform
         gl.texParameteri(target, GL_TEXTURE_MIN_FILTER, texture._gl_min_filter)
         gl.texParameteri(target, GL_TEXTURE_MAG_FILTER, texture._gl_mag_filter)
 
-        base_image = images[0]
-        if base_image.anchor_x or base_image.anchor_y:
-            texture.anchor_x = base_image.anchor_x
-            texture.anchor_y = base_image.anchor_y
-
         texture.images = len(images)
 
         size = (texture.width * texture.height * texture.images * len(internal_format))
@@ -772,7 +767,7 @@ class WebGLTexture3D(_Texture3DShared[WebGLTextureRegion], WebGLTexture, Uniform
         for i, image in enumerate(images):
             item = cls.region_class(0, 0, i, item_width, item_height, texture)
             items.append(item)
-            texture.upload(image, image.anchor_x, image.anchor_y, z=i)
+            texture.upload(image, 0, 0, z=i)
         gl.flush()
 
         texture.items = items
@@ -920,11 +915,6 @@ class WebGLTextureArray(_TextureArrayShared[WebGLTextureArrayRegion], WebGLTextu
             anisotropic_level=anisotropic_level,
             context=context,
         )
-        base_image = images[0]
-        if base_image.anchor_x or base_image.anchor_y:
-            texture.anchor_x = base_image.anchor_x
-            texture.anchor_y = base_image.anchor_y
-
         texture.images = len(images)
         texture.allocate(*images)
         texture.item_width = item_width
@@ -978,7 +968,7 @@ class WebGLTextureArray(_TextureArrayShared[WebGLTextureArrayRegion], WebGLTextu
         self._gl.bindTexture(self.target, self._handle)
 
     def _allocate_image(self, image: ImageData, layer: int) -> None:
-        self.upload(image, image.anchor_x, image.anchor_y, layer)
+        self.upload(image, 0, 0, layer)
 
 WebGLTextureArray.region_class = WebGLTextureArrayRegion
 WebGLTextureArrayRegion.region_class = WebGLTextureArrayRegion

--- a/pyglet/graphics/texture.py
+++ b/pyglet/graphics/texture.py
@@ -508,9 +508,9 @@ class Texture(_AbstractImage, GraphicsResource[Any, TextureKey]):
 
         You must have this texture bound before uploading data.
 
-        The image's anchor point will be aligned to the given ``x`` and ``y``
-        coordinates.  If this texture is a 3D texture, the ``z``
-        parameter gives the image slice to blit into.
+        The given ``x`` and ``y`` coordinates specify the lower-left pixel of
+        the upload. If this texture is a 3D texture, the ``z`` parameter gives
+        the image slice to upload into.
         The ``level`` parameter specifies the mipmap level to upload to.
         """
         if level < 0:
@@ -518,9 +518,6 @@ class Texture(_AbstractImage, GraphicsResource[Any, TextureKey]):
         if level >= self._mipmap_levels:
             msg = f"Mipmap level {level} is not initialized. Call init_mipmaps or generate_mipmaps first."
             raise ImageException(msg)
-        x -= self.anchor_x
-        y -= self.anchor_y
-
         self._begin_upload(image)
 
         self._update_subregion(image, x, y, z, level=level)
@@ -540,7 +537,7 @@ class Texture(_AbstractImage, GraphicsResource[Any, TextureKey]):
 
         The transformation is applied to the texture coordinates only;
         :py:meth:`~pyglet.graphics.texture.Texture.get_image_data` will fetch the
-        untransformed data from the GPU. The transformation is applied around the anchor point.
+        untransformed data from the GPU.
 
         Args:
             flip_x:
@@ -553,14 +550,10 @@ class Texture(_AbstractImage, GraphicsResource[Any, TextureKey]):
         """
         transform = self.get_region(0, 0, self.width, self.height)
         bl, br, tr, tl = 0, 1, 2, 3
-        transform.anchor_x = self.anchor_x
-        transform.anchor_y = self.anchor_y
         if flip_x:
             bl, br, tl, tr = br, bl, tr, tl
-            transform.anchor_x = self.width - self.anchor_x
         if flip_y:
             bl, br, tl, tr = tl, tr, bl, br
-            transform.anchor_y = self.height - self.anchor_y
         rotate %= 360
         if rotate < 0:
             rotate += 360
@@ -568,14 +561,10 @@ class Texture(_AbstractImage, GraphicsResource[Any, TextureKey]):
             pass
         elif rotate == 90:
             bl, br, tr, tl = br, tr, tl, bl
-            transform.anchor_x, transform.anchor_y = transform.anchor_y, transform.width - transform.anchor_x
         elif rotate == 180:
             bl, br, tr, tl = tr, tl, bl, br
-            transform.anchor_x = transform.width - transform.anchor_x
-            transform.anchor_y = transform.height - transform.anchor_y
         elif rotate == 270:
             bl, br, tr, tl = tl, bl, br, tr
-            transform.anchor_x, transform.anchor_y = transform.height - transform.anchor_y, transform.anchor_x
         else:
             raise ImageException("Only 90 degree rotations are supported.")
         if rotate in (90, 270):
@@ -757,10 +746,10 @@ class _Texture3DShared(_TextureSequenceItems[TRegion], Generic[TRegion]):
             self._bind_sequence_texture()
 
             for item, image in zip(self[index], images):  # Needs a test.
-                self.upload(image, image.anchor_x, image.anchor_y, item.z)
+                self.upload(image, 0, 0, item.z)
         else:
             image: ImageData =value
-            self.upload(image, image.anchor_x, image.anchor_y, self[index].z)
+            self.upload(image, 0, 0, self[index].z)
 
 
 class _TextureArrayShared(_TextureSequenceItems[TArrayRegion], Generic[TArrayRegion]):
@@ -795,7 +784,7 @@ class _TextureArrayShared(_TextureSequenceItems[TArrayRegion], Generic[TArrayReg
         start_length = len(self.items)
         item = self.region_class(0, 0, start_length, image.width, image.height, self)
 
-        self.upload(image, image.anchor_x, image.anchor_y, start_length)
+        self.upload(image, 0, 0, start_length)
         self.items.append(item)
         return item
 
@@ -839,13 +828,13 @@ class _TextureArrayShared(_TextureSequenceItems[TArrayRegion], Generic[TArrayReg
             for old_item, image in zip(self[index], images):
                 self._verify_size(image)
                 item = self.region_class(0, 0, old_item.z, image.width, image.height, self)
-                self.upload(image, image.anchor_x, image.anchor_y, old_item.z)
+                self.upload(image, 0, 0, old_item.z)
                 self.items[old_item.z] = item
         else:
             image: ImageData = value
             self._verify_size(image)
             item = self.region_class(0, 0, index, image.width, image.height, self)
-            self.upload(image, image.anchor_x, image.anchor_y, index)
+            self.upload(image, 0, 0, index)
             self.items[index] = item
 
 

--- a/pyglet/gui/ninepatch.py
+++ b/pyglet/gui/ninepatch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyglet.enums import BlendFactor, GeometryMode
+from pyglet.enums import Anchor, BlendFactor, GeometryMode
 from pyglet.sprite import Sprite
 
 if TYPE_CHECKING:
@@ -33,6 +33,7 @@ class NinePatch(Sprite):
     def __init__(self,
                  img: _AbstractImage | Animation,
                  x: float = 0, y: float = 0, z: float = 0,
+                 anchor: Anchor | str | tuple[float, float] | None = None,
                  width: int | None = None, height: int | None = None,
                  blend_src: BlendFactor = BlendFactor.SRC_ALPHA,
                  blend_dest: BlendFactor = BlendFactor.ONE_MINUS_SRC_ALPHA,
@@ -49,6 +50,11 @@ class NinePatch(Sprite):
                 The Y coordinate of the NinePatch.
             z:
                 The Z coordinate of the NinePatch.
+            anchor:
+                Anchor offset relative to the NinePatch's lower-left corner.
+                Pass a numeric ``(x, y)`` tuple for an explicit offset, or a
+                named anchor such as ``"bottom_center"``. Named anchors are
+                recalculated when the NinePatch dimensions change.
             width:
                 The desired width of the NinePatch. This must be
                 greater or equal to the provided image width.
@@ -65,9 +71,9 @@ class NinePatch(Sprite):
                 Optional parent group of the NinePatch.
         """
 
-        self._width = max(width, img.width)
-        self._height = max(height, img.height)
-        super().__init__(img, x, y, z, blend_src, blend_dest, batch, group)
+        self._width = max(width or img.width, img.width)
+        self._height = max(height or img.height, img.height)
+        super().__init__(img, x, y, z, anchor, blend_src, blend_dest, batch, group)
 
     @classmethod
     def create_around_layout(cls,
@@ -110,7 +116,12 @@ class NinePatch(Sprite):
         z = layout.z - 1
         width = int(layout.right - x + border)
         height = int(layout.top - y + border)
-        return cls(img, x, y, z, width, height, blend_src, blend_dest, batch, group)
+        return cls(img, x, y, z, width=width, height=height, blend_src=blend_src,
+                   blend_dest=blend_dest, batch=batch, group=group)
+
+    def _resolve_anchor(self) -> None:
+        if self._anchor is not None:
+            self._anchor_x, self._anchor_y = self._anchor.get_position(self._width, self._height)
 
     def _create_vertex_list(self) -> None:
         # Vertex layout for 9 quads:
@@ -155,11 +166,11 @@ class NinePatch(Sprite):
             center_width = self._width - edge_width - edge_width
             center_height = self._height - edge_height - edge_height
 
-            x0 = -img.anchor_x
+            x0 = -self._anchor_x
             x1 = x0 + edge_width
             x2 = x1 + center_width
             x3 = x2 + edge_width
-            y0 = -img.anchor_y
+            y0 = -self._anchor_y
             y1 = y0 + edge_height
             y2 = y1 + center_height
             y3 = y2 + edge_height
@@ -214,8 +225,7 @@ class NinePatch(Sprite):
     def rotation(self) -> float:
         """Clockwise rotation of the NinePatch, in degrees.
 
-        The NinePatch will be rotated about its image's (anchor_x, anchor_y)
-        position.
+        The NinePatch is rotated about its :attr:`anchor_position`.
         """
         return self._rotation
 
@@ -250,6 +260,7 @@ class NinePatch(Sprite):
     @width.setter
     def width(self, width: float):
         self._width = width
+        self._resolve_anchor()
         self._update_position()
 
     @property
@@ -263,6 +274,7 @@ class NinePatch(Sprite):
     @height.setter
     def height(self, height: float):
         self._height = height
+        self._resolve_anchor()
         self._update_position()
 
     @property

--- a/pyglet/gui/ninepatch.py
+++ b/pyglet/gui/ninepatch.py
@@ -62,15 +62,14 @@ class NinePatch(Sprite):
                 The desired height of the NinePatch. This must be
                 greater or equal to the provided image height.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``GL_ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the NinePatch to.
             group:
                 Optional parent group of the NinePatch.
         """
-
         self._width = max(width or img.width, img.width)
         self._height = max(height or img.height, img.height)
         super().__init__(img, x, y, z, anchor, blend_src, blend_dest, batch, group)
@@ -102,15 +101,14 @@ class NinePatch(Sprite):
             border:
                 Additional padding, in pixels, to place around the label.
             blend_src:
-                OpenGL blend source mode; for example, ``GL_SRC_ALPHA``.
+                Blend source factor.
             blend_dest:
-                OpenGL blend destination mode; for example, ``GL_ONE_MINUS_SRC_ALPHA``.
+                Blend destination factor.
             batch:
                 Optional batch to add the NinePatch to.
             group:
                 Optional parent group of the NinePatch.
         """
-
         x = layout.left - border
         y = layout.bottom - border
         z = layout.z - 1

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -465,8 +465,6 @@ class Slider(WidgetBase):
         self._knob_img = knob
         self._half_knob_width = knob.width / 2
         self._half_knob_height = knob.height / 2
-        self._knob_img.anchor_y = int(knob.height / 2)
-
         self._min_knob_x = x + edge
         self._max_knob_x = x + base.width - knob.width - edge
 
@@ -474,7 +472,10 @@ class Slider(WidgetBase):
         bg_group = Group(order=0, parent=group)
         fg_group = Group(order=1, parent=group)
         self._base_spr = pyglet.sprite.Sprite(self._base_img, x, y, batch=batch, group=bg_group)
-        self._knob_spr = pyglet.sprite.Sprite(self._knob_img, x+edge, y+base.height/2, batch=batch, group=fg_group)
+        self._knob_spr = pyglet.sprite.Sprite(
+            self._knob_img, x + edge, y + base.height / 2, batch=batch, group=fg_group,
+            anchor_y=int(knob.height / 2),
+        )
 
         self._value = 0
         self._in_update = False

--- a/pyglet/image/__init__.py
+++ b/pyglet/image/__init__.py
@@ -32,20 +32,15 @@ Remember that y-coordinates are always increasing upwards.
 Drawing images
 --------------
 
-To draw an image at some point on the screen::
+Images are displayed with sprites. The sprite owns positioning state such as
+its anchor point::
 
-    pic.blit(x, y, z)
-
-This assumes an appropriate view transform and projection have been applied.
-
-Some images have an intrinsic "anchor point": this is the point which will be
-aligned to the ``x`` and ``y`` coordinates when the image is drawn.  By
-default, the anchor point is the lower-left corner of the image.  You can use
-the anchor point to center an image at a given point, for example::
-
-    pic.anchor_x = pic.width // 2
-    pic.anchor_y = pic.height // 2
-    pic.blit(x, y, z)
+    sprite = pyglet.sprite.Sprite(
+        pic, x, y, z,
+        anchor_x=pic.width // 2,
+        anchor_y=pic.height // 2,
+    )
+    sprite.draw()
 
 Texture access
 --------------

--- a/pyglet/image/animation.py
+++ b/pyglet/image/animation.py
@@ -83,9 +83,8 @@ class Animation:
         The transformation is performed by manipulating the texture coordinates,
         which limits this operation to increments of 90 degrees.
 
-        The transformation is applied around the image's anchor point of
-        each frame.  The texture data is shared between the original animation
-        and the transformed animation.
+        The texture data is shared between the original animation and the
+        transformed animation.
         """
         frames = [AnimationFrame(frame.image.get_texture().get_transform(flip_x, flip_y, rotate),
                                  frame.duration) for frame in self.frames]
@@ -98,18 +97,14 @@ class Animation:
     def get_max_width(self) -> int:
         """Get the maximum image frame width.
 
-        This method is useful for determining texture space requirements: due
-        to the use of ``anchor_x`` the actual required viewing area during
-        playback may be larger.
+        This method is useful for determining texture space requirements.
         """
         return max([frame.image.width for frame in self.frames])
 
     def get_max_height(self) -> int:
         """Get the maximum image frame height.
 
-        This method is useful for determining texture space requirements: due
-        to the use of ``anchor_y`` the actual required viewing area during
-        playback may be larger.
+        This method is useful for determining texture space requirements.
         """
         return max([frame.image.height for frame in self.frames])
 

--- a/pyglet/image/base.py
+++ b/pyglet/image/base.py
@@ -39,12 +39,6 @@ class ImageException(Exception):
 class _AbstractImage(ABC):
     """Abstract class representing an image."""
 
-    anchor_x: int = 0
-    """X coordinate of anchor, relative to left edge of image data."""
-
-    anchor_y: int = 0
-    """Y coordinate of anchor, relative to bottom edge of image data."""
-
     def __init__(self, width: int, height: int) -> None:
         """Initialized in subclass."""
         self.width = width
@@ -261,13 +255,7 @@ class ImageData(_AbstractImage):
 
     def create_texture(self, cls: type[Texture]) -> Texture:
         """Given a texture class, create a texture containing this image."""
-        texture = cls.create_from_image(self)
-
-        if self.anchor_x or self.anchor_y:
-            texture.anchor_x = self.anchor_x
-            texture.anchor_y = self.anchor_y
-
-        return texture
+        return cls.create_from_image(self)
 
     def get_texture(self) -> Texture:
         if not self._current_texture:
@@ -475,13 +463,7 @@ class CompressedImageData(_AbstractImage):
 
     def create_texture(self, cls: type[CompressedTexture]) -> Texture:
         """Given a texture class, create a texture containing this image."""
-        texture = cls.create_from_image(self)
-
-        if self.anchor_x or self.anchor_y:
-            texture.anchor_x = self.anchor_x
-            texture.anchor_y = self.anchor_y
-
-        return texture
+        return cls.create_from_image(self)
 
     def get_texture(self) -> CompressedTexture:
         if not self._current_texture:

--- a/pyglet/media/player.py
+++ b/pyglet/media/player.py
@@ -621,8 +621,6 @@ class VideoPlayer(AudioPlayer):
 
         # Flip coordinates so output is correct orientation.
         self._texture = self._texture.get_transform(flip_y=True)
-        # After flipping, the anchor_y is set to the top of the image. We want to keep it at the bottom.
-        self._texture.anchor_y = 0
         return self._texture
 
     def _create_sprite(self) -> None:

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -33,9 +33,8 @@ sub-pixel artifacts.  If you require to use floats, for example for smoother
 animations, you can set the ``subpixel`` parameter to ``True`` when creating
 the sprite (:since: pyglet 1.2).
 
-The sprite's positioning, rotation and scaling all honor the original
-image's anchor (:py:attr:`~pyglet.image.ImageData.anchor_x`,
-:py:attr:`~pyglet.image.ImageData.anchor_y`).
+The sprite's positioning, rotation and scaling honor its
+:py:attr:`~pyglet.sprite.Sprite.anchor_position`.
 
 
 Drawing multiple sprites
@@ -81,7 +80,7 @@ if TYPE_CHECKING:
     from pyglet.graphics.shader import ShaderProgram
 
 from pyglet.graphics import Group
-from pyglet.enums import BlendFactor, GeometryMode, GraphicsAPI
+from pyglet.enums import Anchor, BlendFactor, GeometryMode, GraphicsAPI
 from pyglet.image.base import Animation, ImageData
 from pyglet.graphics.texture import TextureArrayRegion
 
@@ -152,6 +151,9 @@ class Sprite(event.EventDispatcher):
 
     _batch = None
     _animation = None
+    _anchor_x = 0.0
+    _anchor_y = 0.0
+    _anchor: Anchor | None = None
     _frame_index = 0
     _paused = False
     _rotation = 0
@@ -168,6 +170,7 @@ class Sprite(event.EventDispatcher):
     def __init__(self,
                  img: ImageData | Texture | Animation,
                  x: float = 0, y: float = 0, z: float = 0,
+                 anchor: Anchor | str | tuple[float, float] | None = None,
                  blend_src: BlendFactor = BlendFactor.SRC_ALPHA,
                  blend_dest: BlendFactor = BlendFactor.ONE_MINUS_SRC_ALPHA,
                  batch: Batch | None = None,
@@ -185,6 +188,12 @@ class Sprite(event.EventDispatcher):
                 Y coordinate of the sprite.
             z:
                 Z coordinate of the sprite.
+            anchor:
+                Anchor offset relative to the image's lower-left corner. Pass
+                a numeric ``(x, y)`` tuple for an explicit offset, or a named
+                anchor such as ``"bottom_center"`` or
+                :attr:`~pyglet.enums.Anchor.TOP`. Named anchors are
+                recalculated when the image or animation frame changes.
             blend_src:
                 OpenGL blend source mode.  The default is suitable for
                 compositing sprites drawn from back-to-front.
@@ -202,13 +211,21 @@ class Sprite(event.EventDispatcher):
                 A specific shader program to initialize the sprite with. By default, a pre-made shader will be chosen
                 based on the texture type passed. Sprite colors are uploaded as four unsigned bytes; custom programs
                 must use ``program.get_attribute_view(colors="Bn")`` so the values are normalized for the shader.
-
-        .. versionadded:: 2.0.16
-           The *program* parameter.
+        .. versionchanged:: 2.0.16
+           Added *program* parameter.
+        .. versionchanged:: 3.0
+           Added *anchor* parameter.
         """
         self._x = x
         self._y = y
         self._z = z
+        self._anchor_x = 0.0
+        self._anchor_y = 0.0
+        self._anchor = None
+        if isinstance(anchor, tuple):
+            self._anchor_x, self._anchor_y = anchor
+        elif anchor is not None:
+            self._anchor = Anchor(anchor)
 
         if isinstance(img, Animation):
             self._animation = img
@@ -218,6 +235,8 @@ class Sprite(event.EventDispatcher):
                 clock.schedule_once(self._animate, self._next_dt)
         else:
             self._texture = img.get_texture()
+
+        self._resolve_anchor()
 
         if not program:
             if isinstance(img, TextureArrayRegion):
@@ -389,11 +408,12 @@ class Sprite(event.EventDispatcher):
                 clock.schedule_once(self._animate, self._next_dt)
         else:
             self._set_texture(img.get_texture())
-        self._update_position()
 
     def _set_texture(self, texture: Texture) -> None:
+        previous_size = self._texture.width, self._texture.height
         texture_changed = texture.key != self._texture.key
         self._texture = texture
+        self._resolve_anchor()
 
         if texture_changed:
             self._group = self.get_sprite_group()
@@ -405,6 +425,10 @@ class Sprite(event.EventDispatcher):
                 return
 
         self._vertex_list.tex_coords[:] = texture.tex_coords
+
+        # Vertices need to be updated when texture size or anchor differs.
+        if self._anchor is not None or (texture.width, texture.height) != previous_size:
+            self._update_position()
 
     def _create_vertex_list(self) -> None:
         self._vertex_list = self.program.vertex_list_indexed(
@@ -421,8 +445,8 @@ class Sprite(event.EventDispatcher):
             return 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
         img = self._texture
-        x1 = -img.anchor_x
-        y1 = -img.anchor_y
+        x1 = -self._anchor_x
+        y1 = -self._anchor_y
         x2 = x1 + img.width
         y2 = y1 + img.height
 
@@ -434,6 +458,56 @@ class Sprite(event.EventDispatcher):
 
     def _update_position(self) -> None:
         self._vertex_list.position[:] = self._get_vertices()
+
+    def _resolve_anchor(self) -> None:
+        if self._anchor is None:
+            return
+
+        self._anchor_x, self._anchor_y = self._anchor.get_position(self._texture.width, self._texture.height)
+
+    @property
+    def anchor(self) -> Anchor | None:
+        """The named anchor position, or ``None`` when using a numeric anchor."""
+        return self._anchor
+
+    @anchor.setter
+    def anchor(self, anchor: Anchor | str | None) -> None:
+        self._anchor = Anchor(anchor) if anchor is not None else None
+        self._resolve_anchor()
+        self._update_position()
+
+    @property
+    def anchor_x(self) -> float:
+        """X coordinate of the anchor, relative to the image's left edge."""
+        return self._anchor_x
+
+    @anchor_x.setter
+    def anchor_x(self, anchor_x: float) -> None:
+        self._anchor = None
+        self._anchor_x = anchor_x
+        self._update_position()
+
+    @property
+    def anchor_y(self) -> float:
+        """Y coordinate of the anchor, relative to the image's bottom edge."""
+        return self._anchor_y
+
+    @anchor_y.setter
+    def anchor_y(self, anchor_y: float) -> None:
+        self._anchor = None
+        self._anchor_y = anchor_y
+        self._update_position()
+
+    @property
+    def anchor_position(self) -> tuple[float, float]:
+        """The anchor's ``(x, y)`` offset from the sprite's lower-left corner."""
+        return self._anchor_x, self._anchor_y
+
+    @anchor_position.setter
+    def anchor_position(self, position: tuple[float, float]) -> None:
+        self._anchor = None
+        self._anchor_x, self._anchor_y = position
+        self._update_position()
 
     def get_sprite_group(self) -> SpriteGroup | Group:
         """Creates and returns a group to be used to render the sprite.
@@ -491,8 +565,7 @@ class Sprite(event.EventDispatcher):
     def rotation(self) -> float:
         """Clockwise rotation of the sprite, in degrees.
 
-        The sprite image will be rotated about its image's (anchor_x, anchor_y)
-        position.
+        The sprite is rotated about its :attr:`anchor_position`.
         """
         return self._rotation
 
@@ -805,6 +878,7 @@ class MultiTextureSprite(Sprite):
     def __init__(self,
                  images: dict[str, ImageData | Texture | Animation],
                  x: float = 0, y: float = 0, z: float = 0,
+                 anchor: Anchor | str | tuple[float, float] | None = None,
                  blend_src: BlendFactor = BlendFactor.SRC_ALPHA,
                  blend_dest: BlendFactor = BlendFactor.ONE_MINUS_SRC_ALPHA,
                  batch: Batch | None = None,
@@ -823,6 +897,11 @@ class MultiTextureSprite(Sprite):
                 Y coordinate of the sprite.
             z:
                 Z coordinate of the sprite.
+            anchor:
+                Anchor offset relative to the largest layer's lower-left
+                corner. Pass a numeric ``(x, y)`` tuple for an explicit
+                offset, or a named anchor that is recalculated when the
+                anchor texture changes.
             blend_src:
                 OpenGL blend source mode.  The default is suitable for
                 compositing sprites drawn from back-to-front.
@@ -841,7 +920,6 @@ class MultiTextureSprite(Sprite):
                 a generated multi-texture shader will be chosen based on the layer types passed.
 
         .. versionadded:: 3.0
-           The MultiTextureSprite class.
         """
         if not images:
             msg = "MultiTextureSprite requires at least one layer."
@@ -870,7 +948,7 @@ class MultiTextureSprite(Sprite):
         if program is None:
             program = get_default_multitexture_shader(self._textures)
 
-        super().__init__(self._texture, x, y, z, blend_src, blend_dest, batch, group, subpixel, program)
+        super().__init__(self._texture, x, y, z, anchor, blend_src, blend_dest, batch, group, subpixel, program)
         self._schedule_all_animations()
 
     def _schedule_all_animations(self) -> None:

--- a/pyglet/sprite.py
+++ b/pyglet/sprite.py
@@ -195,10 +195,10 @@ class Sprite(event.EventDispatcher):
                 :attr:`~pyglet.enums.Anchor.TOP`. Named anchors are
                 recalculated when the image or animation frame changes.
             blend_src:
-                OpenGL blend source mode.  The default is suitable for
+                Blend source factor. The default is suitable for
                 compositing sprites drawn from back-to-front.
             blend_dest:
-                OpenGL blend destination mode.  The default is suitable for
+                Blend destination factor. The default is suitable for
                 compositing sprites drawn from back-to-front.
             batch:
                 Optional batch to add the sprite to.
@@ -903,10 +903,10 @@ class MultiTextureSprite(Sprite):
                 offset, or a named anchor that is recalculated when the
                 anchor texture changes.
             blend_src:
-                OpenGL blend source mode.  The default is suitable for
+                Blend source factor. The default is suitable for
                 compositing sprites drawn from back-to-front.
             blend_dest:
-                OpenGL blend destination mode.  The default is suitable for
+                Blend destination factor. The default is suitable for
                 compositing sprites drawn from back-to-front.
             batch:
                 Optional batch to add the sprite to.

--- a/tests/integration/graphics/test_texture2d.py
+++ b/tests/integration/graphics/test_texture2d.py
@@ -52,24 +52,6 @@ class TestTextureUploadFetch(unittest.TestCase):
         self.assertEqual(data[9 * 4], 7)
         self.assertEqual(data[10 * 4], 7)
 
-    def test_upload_respects_texture_anchor(self):
-        width, height = 4, 4
-        base = self.create_image(width, height, 0)
-        texture = Texture.create(width, height, blank_data=True)
-        texture.upload(base, 0, 0, 0)
-
-        texture.anchor_x = 1
-        texture.anchor_y = 1
-        image = self.create_image(2, 2, 9)
-        texture.upload(image, 1, 1, 0)
-
-        fetched = texture.get_image_data()
-        data = fetched.get_bytes('RGBA', fetched.width * 4)
-        self.assertEqual(data[0 * 4], 9)
-        self.assertEqual(data[1 * 4], 9)
-        self.assertEqual(data[4 * 4], 9)
-        self.assertEqual(data[5 * 4], 9)
-
     def test_upload_invalid_level(self):
         texture = Texture.create(4, 4, blank_data=True)
         with self.assertRaisesRegex(Exception, "Mipmap level must be non-negative"):

--- a/tests/unit/test_sprite.py
+++ b/tests/unit/test_sprite.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import pyglet
+from pyglet.enums import Anchor
 from pyglet.graphics.texture import TextureArrayRegion
 
 
@@ -223,8 +224,6 @@ def test_init_uses_array_shader_for_texture_array_region(monkeypatch):
     texture = MagicMock()
     texture.width = 1
     texture.height = 1
-    texture.anchor_x = 0
-    texture.anchor_y = 0
     texture.tex_coords = (0.0,) * 12
     texture.id = 1
 
@@ -245,8 +244,6 @@ def _mock_texture(texture_id: int = 1, width: int = 32, height: int = 32, target
     texture.id = texture_id
     texture.width = width
     texture.height = height
-    texture.anchor_x = 0
-    texture.anchor_y = 0
     texture.target = target
     texture.tex_coords = (0.0,) * 12
     texture.get_texture.return_value = texture
@@ -257,6 +254,89 @@ def _mock_image(texture):
     image = MagicMock()
     image.get_texture.return_value = texture
     return image
+
+
+def test_sprite_owns_anchor():
+    sprite = pyglet.sprite.Sprite(_mock_image(_mock_texture(width=32, height=24)), anchor=(4, 6))
+    try:
+        assert sprite.anchor_position == (4, 6)
+        assert sprite._get_vertices() == (-4, -6, 0, 28, -6, 0, 28, 18, 0, -4, 18, 0)  # noqa: SLF001
+    finally:
+        sprite.delete()
+
+
+def test_sprite_anchor_properties_update_vertices():
+    sprite = pyglet.sprite.Sprite(_mock_image(_mock_texture()))
+    try:
+        sprite._update_position = MagicMock()  # noqa: SLF001
+
+        sprite.anchor_x = 3
+        sprite.anchor_y = 5
+        sprite.anchor_position = (7, 11)
+
+        assert sprite.anchor_x == 7
+        assert sprite.anchor_y == 11
+        assert sprite._update_position.call_count == 3  # noqa: SLF001
+    finally:
+        sprite.delete()
+
+
+def test_named_sprite_anchor_tracks_replacement_image_dimensions():
+    texture = _mock_texture(texture_id=1, width=32, height=24)
+    texture.key = 1
+    sprite = pyglet.sprite.Sprite(_mock_image(texture), anchor="bottom_center")
+    try:
+        assert sprite.anchor is Anchor.BOTTOM_CENTER
+        assert sprite.anchor_position == (16, 0)
+
+        replacement = _mock_texture(texture_id=2, width=48, height=18)
+        replacement.key = 2
+        sprite.image = _mock_image(replacement)
+
+        assert sprite.anchor_position == (24, 0)
+
+        sprite.anchor = "top"
+        assert sprite.anchor is Anchor.TOP
+        assert sprite.anchor_position == (24, 18)
+
+        sprite.anchor_x = 5
+        assert sprite.anchor is None
+        assert sprite.anchor_position == (5, 18)
+    finally:
+        sprite.delete()
+
+
+def test_same_size_image_replacement_without_named_anchor_skips_position_update():
+    texture = _mock_texture(texture_id=1)
+    texture.key = 1
+    sprite = pyglet.sprite.Sprite(_mock_image(texture), batch=MagicMock())
+    try:
+        sprite._update_position = MagicMock()  # noqa: SLF001
+        replacement = _mock_texture(texture_id=2)
+        replacement.key = 2
+
+        sprite.image = _mock_image(replacement)
+
+        sprite._update_position.assert_not_called()  # noqa: SLF001
+    finally:
+        sprite.delete()
+
+
+def test_different_size_image_replacement_updates_position_without_named_anchor():
+    texture = _mock_texture(texture_id=1)
+    texture.key = 1
+    sprite = pyglet.sprite.Sprite(_mock_image(texture), batch=MagicMock())
+    try:
+        sprite._update_position = MagicMock()  # noqa: SLF001
+        replacement = _mock_texture(texture_id=2, width=48, height=24)
+        replacement.key = 2
+
+        sprite.image = _mock_image(replacement)
+
+        sprite._update_position.assert_called_once()  # noqa: SLF001
+    finally:
+        sprite.delete()
+
 
 
 def test_multitexture_init_uses_multitexture_shader_getter(monkeypatch):


### PR DESCRIPTION
This removes image and texture's anchor_x/anchor_y. Instead, this functionality has been moved to sprites. 

Sprites now have an anchor parameter that takes either the new Anchor StrEnum for a relative anchor point, or a tuple of floats for an absolute anchor.

This resolves a lot of inconsistencies with image anchor in the code. We've also had requests in the past from users on issues with setting different anchors for different sprites with the same resource.

Also fixes an issue with sprite not updating the size of the sprite when assigning a new texture that differs in dimensions or a new anchor is set.

Fixes geometry and particles section as well.