### PR TITLE
Fix Mat3.__invert__ returning the transpose of the inverse

### DIFF
--- a/pyglet/math.py
+++ b/pyglet/math.py
@@ -1054,10 +1054,11 @@ class Mat3(_typing.NamedTuple):
         # get determinant reciprocal
         rep = 1.0 / det
 
-        # get inverse: A^-1 = def(A)^-1 * adj(A)
-        return Mat3(*(a * rep, b * rep, c * rep,
-                      d * rep, e * rep, f * rep,
-                      g * rep, h * rep, i * rep))
+        # get inverse: A^-1 = det(A)^-1 * adj(A).
+        # adj(A) is the transpose of the cofactor matrix computed above.
+        return Mat3(*(a * rep, d * rep, g * rep,
+                      b * rep, e * rep, h * rep,
+                      c * rep, f * rep, i * rep))
 
     def __round__(self, ndigits: int | None = None) -> Mat3:
         return Mat3(*(round(v, ndigits) for v in self))

--- a/tests/unit/math/test_mat.py
+++ b/tests/unit/math/test_mat.py
@@ -124,6 +124,14 @@ def test_mat3_inversion(mat3):
     # Confirm that Matrix @ its inverse == identity Matrix:
     assert round(mat3 @ inverse_2, 9) == Mat3()
 
+    # The identity matrix is its own transpose, so it cannot detect an inverse
+    # that is returned transposed. Use a non-symmetric matrix as well:
+    m = Mat3(2, 1, 0,
+             0, 3, 1,
+             1, 0, 4)
+    assert round(m @ ~m, 9) == Mat3()
+    assert round(~m @ m, 9) == Mat3()
+
 
 def test_mat3_associative_mul():
     swap_xy = Mat3(0, 1, 0, 1, 0, 0, 0, 0, 1)


### PR DESCRIPTION
`Mat3.__invert__` (`pyglet/math.py:1029`) returns the transpose of the inverse. The cofactors and the determinant expansion are both correct; the values are just handed to the `Mat3(...)` constructor in cofactor order, and `adj(A)` is the transpose of the cofactor matrix. `Mat4.__invert__` right below it does not have this problem.

Measured on 5643960:

* `M @ ~M` is not the identity for 5000/5000 random non-singular `Mat3`, worst deviation 3617. After the fix: 0/5000, worst 2.3e-13. `Mat4` control: 0/5000 before and after.
* `M @ (~M transposed)` is the identity to 2.2e-16 on current main — the result is exactly the transpose, not merely wrong.
* Concrete 2D affine, `Mat3().translate(10, 20).rotate(30)`: `(3, 4, 1)` maps to `(10.5981, 24.9641, 1.0)`, and applying the inverse to that gives `(-3.3038, 26.9186, -504.3332)` instead of the original point. With the fix it returns `(3.0, 4.0, 1.0)`.

`test_mat3_inversion` only inverted the identity fixture, which is its own transpose, so the suite could not see this — it still carries `# TODO: add long hand inversion for mat3`. I extended it with a non-symmetric matrix: it fails on current main, and it also fails two other candidate fixes I tried (swapping only one off-diagonal pair, and flipping the off-diagonal signs), so it is not satisfied by anything transpose-shaped.

`Mat3` is not referenced anywhere else under `pyglet/`, so the blast radius is code calling `~Mat3` directly.

How I found it: fuzzing `pyglet.math` against numpy, using `M @ ~M == I` as the oracle because it needs no assumption about storage order. Not something I hit in an application. AI-assisted (Claude); the measurements are mine and reproducible. Not tested: anything beyond the existing singular-matrix warning path.
