### PR TITLE
Preserve fractional XlibScreenModeXF86 and XlibScreenModeXrandr refresh rates

### DIFF
--- a/pyglet/display/xlib.py
+++ b/pyglet/display/xlib.py
@@ -460,7 +460,7 @@ class XlibScreenXrandr(XlibScreen):
 
 
 class XlibScreenMode(ScreenMode):
-    def __init__(self, screen: XlibScreen, width: int, height: int, rate: int, depth: int):
+    def __init__(self, screen: XlibScreen, width: int, height: int, rate: float, depth: int):
         super().__init__(screen)
         self.width = width
         self.height = height
@@ -473,8 +473,14 @@ class XlibScreenModeXF86(XlibScreenMode):
         self.info = info
         width = info.hdisplay
         height = info.vdisplay
-        rate = round((info.dotclock * 1000) / (info.htotal * info.vtotal))
+        rate = self._calculate_refresh_rate(info)
         super().__init__(screen, width, height, rate, depth)
+
+    @staticmethod
+    def _calculate_refresh_rate(info: xf86vmode.XF86VidModeModeInfo) -> float:
+        if info.htotal > 0 and info.vtotal > 0:
+            return (info.dotclock * 1000) / (info.htotal * info.vtotal)
+        return 0
 
     def __repr__(self) -> str:
         return f'XlibScreenMode(width={self.width!r}, height={self.height!r}, depth={self.depth!r}, rate={self.rate})'
@@ -483,12 +489,13 @@ class XlibScreenModeXF86(XlibScreenMode):
 class XlibScreenModeXrandr(XlibScreenMode):
     def __init__(self, screen: XlibScreen, mode_info: xrandr.XRRModeInfo, mode_id: int, depth: int) -> None:
         self.mode_id = mode_id
-        super().__init__(screen, mode_info.width, mode_info.height, self._calculate_refresh_rate(mode_info), depth)
+        rate = self._calculate_refresh_rate(mode_info)
+        super().__init__(screen, mode_info.width, mode_info.height, rate, depth)
 
     @staticmethod
-    def _calculate_refresh_rate(mode_info: xrandr.XRRModeInfo) -> int:
+    def _calculate_refresh_rate(mode_info: xrandr.XRRModeInfo) -> float:
         if mode_info.hTotal > 0 and mode_info.vTotal > 0:
-            return round(mode_info.dotClock / (mode_info.hTotal * mode_info.vTotal))
+            return mode_info.dotClock / (mode_info.hTotal * mode_info.vTotal)
         return 0
 
     def __repr__(self) -> str:

--- a/tests/integration/platform/test_xlib_display.py
+++ b/tests/integration/platform/test_xlib_display.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import sys
-
 import pytest
 
-if not sys.platform.startswith('linux'):
-    pytest.skip('Xlib display tests require Linux', allow_module_level=True)
+import pyglet
+from tests.annotations import Platform, require_platform
 
-from pyglet.display import xlib
-from pyglet.libs.x11 import xf86vmode, xrandr
+pytestmark = require_platform(Platform.LINUX)
+
+if pyglet.compat_platform in Platform.LINUX:
+    from pyglet.display import xlib
+    from pyglet.libs.x11 import xf86vmode, xrandr
 
 
 def _xrandr_mode(dot_clock=712_000_000, h_total=5_312, v_total=2_237):

--- a/tests/unit/platform/test_xlib_display.py
+++ b/tests/unit/platform/test_xlib_display.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+if not sys.platform.startswith('linux'):
+    pytest.skip('Xlib display tests require Linux', allow_module_level=True)
+
+from pyglet.display import xlib
+from pyglet.libs.x11 import xf86vmode, xrandr
+
+
+def _xrandr_mode(dot_clock=712_000_000, h_total=5_312, v_total=2_237):
+    mode = xrandr.XRRModeInfo()
+    mode.dotClock = dot_clock
+    mode.hTotal = h_total
+    mode.vTotal = v_total
+    return mode
+
+
+def _xf86_mode(dot_clock=712_000, h_total=5_312, v_total=2_237):
+    mode = xf86vmode.XF86VidModeModeInfo()
+    mode.dotclock = dot_clock
+    mode.htotal = h_total
+    mode.vtotal = v_total
+    return mode
+
+
+def test_xrandr_rate_keeps_the_fraction():
+    rate = xlib.XlibScreenModeXrandr._calculate_refresh_rate(_xrandr_mode())
+    assert rate == pytest.approx(59.91781, abs=1e-5)
+    assert rate != 60
+
+
+def test_xf86_rate_keeps_the_fraction():
+    rate = xlib.XlibScreenModeXF86._calculate_refresh_rate(_xf86_mode())
+    assert rate == pytest.approx(59.91781, abs=1e-5)
+    assert rate != 60
+
+
+def test_both_backends_agree_on_the_same_modeline():
+    # XF86VidMode reports the pixel clock in kHz, XRandR in Hz.
+    assert xlib.XlibScreenModeXF86._calculate_refresh_rate(
+        _xf86_mode()
+    ) == pytest.approx(
+        xlib.XlibScreenModeXrandr._calculate_refresh_rate(_xrandr_mode())
+    )
+
+
+@pytest.mark.parametrize('rate', [59.94, 143.998848, 239.76])
+def test_common_non_integer_rates_survive(rate):
+    # A 1000-line modeline makes the arithmetic exact for the assertion.
+    v_total = 1_000
+    h_total = 1_000
+    dot_clock = round(rate * h_total * v_total)
+    assert xlib.XlibScreenModeXrandr._calculate_refresh_rate(
+        _xrandr_mode(dot_clock, h_total, v_total)
+    ) == pytest.approx(rate, abs=1e-6)
+
+
+@pytest.mark.parametrize('h_total,v_total', [(0, 2_237), (5_312, 0), (0, 0)])
+def test_a_modeline_without_totals_is_zero_rather_than_an_error(h_total, v_total):
+    assert xlib.XlibScreenModeXrandr._calculate_refresh_rate(
+        _xrandr_mode(h_total=h_total, v_total=v_total)
+    ) == 0
+    assert xlib.XlibScreenModeXF86._calculate_refresh_rate(
+        _xf86_mode(h_total=h_total, v_total=v_total)
+    ) == 0
+
+
+def test_an_integer_rate_stays_comparable_to_an_integer():
+    # `Screen.get_closest_mode` scores modes with `mode.rate == current.rate`,
+    # so an exact 60Hz modeline must still equal 60 after the change.
+    rate = xlib.XlibScreenModeXrandr._calculate_refresh_rate(
+        _xrandr_mode(dot_clock=60_000_000, h_total=1_000, v_total=1_000)
+    )
+    assert rate == 60


### PR DESCRIPTION
Updated both XlibScreenModeXF86 and XlibScreenModeXrandr to allow fractional refresh rates.  ScreenMode in pyglet.display.base.py was updated to support in #1470.

Tested on XWayland / Gnome on CachyOS. 

On a monitor with a fractional refresh rate set the results were the same:

XRandR  : 59.917811613014415
XF86VM  : 59.917811613014415
identical: True
raw dotclock kHz=712000 htotal=5312 vtotal=2237