### PR TITLE
Extension fallback behavior for GL

### DIFF
--- a/pyglet/graphics/api/gl/context.py
+++ b/pyglet/graphics/api/gl/context.py
@@ -7,6 +7,7 @@ from typing import Callable, TYPE_CHECKING
 from pyglet.graphics import GraphicsAPIError, GraphicsIntegrationError
 from pyglet.graphics.api.gl import gl, gl_info
 from pyglet.graphics.api.gl.base import GLSharedObjectSpace
+from pyglet.graphics.api.gl.gl_fallback import apply_extension_function_fallbacks
 from pyglet.graphics.api.base import SurfaceContext, NullContext
 from pyglet.graphics.api.gl.gl import (
     GL_ALREADY_SIGNALED,
@@ -175,8 +176,9 @@ class OpenGLSurfaceContext(SurfaceContext, GLFunctions):
             # Move this later to a better platform implementation.
             if not self.platform_func and self.platform_func_class:
                 self.platform_func = self.platform_func_class()
-            self.uniform_getters, self.uniform_setters = self._get_uniform_func_tables()
             self._info.query(self)
+            apply_extension_function_fallbacks(self.info, self)
+            self.uniform_getters, self.uniform_setters = self._get_uniform_func_tables()
 
         self.object_space.flush(self)
 

--- a/pyglet/graphics/api/gl/gl_fallback.py
+++ b/pyglet/graphics/api/gl/gl_fallback.py
@@ -1,0 +1,98 @@
+"""Fallbacks for OpenGL functions provided by extensions.
+
+Some extensions expose functionality that later became core OpenGL under a
+suffixed function name. This module lets GL backends use those
+extension functions without changing module globals.
+"""
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ExtensionInfo(Protocol):
+    """The extension information needed to select function fallbacks."""
+
+    def have_extension(self, extension: str) -> bool:
+        """Return whether an extension is available on this context."""
+
+
+EXTENSION_FUNCTION_FALLBACKS: dict[str, dict[str, str]] = {
+    "GL_EXT_separate_shader_objects": {
+        "glActiveShaderProgram": "glActiveShaderProgramEXT",
+        "glBindProgramPipeline": "glBindProgramPipelineEXT",
+        "glCreateShaderProgramv": "glCreateShaderProgramvEXT",
+        "glDeleteProgramPipelines": "glDeleteProgramPipelinesEXT",
+        "glGenProgramPipelines": "glGenProgramPipelinesEXT",
+        "glGetProgramPipelineInfoLog": "glGetProgramPipelineInfoLogEXT",
+        "glGetProgramPipelineiv": "glGetProgramPipelineivEXT",
+        "glIsProgramPipeline": "glIsProgramPipelineEXT",
+        "glProgramParameteri": "glProgramParameteriEXT",
+        "glProgramUniform1f": "glProgramUniform1fEXT",
+        "glProgramUniform1fv": "glProgramUniform1fvEXT",
+        "glProgramUniform1i": "glProgramUniform1iEXT",
+        "glProgramUniform1iv": "glProgramUniform1ivEXT",
+        "glProgramUniform1ui": "glProgramUniform1uiEXT",
+        "glProgramUniform1uiv": "glProgramUniform1uivEXT",
+        "glProgramUniform2f": "glProgramUniform2fEXT",
+        "glProgramUniform2fv": "glProgramUniform2fvEXT",
+        "glProgramUniform2i": "glProgramUniform2iEXT",
+        "glProgramUniform2iv": "glProgramUniform2ivEXT",
+        "glProgramUniform2ui": "glProgramUniform2uiEXT",
+        "glProgramUniform2uiv": "glProgramUniform2uivEXT",
+        "glProgramUniform3f": "glProgramUniform3fEXT",
+        "glProgramUniform3fv": "glProgramUniform3fvEXT",
+        "glProgramUniform3i": "glProgramUniform3iEXT",
+        "glProgramUniform3iv": "glProgramUniform3ivEXT",
+        "glProgramUniform3ui": "glProgramUniform3uiEXT",
+        "glProgramUniform3uiv": "glProgramUniform3uivEXT",
+        "glProgramUniform4f": "glProgramUniform4fEXT",
+        "glProgramUniform4fv": "glProgramUniform4fvEXT",
+        "glProgramUniform4i": "glProgramUniform4iEXT",
+        "glProgramUniform4iv": "glProgramUniform4ivEXT",
+        "glProgramUniform4ui": "glProgramUniform4uiEXT",
+        "glProgramUniform4uiv": "glProgramUniform4uivEXT",
+        "glProgramUniformMatrix2fv": "glProgramUniformMatrix2fvEXT",
+        "glProgramUniformMatrix2x3fv": "glProgramUniformMatrix2x3fvEXT",
+        "glProgramUniformMatrix2x4fv": "glProgramUniformMatrix2x4fvEXT",
+        "glProgramUniformMatrix3fv": "glProgramUniformMatrix3fvEXT",
+        "glProgramUniformMatrix3x2fv": "glProgramUniformMatrix3x2fvEXT",
+        "glProgramUniformMatrix3x4fv": "glProgramUniformMatrix3x4fvEXT",
+        "glProgramUniformMatrix4fv": "glProgramUniformMatrix4fvEXT",
+        "glProgramUniformMatrix4x2fv": "glProgramUniformMatrix4x2fvEXT",
+        "glProgramUniformMatrix4x3fv": "glProgramUniformMatrix4x3fvEXT",
+        "glUseProgramStages": "glUseProgramStagesEXT",
+        "glValidateProgramPipeline": "glValidateProgramPipelineEXT",
+    },
+    "GL_EXT_geometry_shader": {
+        "glFramebufferTexture": "glFramebufferTextureEXT",
+    },
+    "GL_OES_draw_elements_base_vertex": {
+        "glDrawElementsBaseVertex": "glDrawElementsBaseVertexOES",
+        "glDrawElementsInstancedBaseVertex": "glDrawElementsInstancedBaseVertexOES",
+        "glDrawRangeElementsBaseVertex": "glDrawRangeElementsBaseVertexOES",
+        "glMultiDrawElementsBaseVertex": "glMultiDrawElementsBaseVertexEXT",
+    },
+    "GL_OES_tessellation_shader": {
+        "glPatchParameteri": "glPatchParameteriOES",
+    },
+}
+
+
+def get_extension_function_fallbacks(info: ExtensionInfo) -> dict[str, str]:
+    """Return regular function names mapped to extension function names."""
+    fallbacks = {}
+    for extension, extension_fallbacks in EXTENSION_FUNCTION_FALLBACKS.items():
+        if info.have_extension(extension):
+            fallbacks.update(extension_fallbacks)
+    return fallbacks
+
+
+def apply_extension_function_fallbacks(info: ExtensionInfo, functions: object) -> None:
+    """Use available extension functions in place of their regular names.
+
+    ``functions`` must be local to one surface context. Mutating a generated
+    module-level GL binding would incorrectly share a decision between
+    contexts and backends.
+    """
+    for function_name, extension_name in get_extension_function_fallbacks(info).items():
+        setattr(functions, function_name, getattr(functions, extension_name))

--- a/tests/integration/graphics/opengl/test_gl_extension_fallbacks.py
+++ b/tests/integration/graphics/opengl/test_gl_extension_fallbacks.py
@@ -1,3 +1,7 @@
+from tests.annotations import require_graphics_api, GraphicsAPIGroups
+
+pytestmark = require_graphics_api(GraphicsAPIGroups.GL3)
+
 from pyglet.graphics.api.gl.gl_fallback import apply_extension_function_fallbacks
 
 

--- a/tests/unit/test_gl_extension_fallbacks.py
+++ b/tests/unit/test_gl_extension_fallbacks.py
@@ -1,0 +1,45 @@
+from pyglet.graphics.api.gl.gl_fallback import apply_extension_function_fallbacks
+
+
+class _ExtensionInfo:
+    def __init__(self, extensions: set[str]) -> None:
+        self.extensions = extensions
+
+    def have_extension(self, extension: str) -> bool:
+        return extension in self.extensions
+
+
+class _Functions:
+    def __init__(self) -> None:
+        setattr(self, "glActiveShaderProgram", "core")
+        setattr(self, "glActiveShaderProgramEXT", "extension")
+
+    def __getattr__(self, name: str) -> str:
+        return name
+
+
+def test_extension_function_fallback_replaces_the_regular_function() -> None:
+    functions = _Functions()
+
+    apply_extension_function_fallbacks(_ExtensionInfo({"GL_EXT_separate_shader_objects"}), functions)
+
+    assert functions.glActiveShaderProgram == "extension"
+
+
+def test_extension_function_fallback_does_not_apply_without_its_extension() -> None:
+    functions = _Functions()
+
+    apply_extension_function_fallbacks(_ExtensionInfo(set()), functions)
+
+    assert functions.glActiveShaderProgram == "core"
+
+
+def test_extension_function_fallbacks_are_local_to_one_function_table() -> None:
+    extension_functions = _Functions()
+    core_functions = _Functions()
+
+    apply_extension_function_fallbacks(_ExtensionInfo({"GL_EXT_separate_shader_objects"}), extension_functions)
+    apply_extension_function_fallbacks(_ExtensionInfo(set()), core_functions)
+
+    assert extension_functions.glActiveShaderProgram == "extension"
+    assert core_functions.glActiveShaderProgram == "core"

--- a/tools/gen_opengl/gengl.py
+++ b/tools/gen_opengl/gengl.py
@@ -379,7 +379,11 @@ class PygletGLWriter:
                 f"{name}: {f'{arg} | {self.pythontypes[arg]}' if arg in self.pythontypes else arg}" for name, arg in
                 zip(names, arguments, strict=True))
 
-            function_stub = f"def {cmd.name}({argannotations}) -> {self.pythontypes.get(restype, restype)}: ..."
+            function_stub = (
+                f"def {cmd.name}(self, {argannotations}) -> {self.pythontypes.get(restype, restype)}: ..."
+                if argannotations
+                else f"def {cmd.name}(self) -> {self.pythontypes.get(restype, restype)}: ..."
+            )
             self.write_lines(fp, [f"    {function_stub}"])
 
         self.write_lines(fp, [""])


### PR DESCRIPTION
This behavior maps GL extension calls to their core version, this way we do not have to change calls when a core behavior is missing, but the extension is available. 

For example `GL_EXT_separate_shader_objects` extension may be available, but code will fail when calling `glActiveShaderProgram` as only the extension call is supported. This will make it so when calling `glActiveShaderProgram` it will instead call `glActiveShaderProgramEXT`.