### PR TITLE
Permit building with flit core 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
According to flit [changelog](https://flit.pypa.io/en/stable/history.html), this project does not use any of removed features in flit core 4, and this project use `[project]` instead of removed `[tool.flit.metadata]`, so it should be safe to build via flit-core 4. I've already tested this locally and it looks good.

Therefore this PR relax the requirement of flit core to `>=3.2,<5` to make the project be able to build with flit core 4 and make use of the new features coming with flit core 4.

This PR is inspired by AOSC OS [downstream patch](https://github.com/AOSC-Dev/aosc-os-abbs/blob/stable/lang-python/pyglet/autobuild/patches/0001-AOSC-flit-core-4.patch) and works fine in AOSC OS.